### PR TITLE
add complete_inactive_unoccupied space.

### DIFF
--- a/SeQuant/core/space.hpp
+++ b/SeQuant/core/space.hpp
@@ -242,7 +242,7 @@ class IndexSpace {
   static constexpr Type other_unoccupied{0b1000000};
   /// a union of the other_unoccupied space and inactive_unoccupied space.
   /// @note useful when considering active unoccupied orbitals separately from frozen orbitals in F12 theory
-  static constexpr Type complete_inactive_unoccupied{0b1100000};
+  static constexpr Type complete_inactive_unoccupied = IndexSpace::other_unoccupied.unIon(IndexSpace::inactive_unoccupied);
   /// set of all fully unoccupied states
   /// @note this is a union of IndexSpace::unoccupied and IndexSpace::other_unoccupied
   static constexpr Type complete_unoccupied = IndexSpace::unoccupied.unIon(IndexSpace::other_unoccupied);

--- a/SeQuant/core/space.hpp
+++ b/SeQuant/core/space.hpp
@@ -240,6 +240,9 @@ class IndexSpace {
   /// space of sp states that are not used to define the reference (vacuum) state (i.e., they are unoccupied) and not supported
   /// by a supported by a finite computational basis; i.e., these states are the rest of the sp Hilbert space
   static constexpr Type other_unoccupied{0b1000000};
+  /// a union of the other_unoccupied space and inactive_unoccupied space.
+  /// @note useful when considering active unoccupied orbitals separately from frozen orbitals in F12 theory
+  static constexpr Type complete_inactive_unoccupied{0b1100000};
   /// set of all fully unoccupied states
   /// @note this is a union of IndexSpace::unoccupied and IndexSpace::other_unoccupied
   static constexpr Type complete_unoccupied = IndexSpace::unoccupied.unIon(IndexSpace::other_unoccupied);
@@ -267,6 +270,7 @@ class IndexSpace {
                                             all_active,
                                             all,
                                             other_unoccupied,
+                                            complete_inactive_unoccupied,
                                             complete_unoccupied,
                                             complete_maybe_unoccupied,
                                             complete};

--- a/SeQuant/domain/mbpt/convention.cpp
+++ b/SeQuant/domain/mbpt/convention.cpp
@@ -83,6 +83,8 @@ void register_standard_instances() {
                                   qnattr, do_not_throw);
     IndexSpace::register_instance(declab(L"a"), IndexSpace::active_unoccupied,
                                   qnattr, do_not_throw);
+    IndexSpace::register_instance(declab(L"g"), IndexSpace::inactive_unoccupied,
+                                 qnattr, do_not_throw);
     // {α,β.../κ,𝛌...} for complete {unoccupied/any} spstates introduced in
     // DOI 10.1063/1.459921 (MP2-R12 I)
     IndexSpace::register_instance(declab(L"α"), IndexSpace::complete_unoccupied,
@@ -104,6 +106,9 @@ void register_standard_instances() {
                                   do_not_throw);
     // introduced in MPQC for GF, CT-F12, and other ad hoc uses
     IndexSpace::register_instance(declab(L"x"), IndexSpace::all_active, qnattr,
+                                  do_not_throw);
+    // used in virtual projection CT-F12 theory methods in MPQC.
+    IndexSpace::register_instance(declab(L"c"), IndexSpace::complete_inactive_unoccupied, qnattr,
                                   do_not_throw);
     // e.g. see DOI 10.1063/5.0067511
     IndexSpace::register_instance(declab(L"u"), IndexSpace::active, qnattr,
@@ -140,12 +145,14 @@ void make_default_indexregistry() {
     register_index(idxreg_ref, Index{declab(L"i")}, 100);
     register_index(idxreg_ref, Index{declab(L"I")}, 120);
     register_index(idxreg_ref, Index{declab(L"m")}, 110);
-    register_index(idxreg_ref, Index{declab(L"a")}, 1000);
+    register_index(idxreg_ref, Index{declab(L"a")}, 200);
+    register_index(idxreg_ref, Index{declab(L"g")}, 800);
     register_index(idxreg_ref, Index{declab(L"e")}, 1000);
     register_index(idxreg_ref, Index{declab(L"A")}, 1020);
-    register_index(idxreg_ref, Index{declab(L"x")}, 1120);
+    register_index(idxreg_ref, Index{declab(L"x")}, 320);
     register_index(idxreg_ref, Index{declab(L"p")}, 1130);
     register_index(idxreg_ref, Index{declab(L"α'")}, 3000);
+    register_index(idxreg_ref, Index{declab(L"c")}, 3800);
     register_index(idxreg_ref, Index{declab(L"α")}, 4000);
     register_index(idxreg_ref, Index{declab(L"κ")}, 4130);
   }

--- a/tests/unit/test_space.cpp
+++ b/tests/unit/test_space.cpp
@@ -36,10 +36,10 @@ TEST_CASE("IndexSpace", "[elements]") {
 
   SECTION("register_key") {
     REQUIRE_NOTHROW(IndexSpace::register_key(
-        L"g",
+        L"w",
         IndexSpace::all));  // can assign additional key to a space already
                             // registered, this does not redefine base key
-    REQUIRE(IndexSpace::instance(L"g") == IndexSpace::instance(L"p"));
+    REQUIRE(IndexSpace::instance(L"w") == IndexSpace::instance(L"p"));
   }
 
   SECTION("equality") {


### PR DESCRIPTION
add complete_inactive_unoccupied space as a union of other_unoccupied and inactive_unoccupied for CT-F12 methods in MPQC