### PR TITLE
Improve missing space instance error msg

### DIFF
--- a/SeQuant/core/space.cpp
+++ b/SeQuant/core/space.cpp
@@ -43,4 +43,67 @@ std::wstring to_wolfram(const IndexSpace& space) {
   return result;
 }
 
+std::wstring to_wstring(TypeAttr type) {
+  using TypeBitset =
+      std::bitset<sizeof(decltype(IndexSpace::TypeAttr::bitset))>;
+  if (type == IndexSpace::frozen_occupied) {
+    return L"frozen_occupied";
+  } else if (type == IndexSpace::inactive_occupied) {
+    return L"inactive_occupied";
+  } else if (type == IndexSpace::active_occupied) {
+    return L"active_occupied";
+  } else if (type == IndexSpace::occupied) {
+    return L"occupied";
+  } else if (type == IndexSpace::active) {
+    return L"active";
+  } else if (type == IndexSpace::maybe_occupied) {
+    return L"maybe_occupied";
+  } else if (type == IndexSpace::active_maybe_occupied) {
+    return L"active_maybe_occupied";
+  } else if (type == IndexSpace::active_unoccupied) {
+    return L"active_unoccupied";
+  } else if (type == IndexSpace::inactive_unoccupied) {
+    return L"inactive_unoccupied";
+  } else if (type == IndexSpace::unoccupied) {
+    return L"unoccupied";
+  } else if (type == IndexSpace::maybe_unoccupied) {
+    return L"maybe_unoccupied";
+  } else if (type == IndexSpace::active_maybe_unoccupied) {
+    return L"active_maybe_unoccupied";
+  } else if (type == IndexSpace::all_active) {
+    return L"all_active";
+  } else if (type == IndexSpace::all) {
+    return L"all";
+  } else if (type == IndexSpace::other_unoccupied) {
+    return L"other_unoccupied";
+  } else if (type == IndexSpace::complete_unoccupied) {
+    return L"complete_unoccupied";
+  } else if (type == IndexSpace::complete_maybe_unoccupied) {
+    return L"complete_maybe_unoccupied";
+  } else if (type == IndexSpace::complete) {
+    return L"complete";
+  } else {
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+    return std::wstring(L"Custom (") +
+           converter.from_bytes(TypeBitset(type.bitset).to_string()) + L")";
+  }
+}
+
+std::wstring to_wstring(QuantumNumbersAttr qns) {
+  using QNBitset =
+      std::bitset<sizeof(decltype(IndexSpace::QuantumNumbersAttr::bitset))>;
+
+  if (qns == IndexSpace::alpha) {
+    return L"↑";
+  } else if (qns == IndexSpace::beta) {
+    return L"↓";
+  } else if (qns == IndexSpace::nullqns) {
+    return L"";
+  } else {
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+    return L"Custom (" +
+           converter.from_bytes(QNBitset(qns.bitset).to_string()) + L")";
+  }
+}
+
 }  // namespace sequant

--- a/SeQuant/core/space.hpp
+++ b/SeQuant/core/space.hpp
@@ -7,6 +7,8 @@
 
 #include <bitset>
 #include <cassert>
+#include <codecvt>
+#include <locale>
 
 #include "attr.hpp"
 #include "container.hpp"
@@ -107,6 +109,9 @@ struct QuantumNumbersAttr {
     return QuantumNumbersAttr(-0);
   }
 };
+
+std::wstring to_wstring(TypeAttr type);
+std::wstring to_wstring(QuantumNumbersAttr qns);
 
 /// @brief space of Index objects
 ///
@@ -316,6 +321,7 @@ class IndexSpace {
   };
   struct bad_attr : std::invalid_argument {
     bad_attr() : std::invalid_argument("bad attribute") {}
+    using std::invalid_argument::invalid_argument;
   };
 
   struct KeyCompare {
@@ -354,7 +360,12 @@ class IndexSpace {
     const auto attr = Attr(type, qns);
     assert(attr.is_valid());
     if (attr == Attr::null()) return null_instance();
-    if (!instance_exists(attr)) throw bad_attr();
+    if (!instance_exists(attr)) {
+      std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+      throw bad_attr(converter.to_bytes(L"Request to non-existing space: " +
+                                        sequant::to_wstring(type) + L" " +
+                                        sequant::to_wstring(qns)));
+    }
     return instances_.find(attr)->second;
   }
 

--- a/SeQuant/core/space.hpp
+++ b/SeQuant/core/space.hpp
@@ -362,7 +362,7 @@ class IndexSpace {
     if (attr == Attr::null()) return null_instance();
     if (!instance_exists(attr)) {
       std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-      throw bad_attr(converter.to_bytes(L"Request to non-existing space: " +
+      throw bad_attr(converter.to_bytes(L"Request to non-registered space: " +
                                         sequant::to_wstring(type) + L" " +
                                         sequant::to_wstring(qns)));
     }


### PR DESCRIPTION
Instead of only throwing a bad_attr exception without any (useful) error message, we now construct a string representation of the requested space type and quantum numbers.
This should make debugging missing-instance errors more easily.

Step towards #97