### PR TITLE
Support energy expressions to be spintraced

### DIFF
--- a/SeQuant/core/tensor.hpp
+++ b/SeQuant/core/tensor.hpp
@@ -82,6 +82,8 @@ class Tensor : public Expr, public AbstractTensor, public Labeled {
   }
 
  public:
+  /// constructs an uninitialized Tensor
+  /// @sa Tensor::operator bool()
   Tensor() = default;
   virtual ~Tensor();
 
@@ -124,6 +126,13 @@ class Tensor : public Expr, public AbstractTensor, public Labeled {
       : Tensor(label, make_indices(bra_indices), make_indices(ket_indices),
                reserved_tag{}, s, bks, ps) {
     assert_nonreserved_label(label_);
+  }
+
+  /// @return true if the Tensor is initialized
+  explicit operator bool() const {
+    return !label_.empty() && symmetry_ != Symmetry::invalid &&
+           braket_symmetry_ != BraKetSymmetry::invalid &&
+           particle_symmetry_ != ParticleSymmetry::invalid;
   }
 
   std::wstring_view label() const override { return label_; }

--- a/SeQuant/domain/mbpt/spin.hpp
+++ b/SeQuant/domain/mbpt/spin.hpp
@@ -257,7 +257,7 @@ ExprPtr factorize_S(const ExprPtr& expression,
                     bool fast_method = true);
 
 ExprPtr biorthogonal_transform(
-    const sequant::ExprPtr& expr, int n_particles,
+    const sequant::ExprPtr& expr,
     const container::svector<container::svector<sequant::Index>>&
         ext_index_groups = {{}},
     double threshold = 1.e-12);

--- a/examples/srcc/srcc.cpp
+++ b/examples/srcc/srcc.cpp
@@ -166,7 +166,7 @@ class compute_cceqvec {
           }
 
           // Biorthogonal transformation
-          eqvec[R] = biorthogonal_transform(eqvec[R], R, ext_idxs);
+          eqvec[R] = biorthogonal_transform(eqvec[R], ext_idxs);
 
           // restore the particle symmetrizer
           auto bixs = ext_idxs | ranges::views::transform(

--- a/tests/unit/test_parse_expr.cpp
+++ b/tests/unit/test_parse_expr.cpp
@@ -71,10 +71,10 @@ TEST_CASE("TEST_PARSE_EXPR", "[parse_expr]") {
     REQUIRE(expr->as<Tensor>().ket().size() == 1);
     REQUIRE(expr->as<Tensor>().ket().at(0) == L"a_1");
 
-    REQUIRE(*expr == *parse_expr(L"t_{i1}^{a1}"));
-    REQUIRE(*expr == *parse_expr(L"t^{a1}_{i1}"));
-    REQUIRE(*expr == *parse_expr(L"t{i_1; a_1}"));
-    REQUIRE(*expr == *parse_expr(L"t_{i_1}^{a_1}"));
+    REQUIRE(expr == parse_expr(L"t_{i1}^{a1}"));
+    REQUIRE(expr == parse_expr(L"t^{a1}_{i1}"));
+    REQUIRE(expr == parse_expr(L"t{i_1; a_1}"));
+    REQUIRE(expr == parse_expr(L"t_{i_1}^{a_1}"));
 
     expr = parse_expr(L"t{i1,i2;a1,a2}");
     REQUIRE(expr->as<Tensor>().bra().size() == 2);
@@ -84,9 +84,9 @@ TEST_CASE("TEST_PARSE_EXPR", "[parse_expr]") {
     REQUIRE(expr->as<Tensor>().ket().at(0).label() == L"a_1");
     REQUIRE(expr->as<Tensor>().ket().at(1).label() == L"a_2");
 
-    REQUIRE(*expr == *parse_expr(L"+t{i1, i2; a1, a2}"));
+    REQUIRE(expr == parse_expr(L"+t{i1, i2; a1, a2}"));
     REQUIRE(parse_expr(L"-t{i1;a1}")->is<Product>());
-    REQUIRE(*expr == *parse_expr(L"t{\ti1, \ti2; \na1,\t a2 \t}"));
+    REQUIRE(expr == parse_expr(L"t{\ti1, \ti2; \na1,\t a2 \t}"));
 
     // Tensor labels including underscores
     REQUIRE(parse_expr(L"T_1{i_1;a_1}")->as<Tensor>().label() == L"T_1");
@@ -157,8 +157,8 @@ TEST_CASE("TEST_PARSE_EXPR", "[parse_expr]") {
 
     auto const& prod = expr->as<Product>();
     REQUIRE(prod.scalar() == rational{-1, 2});
-    REQUIRE(*prod.factor(0) == *parse_expr(L"g_{i_2, i_3}^{i_1, a_2}"));
-    REQUIRE(*prod.factor(1) == *parse_expr(L"t^{i2, i3}_{a1, a2}"));
+    REQUIRE(prod.factor(0) == parse_expr(L"g_{i_2, i_3}^{i_1, a_2}"));
+    REQUIRE(prod.factor(1) == parse_expr(L"t^{i2, i3}_{a1, a2}"));
     REQUIRE(parse_expr(L"-1/2 * δ * t{i1;a1}") ==
             parse_expr(L"-1/2  δ  t{i1;a1}"));
     auto const prod2 = parse_expr(L"-1/2 * δ * γ * t{i1;a1}")->as<Product>();
@@ -175,16 +175,16 @@ TEST_CASE("TEST_PARSE_EXPR", "[parse_expr]") {
     REQUIRE(expr1->is<Sum>());
 
     auto const& sum1 = expr1->as<Sum>();
-    REQUIRE(*sum1.summand(0) == *parse_expr(L"f{a1;i1}"));
-    REQUIRE(*sum1.summand(1) ==
-            *parse_expr(L"- 1/2 * g{i2,a1; a2,a3} * t{a2,a3; i1,i2}"));
+    REQUIRE(sum1.summand(0) == parse_expr(L"f{a1;i1}"));
+    REQUIRE(sum1.summand(1) ==
+            parse_expr(L"- 1/2 * g{i2,a1; a2,a3} * t{a2,a3; i1,i2}"));
 
     auto expr2 = parse_expr(L"a - 4");
     REQUIRE(expr2->is<Sum>());
 
     auto const& sum2 = expr2->as<Sum>();
-    REQUIRE(*sum2.summand(0) == *parse_expr(L"a"));
-    REQUIRE(*sum2.summand(1) == *parse_expr(L"-4"));
+    REQUIRE(sum2.summand(0) == parse_expr(L"a"));
+    REQUIRE(sum2.summand(1) == parse_expr(L"-4"));
   }
 
   SECTION("Parentheses") {
@@ -207,9 +207,9 @@ TEST_CASE("TEST_PARSE_EXPR", "[parse_expr]") {
     REQUIRE(prod2.size() == 2);
     REQUIRE(prod2.scalar() == rational{-1, 2});
     REQUIRE(prod2.factor(0)->is<Product>());
-    REQUIRE(*prod2.factor(0)->at(0) == *parse_expr(L"g{i2,i3; a2,a3}"));
-    REQUIRE(*prod2.factor(0)->at(1) == *parse_expr(L"t{a1,a3; i2,i3}"));
-    REQUIRE(*prod2.factor(1) == *parse_expr(L"t{a2;i1}"));
+    REQUIRE(prod2.factor(0)->at(0) == parse_expr(L"g{i2,i3; a2,a3}"));
+    REQUIRE(prod2.factor(0)->at(1) == parse_expr(L"t{a1,a3; i2,i3}"));
+    REQUIRE(prod2.factor(1) == parse_expr(L"t{a2;i1}"));
 
     auto expr3 = parse_expr(
         L"(-1/2) ( g{i2,i3; a2,a3} * t{a1,a3; i2,i3} ) * (1/2) * ((t{a2;i1}))");
@@ -219,9 +219,9 @@ TEST_CASE("TEST_PARSE_EXPR", "[parse_expr]") {
     REQUIRE(prod3.size() == 2);
     REQUIRE(prod3.scalar() == rational{-1, 4});
     REQUIRE(prod3.factor(0)->is<Product>());
-    REQUIRE(*prod3.factor(0)->at(0) == *parse_expr(L"g{i2,i3; a2,a3}"));
-    REQUIRE(*prod3.factor(0)->at(1) == *parse_expr(L"t{a1,a3; i2,i3}"));
-    REQUIRE(*prod3.factor(1) == *parse_expr(L"t{a2;i1}"));
+    REQUIRE(prod3.factor(0)->at(0) == parse_expr(L"g{i2,i3; a2,a3}"));
+    REQUIRE(prod3.factor(0)->at(1) == parse_expr(L"t{a1,a3; i2,i3}"));
+    REQUIRE(prod3.factor(1) == parse_expr(L"t{a2;i1}"));
 
     auto expr4 = parse_expr(L"1/2 (a + b) * c");
     REQUIRE(expr4->is<Product>());
@@ -252,22 +252,22 @@ TEST_CASE("TEST_PARSE_EXPR", "[parse_expr]") {
     REQUIRE(sum.summand(0)->is<Product>());
     REQUIRE(sum.summand(0)->as<Product>().scalar() == rational{1, 4});
     REQUIRE(sum.summand(0)->size() == 1);
-    REQUIRE(*sum.summand(0)->at(0) == *parse_expr(L"g{a1,a2; i1,i2}"));
+    REQUIRE(sum.summand(0)->at(0) == parse_expr(L"g{a1,a2; i1,i2}"));
 
     REQUIRE(sum.summand(1)->is<Product>());
     auto const& prod = sum.summand(1)->as<Product>();
 
     REQUIRE(prod.scalar() == rational{1, 4});
     REQUIRE(prod.size() == 3);
-    REQUIRE(*prod.factor(0) == *parse_expr(L"g{i3,i4; a3,a4}"));
+    REQUIRE(prod.factor(0) == parse_expr(L"g{i3,i4; a3,a4}"));
 
     REQUIRE(prod.factor(1)->is<Product>());
-    REQUIRE(*prod.factor(1)->at(0) == *parse_expr(L"t{a3;i1}"));
-    REQUIRE(*prod.factor(1)->at(1) == *parse_expr(L"t{a4;i2}"));
+    REQUIRE(prod.factor(1)->at(0) == parse_expr(L"t{a3;i1}"));
+    REQUIRE(prod.factor(1)->at(1) == parse_expr(L"t{a4;i2}"));
 
     REQUIRE(prod.factor(2)->is<Product>());
-    REQUIRE(*prod.factor(2)->at(0) == *parse_expr(L"t{a1;i3}"));
-    REQUIRE(*prod.factor(2)->at(1) == *parse_expr(L"t{a2;i4}"));
+    REQUIRE(prod.factor(2)->at(0) == parse_expr(L"t{a1;i3}"));
+    REQUIRE(prod.factor(2)->at(1) == parse_expr(L"t{a2;i4}"));
   }
 
   SECTION("Empty input") { REQUIRE(parse_expr(L"") == nullptr); }

--- a/tests/unit/test_spin.cpp
+++ b/tests/unit/test_spin.cpp
@@ -663,20 +663,14 @@ SECTION("Closed-shell spintrace CCD") {
     const auto input = ex<Sum>(ExprPtrList{parse_expr(
         L"1/4 g{i_1,i_2;a_1,a_2} t{a_1,a_2;i_1,i_2}", Symmetry::antisymm)});
     auto result = closed_shell_CC_spintrace(input);
-
-	// Canonicalize the order of the addends in the result
-	ExprPtr firstAddend;
-	ExprPtr secondAddend;
-	if (result.as<Sum>().summand(0).as<Product>().scalar() == -1) {
-		firstAddend = result.as<Sum>().summand(1);
-		secondAddend = result.as<Sum>().summand(0);
-	} else {
-		firstAddend = result.as<Sum>().summand(0);
-		secondAddend = result.as<Sum>().summand(1);
-	}
-
-	REQUIRE(*firstAddend == *parse_expr(L"2 g{i_1,i_2;a_1,a_2} t{a_1,a_2;i_1,i_2}", Symmetry::nonsymm));
-	REQUIRE(*secondAddend == *parse_expr(L"-g{i_1,i_2;a_1,a_2} t{a_1,a_2;i_2,i_1}", Symmetry::nonsymm));
+    if constexpr (hash_version() == hash::Impl::BoostPre181)
+      REQUIRE(result == parse_expr(L"- g{i_1,i_2;a_1,a_2} t{a_1,a_2;i_2,i_1} + "
+                                   L"2 g{i_1,i_2;a_1,a_2} t{a_1,a_2;i_1,i_2}",
+                                   Symmetry::nonsymm));
+    else
+      REQUIRE(result == parse_expr(L"2 g{i_1,i_2;a_1,a_2} t{a_1,a_2;i_1,i_2} - "
+                                   L"g{i_1,i_2;a_1,a_2} t{a_1,a_2;i_2,i_1}",
+                                   Symmetry::nonsymm));
   }
 }
 

--- a/tests/unit/test_spin.cpp
+++ b/tests/unit/test_spin.cpp
@@ -2,7 +2,9 @@
 // Created by Nakul Teke on 12/20/19.
 //
 
+#include "SeQuant/core/parse_expr.hpp"
 #include "SeQuant/domain/mbpt/spin.hpp"
+
 #include "catch.hpp"
 #include "test_config.hpp"
 
@@ -652,6 +654,29 @@ SECTION("Swap bra kets") {
     REQUIRE(result->to_latex() ==
             L"{ \\bigl({f^{{i_1}}_{{i_5}}} + "
             L"{{g^{{a_5}{a_6}}_{{i_5}{i_6}}}{t^{{i_2}}_{{a_6}}}}\\bigr) }");
+  }
+}
+
+SECTION("Closed-shell spintrace CCD") {
+  // Energy expression
+  {
+    const auto input = ex<Sum>(ExprPtrList{parse_expr(
+        L"1/4 g{i_1,i_2;a_1,a_2} t{a_1,a_2;i_1,i_2}", Symmetry::antisymm)});
+    auto result = closed_shell_CC_spintrace(input);
+
+	// Canonicalize the order of the addends in the result
+	ExprPtr firstAddend;
+	ExprPtr secondAddend;
+	if (result.as<Sum>().summand(0).as<Product>().scalar() == -1) {
+		firstAddend = result.as<Sum>().summand(1);
+		secondAddend = result.as<Sum>().summand(0);
+	} else {
+		firstAddend = result.as<Sum>().summand(0);
+		secondAddend = result.as<Sum>().summand(1);
+	}
+
+	REQUIRE(*firstAddend == *parse_expr(L"2 g{i_1,i_2;a_1,a_2} t{a_1,a_2;i_1,i_2}", Symmetry::nonsymm));
+	REQUIRE(*secondAddend == *parse_expr(L"-g{i_1,i_2;a_1,a_2} t{a_1,a_2;i_2,i_1}", Symmetry::nonsymm));
   }
 }
 

--- a/tests/unit/test_tensor.cpp
+++ b/tests/unit/test_tensor.cpp
@@ -8,13 +8,12 @@
 #include "SeQuant/core/wick.hpp"
 
 TEST_CASE("Tensor", "[elements]") {
-
   using namespace sequant;
 
   SECTION("constructors") {
-
     REQUIRE_NOTHROW(Tensor{});
     auto t1 = Tensor{};
+    REQUIRE(!t1);
     REQUIRE(t1.bra_rank() == 0);
     REQUIRE(t1.ket_rank() == 0);
     REQUIRE(t1.rank() == 0);
@@ -25,6 +24,7 @@ TEST_CASE("Tensor", "[elements]") {
 
     REQUIRE_NOTHROW(Tensor(L"F", {L"i_1"}, {L"i_1"}));
     auto t2 = Tensor(L"F", {L"i_1"}, {L"i_1"});
+    REQUIRE(t2);
     REQUIRE(t2.bra_rank() == 1);
     REQUIRE(t2.ket_rank() == 1);
     REQUIRE(t2.rank() == 1);
@@ -35,6 +35,7 @@ TEST_CASE("Tensor", "[elements]") {
 
     REQUIRE_NOTHROW(Tensor(L"N", {L"i_1"}, {}));
     auto t3 = Tensor(L"N", {L"i_1"}, {});
+    REQUIRE(t3);
     REQUIRE(t3.bra_rank() == 1);
     REQUIRE(t3.ket_rank() == 0);
     REQUIRE_THROWS(t3.rank());
@@ -43,8 +44,13 @@ TEST_CASE("Tensor", "[elements]") {
     REQUIRE(t3.particle_symmetry() == ParticleSymmetry::symm);
     REQUIRE(t3.label() == L"N");
 
-    REQUIRE_NOTHROW(Tensor(L"g", {Index{L"i_1"}, Index{L"i_2"}}, {Index{L"i_3"}, Index{L"i_4"}}, Symmetry::nonsymm, BraKetSymmetry::symm, ParticleSymmetry::nonsymm));
-    auto t4 = Tensor(L"g", {Index{L"i_1"}, Index{L"i_2"}}, {Index{L"i_3"}, Index{L"i_4"}}, Symmetry::nonsymm, BraKetSymmetry::symm, ParticleSymmetry::nonsymm);
+    REQUIRE_NOTHROW(Tensor(L"g", {Index{L"i_1"}, Index{L"i_2"}},
+                           {Index{L"i_3"}, Index{L"i_4"}}, Symmetry::nonsymm,
+                           BraKetSymmetry::symm, ParticleSymmetry::nonsymm));
+    auto t4 = Tensor(L"g", {Index{L"i_1"}, Index{L"i_2"}},
+                     {Index{L"i_3"}, Index{L"i_4"}}, Symmetry::nonsymm,
+                     BraKetSymmetry::symm, ParticleSymmetry::nonsymm);
+    REQUIRE(t4);
     REQUIRE(t4.bra_rank() == 2);
     REQUIRE(t4.ket_rank() == 2);
     REQUIRE(t4.rank() == 2);
@@ -99,8 +105,10 @@ TEST_CASE("Tensor", "[elements]") {
     auto t1 = Tensor(L"F", {L"i_1"}, {L"i_2"});
     REQUIRE(to_latex(t1) == L"{F^{{i_2}}_{{i_1}}}");
 
-    auto h1 = ex<Tensor>(L"F", WstrList{L"i_1"}, WstrList{L"i_2"}) * ex<FNOperator>(WstrList{L"i_1"}, WstrList{L"i_2"});
-    REQUIRE(to_latex(h1) == L"{{F^{{i_2}}_{{i_1}}}{\\tilde{a}^{{i_1}}_{{i_2}}}}");
+    auto h1 = ex<Tensor>(L"F", WstrList{L"i_1"}, WstrList{L"i_2"}) *
+              ex<FNOperator>(WstrList{L"i_1"}, WstrList{L"i_2"});
+    REQUIRE(to_latex(h1) ==
+            L"{{F^{{i_2}}_{{i_1}}}{\\tilde{a}^{{i_1}}_{{i_2}}}}");
 
   }  // SECTION("latex")
 
@@ -109,9 +117,11 @@ TEST_CASE("Tensor", "[elements]") {
     REQUIRE_NOTHROW(t1.adjoint());
     REQUIRE(to_latex(t1) == L"{F^{{i_1}{i_2}}_{{i_3}{i_4}}}");
 
-    auto h1 = ex<Tensor>(L"F", WstrList{L"i_1"}, WstrList{L"i_2"}) * ex<FNOperator>(WstrList{L"i_1"}, WstrList{L"i_2"});
+    auto h1 = ex<Tensor>(L"F", WstrList{L"i_1"}, WstrList{L"i_2"}) *
+              ex<FNOperator>(WstrList{L"i_1"}, WstrList{L"i_2"});
     h1 = adjoint(h1);
-    REQUIRE(to_latex(h1) == L"{{\\tilde{a}^{{i_2}}_{{i_1}}}{F^{{i_1}}_{{i_2}}}}");
+    REQUIRE(to_latex(h1) ==
+            L"{{\\tilde{a}^{{i_2}}_{{i_1}}}{F^{{i_1}}_{{i_2}}}}");
 
   }  // SECTION("latex")
 


### PR DESCRIPTION
The closed_shell_CC_spintrace function would error if it was fed the CC energy equations, because it unconditionally performs a biorthogonal transform, which assumes the presence of external indices (aka: it assumes that we are dealing with a CC residual equation).

This commit changes the code so that we only perform the transformation for residuals, but skip it for energy expressions (fully contracted expressions).