### PR TITLE
Revamp and fix enable-ifs in expr.cpp

### DIFF
--- a/SeQuant/core/expr.hpp
+++ b/SeQuant/core/expr.hpp
@@ -14,6 +14,7 @@
 #include "SeQuant/core/logger.hpp"
 #include "SeQuant/core/meta.hpp"
 #include "SeQuant/core/rational.hpp"
+#include "SeQuant/core/meta.hpp"
 #include "SeQuant/core/wolfram.hpp"
 
 #include <range/v3/all.hpp>
@@ -26,9 +27,40 @@
 #include <iostream>
 #include <memory>
 #include <optional>
+#include <type_traits>
 #include <vector>
 
 namespace sequant {
+
+namespace {
+
+
+template <typename T>
+constexpr bool is_an_expr_v = meta::is_base_of_v<Expr, T>;
+template <typename T>
+constexpr bool is_expr_v = meta::is_same_v<Expr, T>;
+
+template <typename T>
+constexpr bool is_a_constant_v = meta::is_base_of_v<Constant, T>;
+template <typename T>
+constexpr bool is_constant_v = meta::is_same_v<Constant, T>;
+
+template <typename T>
+constexpr bool is_a_sum_v = meta::is_base_of_v<Sum, T>;
+template <typename T>
+constexpr bool is_sum_v = meta::is_same_v<Sum, T>;
+
+template <typename T>
+constexpr bool is_a_product_v = meta::is_base_of_v<Product, T>;
+template <typename T>
+constexpr bool is_product_v = meta::is_same_v<Product, T>;
+
+template <typename T>
+constexpr bool is_a_variable_v = meta::is_base_of_v<Variable, T>;
+template <typename T>
+constexpr bool is_variable_v = meta::is_same_v<Variable, T>;
+
+}  // namespace
 
 /// @brief ExprPtr is a multiple-owner smart pointer to Expr
 
@@ -47,20 +79,14 @@ class ExprPtr : public std::shared_ptr<Expr> {
                             std::is_same_v<std::remove_const_t<E>, Expr> ||
                             std::is_base_of_v<Expr, std::remove_const_t<E>>>>
   ExprPtr(const std::shared_ptr<E> &other_sptr) : base_type(other_sptr) {}
-  template <typename E, typename = std::enable_if_t<
-                            std::is_same_v<std::remove_const_t<E>, Expr> ||
-                            std::is_base_of_v<Expr, std::remove_const_t<E>>>>
+  template <typename E, typename = std::enable_if_t<is_an_expr_v<E>>>
   ExprPtr(std::shared_ptr<E> &&other_sptr) : base_type(std::move(other_sptr)) {}
-  template <typename E, typename = std::enable_if_t<
-                            std::is_same_v<std::remove_const_t<E>, Expr> ||
-                            std::is_base_of_v<Expr, std::remove_const_t<E>>>>
+  template <typename E, typename = std::enable_if_t<is_an_expr_v<E>>>
   ExprPtr &operator=(const std::shared_ptr<E> &other_sptr) {
     as_shared_ptr() = other_sptr;
     return *this;
   }
-  template <typename E, typename = std::enable_if_t<
-                            std::is_same_v<std::remove_const_t<E>, Expr> ||
-                            std::is_base_of_v<Expr, std::remove_const_t<E>>>>
+  template <typename E, typename = std::enable_if_t<is_an_expr_v<E>>>
   ExprPtr &operator=(std::shared_ptr<E> &&other_sptr) {
     as_shared_ptr() = std::move(other_sptr);
     return *this;
@@ -82,7 +108,7 @@ class ExprPtr : public std::shared_ptr<Expr> {
   const base_type &as_shared_ptr() const &;
   base_type &&as_shared_ptr() &&;
 
-  template <typename E, typename = std::enable_if_t<!std::is_same_v<E, Expr>>>
+  template <typename E, typename = std::enable_if_t<!is_expr_v<E>>>
   std::shared_ptr<E> as_shared_ptr() const {
     assert(this->is<E>());
     return std::static_pointer_cast<E>(this->as_shared_ptr());
@@ -286,13 +312,13 @@ class Expr : public std::enable_shared_from_this<Expr>,
   struct is_shared_ptr_of_expr : std::false_type {};
   template <typename T>
   struct is_shared_ptr_of_expr<std::shared_ptr<T>,
-                               std::enable_if_t<std::is_same_v<Expr, T>>>
+                               std::enable_if_t<is_expr_v<T>>>
       : std::true_type {};
   template <typename T, typename Enabler = void>
   struct is_shared_ptr_of_expr_or_derived : std::false_type {};
   template <typename T>
-  struct is_shared_ptr_of_expr_or_derived<
-      std::shared_ptr<T>, std::enable_if_t<std::is_base_of<Expr, T>::value>>
+  struct is_shared_ptr_of_expr_or_derived<std::shared_ptr<T>,
+                                          std::enable_if_t<is_an_expr_v<T>>>
       : std::true_type {};
 
   /// @brief Reports if this is a c-number
@@ -386,9 +412,8 @@ class Expr : public std::enable_shared_from_this<Expr>,
   /// @tparam T Expr or a class derived from Expr
   /// @return true if @c *this is less than @c that
   /// @note the derived class must implement Expr::static_less_than
-  template <typename T>
-  std::enable_if_t<std::is_base_of<Expr, T>::value, bool> operator<(
-      const T &that) const {
+  template <typename T, typename = std::enable_if<is_an_expr_v<T>>>
+  bool operator<(const T &that) const {
     if (type_id() ==
         that.type_id()) {  // if same type, use generic (or type-specific, if
                            // available) comparison
@@ -417,17 +442,17 @@ class Expr : public std::enable_shared_from_this<Expr>,
   /// @return true if this object is of type @c T
   template <typename T>
   bool is() const {
-    if constexpr (std::is_same_v<std::decay_t<T>, Expr>)
+    if constexpr (is_expr_v<T>)
       return true;
     else
-      return this->type_id() == get_type_id<std::decay_t<T>>();
+      return this->type_id() == get_type_id<meta::remove_cvref_t<T>>();
   }
 
   /// @tparam T an Expr type
   /// @return this object cast to type @c T
   template <typename T>
   const T &as() const {
-    assert(this->is<std::decay_t<T>>());  // so that as<const T>() works fine
+    assert(this->is<T>());
     return static_cast<const T &>(*this);
   }
 
@@ -435,7 +460,7 @@ class Expr : public std::enable_shared_from_this<Expr>,
   /// @return this object cast to type @c T
   template <typename T>
   T &as() {
-    assert(this->is<std::decay_t<T>>());  // so that as<const T>() works fine
+    assert(this->is<T>());
     return static_cast<T &>(*this);
   }
 
@@ -680,8 +705,7 @@ class Constant : public Expr {
   Constant(Constant &&) = default;
   Constant &operator=(const Constant &) = default;
   Constant &operator=(Constant &&) = default;
-  template <typename U, typename = std::enable_if_t<
-                            !std::is_same_v<std::decay_t<U>, Constant>>>
+  template <typename U, typename = std::enable_if_t<!is_constant_v<U>>>
   explicit Constant(U &&value) : value_(std::forward<U>(value)) {}
 
  private:
@@ -785,8 +809,7 @@ class Variable : public Expr, public Labeled {
   Variable(Variable &&) = default;
   Variable &operator=(const Variable &) = default;
   Variable &operator=(Variable &&) = default;
-  template <typename U, typename = std::enable_if_t<
-                            !std::is_same_v<std::decay_t<U>, Variable>>>
+  template <typename U, typename = std::enable_if_t<!is_variable_v<U>>>
   explicit Variable(U &&label) : label_(std::forward<U>(label)) {}
 
   Variable(std::wstring label) : label_(std::move(label)), conjugated_(false) {}
@@ -862,10 +885,9 @@ class Product : public Expr {
   /// @param rng a range of factors
   /// @param flatten_tag if Flatten::Yes, flatten the factors
   template <typename Range,
-            typename = std::enable_if_t<
-                meta::is_range_v<std::decay_t<Range>> &&
-                !std::is_same_v<std::remove_reference_t<Range>, ExprPtrList> &&
-                !std::is_same_v<std::remove_reference_t<Range>, Product>>>
+            typename = std::enable_if_t<meta::is_range_v<std::decay_t<Range>> &&
+                                        !meta::is_same_v<Range, ExprPtrList> &&
+                                        !meta::is_same_v<Range, Product>>>
   explicit Product(Range &&rng, Flatten flatten_tag = Flatten::Yes) {
     using ranges::begin;
     using ranges::end;
@@ -976,8 +998,7 @@ class Product : public Expr {
   /// @return @c *this
   /// @warning if @p factor is a Product, it is flattened recursively
   template <typename T, typename Factor,
-            typename = std::enable_if_t<
-                std::is_base_of_v<Expr, std::remove_reference_t<Factor>>>>
+            typename = std::enable_if_t<is_an_expr_v<Factor>>>
   Product &append(T scalar, Factor &&factor,
                   Flatten flatten_tag = Flatten::Yes) {
     return this->append(scalar,
@@ -1031,8 +1052,7 @@ class Product : public Expr {
   /// @warning if @p factor is a Product, it is flattened recursively
   /// @note this is less efficient than append()
   template <typename T, typename Factor,
-            typename = std::enable_if_t<
-                std::is_base_of_v<Expr, std::remove_reference_t<Factor>>>>
+            typename = std::enable_if_t<is_an_expr_v<Factor>>>
   Product &prepend(T scalar, Factor &&factor,
                    Flatten flatten_tag = Flatten::Yes) {
     return this->prepend(scalar,
@@ -1272,9 +1292,8 @@ class Sum : public Expr {
   /// construct a Sum out of a range of summands
   /// @param rng a range
   template <typename Range,
-            typename = std::enable_if_t<
-                meta::is_range_v<std::decay_t<Range>> &&
-                !std::is_same_v<std::remove_reference_t<Range>, ExprPtrList>>>
+            typename = std::enable_if_t<meta::is_range_v<std::decay_t<Range>> &&
+                                        !meta::is_same_v<Range, ExprPtrList>>>
   explicit Sum(Range &&rng) {
     // use append to flatten out Sum summands
     for (auto &&v : rng) {

--- a/SeQuant/core/expr_fwd.hpp
+++ b/SeQuant/core/expr_fwd.hpp
@@ -23,6 +23,8 @@ class NCProduct;
 using NCProductPtr = std::shared_ptr<NCProduct>;
 class Sum;
 using SumPtr = std::shared_ptr<Sum>;
+class Variable;
+using VariablePtr = std::shared_ptr<Variable>;
 
 }  // namespace sequant
 

--- a/SeQuant/core/meta.hpp
+++ b/SeQuant/core/meta.hpp
@@ -226,6 +226,26 @@ static constexpr bool is_range_v =
     (is_detected_v<is_range_impl::ranges_begin_t, T> &&
      is_detected_v<is_range_impl::ranges_end_t, T>);
 
+
+/// is_same
+/// Checks whether \c T is a \c Base (is either the same class or a sub-class
+/// ignoring CV and reference qualifiers
+template <typename Base, typename T>
+using is_base_of = std::is_base_of<remove_cvref_t<Base>, remove_cvref_t<T>>;
+template <typename Base, typename T>
+constexpr bool is_base_of_v = is_base_of<Base, T>::value;
+
+/// is_same
+/// Checks whether \c T and \c U are the same type, ignoring any CV and
+/// reference qualifiers
+template <typename T, typename U>
+struct is_same
+    : std::bool_constant<std::is_same_v<remove_cvref_t<T>, remove_cvref_t<U>>> {
+};
+
+template <typename T, typename U>
+constexpr bool is_same_v = is_same<T, U>::value;
+
 }  // namespace meta
 }  // namespace sequant
 

--- a/SeQuant/domain/eval/eval.hpp
+++ b/SeQuant/domain/eval/eval.hpp
@@ -7,6 +7,7 @@
 #include <SeQuant/core/eval_node.hpp>
 #include <SeQuant/core/logger.hpp>
 #include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/meta.hpp>
 #include <SeQuant/domain/eval/cache_manager.hpp>
 
 #include <btas/btas.h>


### PR DESCRIPTION
The used enable-ifs looked a bit scary and have therefore been
refactored to use intermediates with (hopefully) clear names.

Furthermore, a couple of tests in those enable-ifs have been performed
with std::is_same, but only removing const from the compared type and
thus these checks would not work properly as soon as a reference type
was passed.
This could be observed while constructing a Product from a non-const
other product. Thus, the type of the to-be-copied object was just
Product & and not const Product &, which is what the copy-ctor
(correctly) is defined for. However, there is the templated
Product(Range &&) ctor, that thanks to the universal reference is the
more specialized candidate in this case (it takes the type as-is without
requiring a const to be slapped on). This would lead to the product
being copied, but also flattened (as this is the default behavior of the
range-ctor).