### PR TITLE
Streamline includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,11 @@ set(SEQUANT_INSTALL_DOCDIR "${SEQUANT_INSTALL_SHAREDIR}/doc"
 set(SEQUANT_INSTALL_CMAKEDIR "lib/cmake/sequant"
         CACHE PATH "SeQuant CMAKE install directory")
 
+############################
+# Additional build variables
+############################
+option(SEQUANT_IWYU "Whether to use the include-what-you-use tool (if found)" OFF)
+
 ##########################
 # SeQuant package options
 ##########################
@@ -365,6 +370,19 @@ endif ()
 # build all of boost before SeQuant, including parts it does not use
 if (Boost_BUILT_FROM_SOURCE AND TARGET build-boost-in-SeQuant)
     add_dependencies(SeQuant build-boost-in-SeQuant)
+endif()
+
+if (SEQUANT_IWYU)
+	find_program(iwyu_path NAMES include-what-you-use iwyu)
+
+	if (iwyu_path)
+		set(iwyu_options_and_path
+			"${iwyu_path}"
+			-Xiwyu --cxx17ns
+			-Xiwyu --no_comments
+		)
+		set_property(TARGET SeQuant PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${iwyu_options_and_path})
+	endif()
 endif()
 
 ### unit tests

--- a/SeQuant/core/abstract_tensor.cpp
+++ b/SeQuant/core/abstract_tensor.cpp
@@ -2,10 +2,10 @@
 // Created by Eduard Valeyev on 2019-03-24.
 //
 
-#include "expr.hpp"
-#include "index.hpp"
-#include "abstract_tensor.hpp"
-#include "container.hpp"
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/container.hpp>
 
 #include <regex>
 

--- a/SeQuant/core/abstract_tensor.cpp
+++ b/SeQuant/core/abstract_tensor.cpp
@@ -2,7 +2,14 @@
 // Created by Eduard Valeyev on 2019-03-24.
 //
 
+#include "expr.hpp"
+#include "index.hpp"
 #include "abstract_tensor.hpp"
+#include "container.hpp"
+
+#include <regex>
+
+#include <range/v3/functional/identity.hpp>
 
 namespace sequant {
 

--- a/SeQuant/core/abstract_tensor.hpp
+++ b/SeQuant/core/abstract_tensor.hpp
@@ -10,14 +10,24 @@
 #include <boost/core/demangle.hpp>
 
 #include "algorithm.hpp"
+#include "attr.hpp"
+#include "container.hpp"
 #include "expr.hpp"
 #include "index.hpp"
 
-#include <thread>
+#include <algorithm>
+#include <cstdlib>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <typeinfo>
+#include <utility>
 
 namespace sequant {
-
-class TensorCanonicalizer;
 
 /// This interface class defines a Tensor concept. Object @c t of a type that
 /// meets the concept must satisfy the following:

--- a/SeQuant/core/abstract_tensor.hpp
+++ b/SeQuant/core/abstract_tensor.hpp
@@ -5,15 +5,11 @@
 #ifndef SEQUANT_ABSTRACT_TENSOR_HPP
 #define SEQUANT_ABSTRACT_TENSOR_HPP
 
-#include <range/v3/all.hpp>
-
-#include <boost/core/demangle.hpp>
-
-#include "algorithm.hpp"
-#include "attr.hpp"
-#include "container.hpp"
-#include "expr.hpp"
-#include "index.hpp"
+#include <SeQuant/core/algorithm.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
 
 #include <algorithm>
 #include <cstdlib>
@@ -26,6 +22,11 @@
 #include <string_view>
 #include <typeinfo>
 #include <utility>
+
+#include <range/v3/all.hpp>
+
+#include <boost/core/demangle.hpp>
+
 
 namespace sequant {
 

--- a/SeQuant/core/asy_cost.cpp
+++ b/SeQuant/core/asy_cost.cpp
@@ -1,8 +1,8 @@
-#include "asy_cost.hpp"
-#include "container.hpp"
-#include "meta/meta.hpp"
-#include "rational.hpp"
-#include "wstring.hpp"
+#include <SeQuant/core/asy_cost.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/meta.hpp>
+#include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/wstring.hpp>
 
 #include <boost/numeric/conversion/cast.hpp>
 

--- a/SeQuant/core/asy_cost.cpp
+++ b/SeQuant/core/asy_cost.cpp
@@ -1,5 +1,16 @@
 #include "asy_cost.hpp"
+#include "container.hpp"
+#include "meta/meta.hpp"
+#include "rational.hpp"
+#include "wstring.hpp"
+
 #include <boost/numeric/conversion/cast.hpp>
+
+#include <cmath>
+#include <limits>
+
+#include <range/v3/iterator.hpp>
+#include <range/v3/view.hpp>
 
 namespace sequant {
 

--- a/SeQuant/core/asy_cost.hpp
+++ b/SeQuant/core/asy_cost.hpp
@@ -2,11 +2,11 @@
 #define SEQUANT_ASY_COST_HPP
 
 #include <SeQuant/core/container.hpp>
-#include <SeQuant/core/math.hpp>
-#include <SeQuant/core/wstring.hpp>
-#include <range/v3/algorithm.hpp>
-#include <range/v3/view.hpp>
-#include <sstream>
+#include <SeQuant/core/rational.hpp>
+
+#include <cstddef>
+#include <string>
+#include <utility>
 
 namespace sequant {
 

--- a/SeQuant/core/container.hpp
+++ b/SeQuant/core/container.hpp
@@ -9,6 +9,7 @@
 #include <boost/container/flat_set.hpp>
 #include <boost/container/small_vector.hpp>
 #include <boost/range.hpp>
+
 #include <map>
 #include <set>
 #include <vector>

--- a/SeQuant/core/context.cpp
+++ b/SeQuant/core/context.cpp
@@ -1,6 +1,6 @@
-#include "SeQuant/core/context.hpp"
-#include "SeQuant/core/attr.hpp"
-#include "SeQuant/core/utility/context.hpp"
+#include <SeQuant/core/context.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/utility/context.hpp>
 
 namespace sequant {
 
@@ -74,5 +74,5 @@ Context& Context::set_first_dummy_index_ordinal(
 }  // namespace sequant
 
 #ifdef SEQUANT_HAS_MIMALLOC
-#include "mimalloc-new-delete.h"
+#include <mimalloc-new-delete.h>
 #endif

--- a/SeQuant/core/context.cpp
+++ b/SeQuant/core/context.cpp
@@ -1,4 +1,6 @@
 #include "SeQuant/core/context.hpp"
+#include "SeQuant/core/attr.hpp"
+#include "SeQuant/core/utility/context.hpp"
 
 namespace sequant {
 

--- a/SeQuant/core/context.hpp
+++ b/SeQuant/core/context.hpp
@@ -2,12 +2,14 @@
 #define SEQUANT_CORE_CONTEXT_HPP
 
 #include "attr.hpp"
-#include "index.hpp"
-#include "space.hpp"
-
 #include "utility/context.hpp"
 
+#include <cstddef>
+#include <memory>
+
 namespace sequant {
+
+class IndexRegistry;
 
 /// Specifies second quantization context, such as vacuum choice, whether index
 /// spaces are orthonormal, sizes of index spaces, etc.

--- a/SeQuant/core/context.hpp
+++ b/SeQuant/core/context.hpp
@@ -1,8 +1,8 @@
 #ifndef SEQUANT_CORE_CONTEXT_HPP
 #define SEQUANT_CORE_CONTEXT_HPP
 
-#include "attr.hpp"
-#include "utility/context.hpp"
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/utility/context.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/SeQuant/core/eval_expr.cpp
+++ b/SeQuant/core/eval_expr.cpp
@@ -1,9 +1,28 @@
-#include "eval_expr.hpp"
-#include <SeQuant/core/hash.hpp>
+#include "SeQuant/core/eval_expr.hpp"
+#include "SeQuant/core/attr.hpp"
+#include "SeQuant/core/complex.hpp"
+#include "SeQuant/core/container.hpp"
+#include "SeQuant/core/context.hpp"
+#include "SeQuant/core/expr.hpp"
+#include "SeQuant/core/hash.hpp"
+#include "SeQuant/core/index.hpp"
+#include "SeQuant/core/tensor.hpp"
+#include "SeQuant/core/wstring.hpp"
+
+#include <range/v3/action.hpp>
 #include <range/v3/algorithm.hpp>
+#include <range/v3/functional.hpp>
+#include <range/v3/iterator.hpp>
 #include <range/v3/view.hpp>
 
-#include <cmath>
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <memory>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace sequant {
 

--- a/SeQuant/core/eval_expr.cpp
+++ b/SeQuant/core/eval_expr.cpp
@@ -1,13 +1,13 @@
-#include "SeQuant/core/eval_expr.hpp"
-#include "SeQuant/core/attr.hpp"
-#include "SeQuant/core/complex.hpp"
-#include "SeQuant/core/container.hpp"
-#include "SeQuant/core/context.hpp"
-#include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/hash.hpp"
-#include "SeQuant/core/index.hpp"
-#include "SeQuant/core/tensor.hpp"
-#include "SeQuant/core/wstring.hpp"
+#include <SeQuant/core/eval_expr.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/complex.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/context.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/wstring.hpp>
 
 #include <range/v3/action.hpp>
 #include <range/v3/algorithm.hpp>

--- a/SeQuant/core/eval_expr.hpp
+++ b/SeQuant/core/eval_expr.hpp
@@ -1,10 +1,16 @@
 #ifndef SEQUANT_EVAL_EXPR_HPP
 #define SEQUANT_EVAL_EXPR_HPP
 
-#include <SeQuant/core/expr_fwd.hpp>
-#include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
+
+#include <cstddef>
+#include <string>
 
 namespace sequant {
+
+class Tensor;
 
 ///
 /// \brief The EvalOp enum
@@ -166,7 +172,6 @@ class EvalExpr {
   /// \return Constant const&.
   ///
   [[nodiscard]] Constant const& as_constant() const noexcept;
-
 
   ///
   /// \brief Calls to<Variable>() on ExprPtr held by this object.

--- a/SeQuant/core/eval_node.hpp
+++ b/SeQuant/core/eval_node.hpp
@@ -8,6 +8,7 @@
 #include "asy_cost.hpp"
 #include "binary_node.hpp"
 #include "eval_expr.hpp"
+#include "tensor.hpp"
 
 #include <SeQuant/core/math.hpp>
 

--- a/SeQuant/core/eval_node.hpp
+++ b/SeQuant/core/eval_node.hpp
@@ -5,11 +5,10 @@
 #ifndef SEQUANT_EVAL_NODE_HPP
 #define SEQUANT_EVAL_NODE_HPP
 
-#include "asy_cost.hpp"
-#include "binary_node.hpp"
-#include "eval_expr.hpp"
-#include "tensor.hpp"
-
+#include <SeQuant/core/asy_cost.hpp>
+#include <SeQuant/core/binary_node.hpp>
+#include <SeQuant/core/eval_expr.hpp>
+#include <SeQuant/core/tensor.hpp>
 #include <SeQuant/core/math.hpp>
 
 namespace sequant {

--- a/SeQuant/core/expr.cpp
+++ b/SeQuant/core/expr.cpp
@@ -2,12 +2,12 @@
 // Created by Eduard Valeyev on 2019-02-06.
 //
 
-#include "expr.hpp"
-#include "abstract_tensor.hpp"
-#include "algorithm.hpp"
-#include "logger.hpp"
-#include "tensor.hpp"
-#include "tensor_network.hpp"
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/algorithm.hpp>
+#include <SeQuant/core/logger.hpp>
+#include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/tensor_network.hpp>
 
 #include <range/v3/all.hpp>
 

--- a/SeQuant/core/expr.cpp
+++ b/SeQuant/core/expr.cpp
@@ -3,9 +3,16 @@
 //
 
 #include "expr.hpp"
+#include "abstract_tensor.hpp"
+#include "algorithm.hpp"
 #include "logger.hpp"
 #include "tensor.hpp"
 #include "tensor_network.hpp"
+
+#include <range/v3/all.hpp>
+
+#include <thread>
+#include <vector>
 
 namespace sequant {
 

--- a/SeQuant/core/expr.hpp
+++ b/SeQuant/core/expr.hpp
@@ -7,28 +7,34 @@
 
 #include "SeQuant/core/expr_fwd.hpp"
 
-#include "SeQuant/core/complex.hpp"
-#include "SeQuant/core/container.hpp"
-#include "SeQuant/core/hash.hpp"
-#include "SeQuant/core/latex.hpp"
-#include "SeQuant/core/logger.hpp"
-#include "SeQuant/core/meta.hpp"
-#include "SeQuant/core/rational.hpp"
-#include "SeQuant/core/meta.hpp"
-#include "SeQuant/core/wolfram.hpp"
+#include <SeQuant/core/complex.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/latex.hpp>
+#include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/wolfram.hpp>
 
 #include <range/v3/all.hpp>
 
 #include <boost/core/demangle.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <algorithm>
 #include <atomic>
-#include <complex>
+#include <cassert>
+#include <cstdlib>
+#include <functional>
+#include <initializer_list>
 #include <iostream>
+#include <iterator>
 #include <memory>
 #include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
 #include <type_traits>
-#include <vector>
+#include <typeinfo>
+#include <utility>
 
 namespace sequant {
 
@@ -1678,8 +1684,9 @@ T &ExprPtr::as() {
 
 }  // namespace sequant
 
+
+#endif  // SEQUANT_EXPR_HPP
+
 #include "expr_operator.hpp"
 
 #include "expr_algorithm.hpp"
-
-#endif  // SEQUANT_EXPR_HPP

--- a/SeQuant/core/expr_algorithm.hpp
+++ b/SeQuant/core/expr_algorithm.hpp
@@ -5,6 +5,9 @@
 #ifndef SEQUANT_EXPR_ALGORITHM_HPP
 #define SEQUANT_EXPR_ALGORITHM_HPP
 
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/logger.hpp>
+
 namespace sequant {
 
 /// Recursively canonicalizes an Expr and replaces it as needed

--- a/SeQuant/core/fwd.hpp
+++ b/SeQuant/core/fwd.hpp
@@ -8,6 +8,6 @@
 /// @brief the main namespace of the SeQuant framework
 namespace sequant {}
 
-#include "SeQuant/core/expr_fwd.hpp"
+#include <SeQuant/core/expr_fwd.hpp>
 
 #endif  // SEQUANT_CORE_FWD_HPP

--- a/SeQuant/core/hash.hpp
+++ b/SeQuant/core/hash.hpp
@@ -18,7 +18,7 @@ namespace sequant_boost = boost;
 #error "SeQuant requires Boost 1.81 or later for hashing"
 #endif
 
-#include "meta.hpp"
+#include <SeQuant/core/meta.hpp>
 
 namespace sequant {
 

--- a/SeQuant/core/index.cpp
+++ b/SeQuant/core/index.cpp
@@ -2,10 +2,10 @@
 // Created by Eduard Valeyev on 4/30/20.
 //
 
-#include "SeQuant/core/index.hpp"
-#include "SeQuant/core/context.hpp"
-#include "SeQuant/core/latex.hpp"
-#include "SeQuant/core/wstring.hpp"
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/context.hpp>
+#include <SeQuant/core/latex.hpp>
+#include <SeQuant/core/wstring.hpp>
 
 #include <unordered_map>
 

--- a/SeQuant/core/index.cpp
+++ b/SeQuant/core/index.cpp
@@ -2,13 +2,12 @@
 // Created by Eduard Valeyev on 4/30/20.
 //
 
-#include "../../SeQuant/core/index.hpp"
+#include "SeQuant/core/index.hpp"
+#include "SeQuant/core/context.hpp"
+#include "SeQuant/core/latex.hpp"
+#include "SeQuant/core/wstring.hpp"
 
-#include "../../SeQuant/core/context.hpp"
-
-#include "../../SeQuant/core/wstring.hpp"
-
-#include "../../SeQuant/core/latex.hpp"
+#include <unordered_map>
 
 namespace sequant {
 

--- a/SeQuant/core/index.hpp
+++ b/SeQuant/core/index.hpp
@@ -5,21 +5,31 @@
 #ifndef SEQUANT_INDEX_H
 #define SEQUANT_INDEX_H
 
+#include <algorithm>
 #include <atomic>
+#include <cassert>
+#include <cstdint>
+#include <cwchar>
 #include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <map>
 #include <mutex>
 #include <optional>
-#include <set>
+#include <stdexcept>
 #include <string>
-#include <unordered_map>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 #include <range/v3/all.hpp>
 
-#include "SeQuant/core/utility/string.hpp"
-#include "attr.hpp"
 #include "container.hpp"
 #include "hash.hpp"
 #include "space.hpp"
+#include "utility/string.hpp"
 #include "tag.hpp"
 
 // change to 1 to make thread-safe

--- a/SeQuant/core/index.hpp
+++ b/SeQuant/core/index.hpp
@@ -5,6 +5,15 @@
 #ifndef SEQUANT_INDEX_H
 #define SEQUANT_INDEX_H
 
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/space.hpp>
+#include <SeQuant/core/tag.hpp>
+#include <SeQuant/core/utility/string.hpp>
+
+// Only needed due to a (likely) compiler bug in Apple Clang
+#include <SeQuant/core/attr.hpp>
+
 #include <algorithm>
 #include <atomic>
 #include <cassert>
@@ -25,15 +34,6 @@
 #include <vector>
 
 #include <range/v3/all.hpp>
-
-#include "container.hpp"
-#include "hash.hpp"
-#include "space.hpp"
-#include "utility/string.hpp"
-#include "tag.hpp"
-
-// Only needed due to a (likely) compiler bug in Apple Clang
-#include "attr.hpp"
 
 // change to 1 to make thread-safe
 #define SEQUANT_INDEX_THREADSAFE 1

--- a/SeQuant/core/index.hpp
+++ b/SeQuant/core/index.hpp
@@ -32,6 +32,9 @@
 #include "utility/string.hpp"
 #include "tag.hpp"
 
+// Only needed due to a (likely) compiler bug in Apple Clang
+#include "attr.hpp"
+
 // change to 1 to make thread-safe
 #define SEQUANT_INDEX_THREADSAFE 1
 

--- a/SeQuant/core/latex.cpp
+++ b/SeQuant/core/latex.cpp
@@ -2,7 +2,7 @@
 // Created by Eduard Valeyev on 7/18/23.
 //
 
-#include "SeQuant/core/latex.ipp"
+#include <SeQuant/core/latex.ipp>
 
 namespace sequant::detail {
 

--- a/SeQuant/core/latex.hpp
+++ b/SeQuant/core/latex.hpp
@@ -7,6 +7,12 @@
 
 #include <SeQuant/core/meta.hpp>
 #include <SeQuant/core/wstring.hpp>
+
+#include <cmath>
+#include <complex>
+#include <limits>
+#include <string>
+#include <string_view>
 #include <type_traits>
 
 namespace sequant {

--- a/SeQuant/core/logger.hpp
+++ b/SeQuant/core/logger.hpp
@@ -5,7 +5,7 @@
 #ifndef SEQUANT_LOGGER_HPP
 #define SEQUANT_LOGGER_HPP
 
-#include "../core/utility/singleton.hpp"
+#include <SeQuant/core/utility/singleton.hpp>
 
 #include <iostream>
 

--- a/SeQuant/core/op.cpp
+++ b/SeQuant/core/op.cpp
@@ -2,10 +2,10 @@
 // Created by Eduard Valeyev on 2019-02-18.
 //
 
-#include "SeQuant/core/op.hpp"
-#include "SeQuant/core/attr.hpp"
-#include "SeQuant/core/container.hpp"
-#include "SeQuant/core/expr.hpp"
+#include <SeQuant/core/op.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/expr.hpp>
 
 #include <limits>
 

--- a/SeQuant/core/op.cpp
+++ b/SeQuant/core/op.cpp
@@ -2,7 +2,12 @@
 // Created by Eduard Valeyev on 2019-02-18.
 //
 
-#include <SeQuant/core/op.hpp>
+#include "SeQuant/core/op.hpp"
+#include "SeQuant/core/attr.hpp"
+#include "SeQuant/core/container.hpp"
+#include "SeQuant/core/expr.hpp"
+
+#include <limits>
 
 namespace sequant {
 namespace detail {

--- a/SeQuant/core/op.hpp
+++ b/SeQuant/core/op.hpp
@@ -5,6 +5,17 @@
 #ifndef SEQUANT_CORE_OP_H
 #define SEQUANT_CORE_OP_H
 
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/context.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/hugenholtz.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/ranges.hpp>
+#include <SeQuant/core/space.hpp>
+
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -20,17 +31,6 @@
 #include <utility>
 
 #include <range/v3/all.hpp>
-
-#include "abstract_tensor.hpp"
-#include "attr.hpp"
-#include "container.hpp"
-#include "context.hpp"
-#include "expr.hpp"
-#include "hash.hpp"
-#include "hugenholtz.hpp"
-#include "index.hpp"
-#include "ranges.hpp"
-#include "space.hpp"
 
 namespace sequant {
 

--- a/SeQuant/core/op.hpp
+++ b/SeQuant/core/op.hpp
@@ -5,7 +5,19 @@
 #ifndef SEQUANT_CORE_OP_H
 #define SEQUANT_CORE_OP_H
 
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <iterator>
+#include <memory>
 #include <numeric>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <utility>
 
 #include <range/v3/all.hpp>
 
@@ -18,6 +30,7 @@
 #include "hugenholtz.hpp"
 #include "index.hpp"
 #include "ranges.hpp"
+#include "space.hpp"
 
 namespace sequant {
 

--- a/SeQuant/core/optimize.hpp
+++ b/SeQuant/core/optimize.hpp
@@ -1,11 +1,21 @@
 #ifndef SEQUANT_OPTIMIZE_OPTIMIZE_HPP
 #define SEQUANT_OPTIMIZE_OPTIMIZE_HPP
 
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <functional>
+#include <iterator>
 #include <limits>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
 #include <utility>
 
+#include <SeQuant/core/abstract_tensor.hpp>
 #include <SeQuant/core/container.hpp>
-#include <SeQuant/core/eval_node.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
 #include <SeQuant/core/tensor_network.hpp>
 
 #if __cplusplus >= 202002L
@@ -32,6 +42,8 @@ bool has_single_bit(T x) noexcept {
 namespace sequant {
 /// Optimize an expression assuming the number of virtual orbitals
 /// greater than the number of occupied orbitals.
+
+class Tensor;
 
 /// \param expr Expression to be optimized.
 /// \return EvalNode object.

--- a/SeQuant/core/optimize/fusion.cpp
+++ b/SeQuant/core/optimize/fusion.cpp
@@ -1,5 +1,11 @@
 #include "fusion.hpp"
-#include <range/v3/action.hpp>
+#include "SeQuant/core/complex.hpp"
+#include "SeQuant/core/container.hpp"
+#include "SeQuant/core/expr.hpp"
+#include "SeQuant/core/expr_operator.hpp"
+
+#include <range/v3/algorithm.hpp>
+#include <range/v3/iterator.hpp>
 #include <range/v3/view.hpp>
 
 namespace sequant::opt {

--- a/SeQuant/core/optimize/fusion.cpp
+++ b/SeQuant/core/optimize/fusion.cpp
@@ -1,8 +1,9 @@
 #include "fusion.hpp"
-#include "SeQuant/core/complex.hpp"
-#include "SeQuant/core/container.hpp"
-#include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/expr_operator.hpp"
+
+#include <SeQuant/core/complex.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/expr_operator.hpp>
 
 #include <range/v3/algorithm.hpp>
 #include <range/v3/iterator.hpp>

--- a/SeQuant/core/optimize/optimize.cpp
+++ b/SeQuant/core/optimize/optimize.cpp
@@ -7,11 +7,11 @@
 #include <SeQuant/core/container.hpp>
 #include <SeQuant/core/complex.hpp>
 
-#include "range/v3/iterator/basic_iterator.hpp"
-#include "range/v3/range/access.hpp"
-#include "range/v3/view/tail.hpp"
-#include "range/v3/view/transform.hpp"
-#include "range/v3/view/view.hpp"
+#include <range/v3/iterator/basic_iterator.hpp>
+#include <range/v3/range/access.hpp>
+#include <range/v3/view/tail.hpp>
+#include <range/v3/view/transform.hpp>
+#include <range/v3/view/view.hpp>
 
 #include <memory>
 #include <stack>

--- a/SeQuant/core/optimize/optimize.cpp
+++ b/SeQuant/core/optimize/optimize.cpp
@@ -1,7 +1,31 @@
+#include <SeQuant/core/eval_expr.hpp>
+#include <SeQuant/core/eval_node.hpp>
+#include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/optimize.hpp>
-#include <stack>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/binary_node.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/complex.hpp>
 
-namespace sequant::opt {
+#include "range/v3/iterator/basic_iterator.hpp"
+#include "range/v3/range/access.hpp"
+#include "range/v3/view/tail.hpp"
+#include "range/v3/view/transform.hpp"
+#include "range/v3/view/view.hpp"
+
+#include <memory>
+#include <stack>
+#include <cassert>
+#include <cstddef>
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+namespace sequant {
+
+class Tensor;
+
+namespace opt {
 
 ExprPtr tail_factor(ExprPtr const& expr) noexcept {
   if (expr->is<Tensor>())
@@ -131,4 +155,6 @@ Sum reorder(Sum const& sum) {
   assert(result.size() == sum.size());
   return result;
 }
-}  // namespace sequant::opt
+
+}  // namespace opt
+}  // namespace sequant

--- a/SeQuant/core/parse/ast_conversions.hpp
+++ b/SeQuant/core/parse/ast_conversions.hpp
@@ -5,8 +5,7 @@
 #ifndef SEQUANT_CORE_PARSE_AST_CONVERSIONS_HPP
 #define SEQUANT_CORE_PARSE_AST_CONVERSIONS_HPP
 
-#include "ast.hpp"
-
+#include <SeQuant/core/parse/ast.hpp>
 #include <SeQuant/core/container.hpp>
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>

--- a/SeQuant/core/parse/deparse.cpp
+++ b/SeQuant/core/parse/deparse.cpp
@@ -4,13 +4,19 @@
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>
 #include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/complex.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
+#include <range/v3/all.hpp>
 
 #include <cassert>
 #include <codecvt>
 #include <locale>
 #include <string>
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
 
 namespace sequant {
 

--- a/SeQuant/core/parse/deparse.cpp
+++ b/SeQuant/core/parse/deparse.cpp
@@ -1,4 +1,4 @@
-#include "SeQuant/core/parse_expr.hpp"
+#include <SeQuant/core/parse_expr.hpp>
 
 #include <SeQuant/core/attr.hpp>
 #include <SeQuant/core/expr.hpp>

--- a/SeQuant/core/parse/parse.cpp
+++ b/SeQuant/core/parse/parse.cpp
@@ -2,11 +2,10 @@
 // Created by Robert Adam on 2023-09-20
 //
 
-#include "SeQuant/core/parse_expr.hpp"
-#include "ast.hpp"
-#include "ast_conversions.hpp"
-#include "semantic_actions.hpp"
-
+#include <SeQuant/core/parse_expr.hpp>
+#include <SeQuant/core/parse/ast.hpp>
+#include <SeQuant/core/parse/ast_conversions.hpp>
+#include <SeQuant/core/parse/semantic_actions.hpp>
 #include <SeQuant/core/attr.hpp>
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/space.hpp>

--- a/SeQuant/core/parse/parse.cpp
+++ b/SeQuant/core/parse/parse.cpp
@@ -8,11 +8,8 @@
 #include "semantic_actions.hpp"
 
 #include <SeQuant/core/attr.hpp>
-#include <SeQuant/core/container.hpp>
 #include <SeQuant/core/expr.hpp>
-#include <SeQuant/core/index.hpp>
 #include <SeQuant/core/space.hpp>
-#include <SeQuant/core/tensor.hpp>
 
 #define BOOST_SPIRIT_X3_UNICODE
 #include <boost/core/demangle.hpp>
@@ -20,13 +17,15 @@
 #include <boost/spirit/home/x3/support/utility/error_reporting.hpp>
 #include <boost/variant.hpp>
 
-#include <algorithm>
-#include <cassert>
-#include <cstdint>
+#include <cstddef>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 #include <functional>
 #include <iostream>
-#include <memory>
-#include <type_traits>
 
 namespace sequant {
 

--- a/SeQuant/core/parse/semantic_actions.hpp
+++ b/SeQuant/core/parse/semantic_actions.hpp
@@ -5,8 +5,7 @@
 #ifndef SEQUANT_CORE_PARSE_SEMANTIC_ACTIONS_HPP
 #define SEQUANT_CORE_PARSE_SEMANTIC_ACTIONS_HPP
 
-#include "ast.hpp"
-
+#include <SeQuant/core/parse/ast.hpp>
 #include <SeQuant/core/utility/string.hpp>
 
 #define BOOST_SPIRIT_X3_UNICODE

--- a/SeQuant/core/parse_expr.hpp
+++ b/SeQuant/core/parse_expr.hpp
@@ -2,8 +2,9 @@
 #define SEQUANT_PARSE_EXPR_HPP
 
 #include <SeQuant/core/attr.hpp>
-#include <SeQuant/core/expr_fwd.hpp>
+#include <SeQuant/core/expr.hpp>
 
+#include <string>
 #include <string_view>
 #include <stdexcept>
 #include <string>

--- a/SeQuant/core/runtime.cpp
+++ b/SeQuant/core/runtime.cpp
@@ -1,5 +1,6 @@
 #include <SeQuant/core/runtime.hpp>
 
+#include <exception>
 #include <iostream>
 #include <locale>
 

--- a/SeQuant/core/runtime.hpp
+++ b/SeQuant/core/runtime.hpp
@@ -5,16 +5,20 @@
 #ifndef SEQUANT_RUNTIME_HPP
 #define SEQUANT_RUNTIME_HPP
 
-#include <atomic>
-#include <mutex>
+#include <cstdlib>
+#include <memory>
 #include <stdexcept>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include <SeQuant/core/ranges.hpp>
 
 #ifdef SEQUANT_HAS_EXECUTION_HEADER
 #include <execution>
+#else
+#include <atomic>
+#include <mutex>
 #endif
 
 namespace sequant {

--- a/SeQuant/core/space.cpp
+++ b/SeQuant/core/space.cpp
@@ -3,6 +3,9 @@
 //
 
 #include "space.hpp"
+#include "container.hpp"
+
+#include <bitset>
 
 int32_t sequant::TypeAttr::used_bits = 0xffff;
 

--- a/SeQuant/core/space.cpp
+++ b/SeQuant/core/space.cpp
@@ -2,8 +2,8 @@
 // Created by Eduard Valeyev on 3/27/18.
 //
 
-#include "space.hpp"
-#include "container.hpp"
+#include <SeQuant/core/space.hpp>
+#include <SeQuant/core/container.hpp>
 
 #include <bitset>
 

--- a/SeQuant/core/space.hpp
+++ b/SeQuant/core/space.hpp
@@ -5,12 +5,16 @@
 #ifndef SEQUANT_SPACE_H
 #define SEQUANT_SPACE_H
 
-#include <bitset>
 #include <cassert>
 #include <codecvt>
+#include <cstdint>
+#include <cstdlib>
 #include <locale>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
 
-#include "attr.hpp"
 #include "container.hpp"
 
 #include <range/v3/algorithm/any_of.hpp>

--- a/SeQuant/core/space.hpp
+++ b/SeQuant/core/space.hpp
@@ -15,7 +15,7 @@
 #include <string_view>
 #include <utility>
 
-#include "container.hpp"
+#include <SeQuant/core/container.hpp>
 
 #include <range/v3/algorithm/any_of.hpp>
 

--- a/SeQuant/core/tag.hpp
+++ b/SeQuant/core/tag.hpp
@@ -5,8 +5,8 @@
 #ifndef SEQUANT_TAG_HPP
 #define SEQUANT_TAG_HPP
 
-#include "any.hpp"
-#include "meta.hpp"
+#include <SeQuant/core/meta.hpp>
+#include <SeQuant/core/any.hpp>
 
 namespace sequant {
 

--- a/SeQuant/core/tensor.cpp
+++ b/SeQuant/core/tensor.cpp
@@ -2,10 +2,10 @@
 // Created by Eduard Valeyev on 2019-01-30.
 //
 
-#include "tensor.hpp"
-#include "abstract_tensor.hpp"
-#include "expr.hpp"
-#include "index.hpp"
+#include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
 
 namespace sequant {
 

--- a/SeQuant/core/tensor.cpp
+++ b/SeQuant/core/tensor.cpp
@@ -3,6 +3,9 @@
 //
 
 #include "tensor.hpp"
+#include "abstract_tensor.hpp"
+#include "expr.hpp"
+#include "index.hpp"
 
 namespace sequant {
 

--- a/SeQuant/core/tensor.hpp
+++ b/SeQuant/core/tensor.hpp
@@ -5,6 +5,15 @@
 #ifndef SEQUANT_TENSOR_HPP
 #define SEQUANT_TENSOR_HPP
 
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/context.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/latex.hpp>
+
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -19,15 +28,6 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
-
-#include "abstract_tensor.hpp"
-#include "attr.hpp"
-#include "container.hpp"
-#include "context.hpp"
-#include "expr.hpp"
-#include "hash.hpp"
-#include "index.hpp"
-#include "latex.hpp"
 
 #include <range/v3/all.hpp>
 

--- a/SeQuant/core/tensor.hpp
+++ b/SeQuant/core/tensor.hpp
@@ -5,16 +5,31 @@
 #ifndef SEQUANT_TENSOR_HPP
 #define SEQUANT_TENSOR_HPP
 
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <initializer_list>
+#include <iterator>
 #include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 #include "abstract_tensor.hpp"
-#include "algorithm.hpp"
 #include "attr.hpp"
+#include "container.hpp"
 #include "context.hpp"
 #include "expr.hpp"
 #include "hash.hpp"
 #include "index.hpp"
 #include "latex.hpp"
+
+#include <range/v3/all.hpp>
 
 namespace sequant {
 

--- a/SeQuant/core/tensor_network.cpp
+++ b/SeQuant/core/tensor_network.cpp
@@ -2,20 +2,20 @@
 // Created by Eduard Valeyev on 2019-02-26.
 //
 
-#include "tensor_network.hpp"
-#include "abstract_tensor.hpp"
-#include "algorithm.hpp"
-#include "attr.hpp"
-#include "bliss.hpp"
-#include "complex.hpp"
-#include "container.hpp"
-#include "expr.hpp"
-#include "hash.hpp"
-#include "index.hpp"
-#include "latex.hpp"
-#include "logger.hpp"
-#include "tag.hpp"
-#include "wstring.hpp"
+#include <SeQuant/core/tensor_network.hpp>
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/algorithm.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/bliss.hpp>
+#include <SeQuant/core/complex.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/latex.hpp>
+#include <SeQuant/core/logger.hpp>
+#include <SeQuant/core/tag.hpp>
+#include <SeQuant/core/wstring.hpp>
 
 #include <algorithm>
 #include <iostream>
@@ -23,12 +23,12 @@
 #include <sstream>
 #include <type_traits>
 
-#include "range/v3/algorithm/for_each.hpp"
-#include "range/v3/algorithm/none_of.hpp"
-#include "range/v3/functional/identity.hpp"
-#include "range/v3/iterator/basic_iterator.hpp"
-#include "range/v3/view/any_view.hpp"
-#include "range/v3/view/view.hpp"
+#include <range/v3/algorithm/for_each.hpp>
+#include <range/v3/algorithm/none_of.hpp>
+#include <range/v3/functional/identity.hpp>
+#include <range/v3/iterator/basic_iterator.hpp>
+#include <range/v3/view/any_view.hpp>
+#include <range/v3/view/view.hpp>
 
 namespace sequant {
 

--- a/SeQuant/core/tensor_network.cpp
+++ b/SeQuant/core/tensor_network.cpp
@@ -3,8 +3,32 @@
 //
 
 #include "tensor_network.hpp"
+#include "abstract_tensor.hpp"
+#include "algorithm.hpp"
+#include "attr.hpp"
 #include "bliss.hpp"
+#include "complex.hpp"
+#include "container.hpp"
+#include "expr.hpp"
+#include "hash.hpp"
+#include "index.hpp"
+#include "latex.hpp"
 #include "logger.hpp"
+#include "tag.hpp"
+#include "wstring.hpp"
+
+#include <algorithm>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <type_traits>
+
+#include "range/v3/algorithm/for_each.hpp"
+#include "range/v3/algorithm/none_of.hpp"
+#include "range/v3/functional/identity.hpp"
+#include "range/v3/iterator/basic_iterator.hpp"
+#include "range/v3/view/any_view.hpp"
+#include "range/v3/view/view.hpp"
 
 namespace sequant {
 

--- a/SeQuant/core/tensor_network.hpp
+++ b/SeQuant/core/tensor_network.hpp
@@ -7,7 +7,18 @@
 
 #include "abstract_tensor.hpp"
 #include "container.hpp"
-#include "tensor.hpp"
+#include "expr.hpp"
+#include "index.hpp"
+
+#include <cassert>
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 // forward declarations
 namespace bliss {

--- a/SeQuant/core/tensor_network.hpp
+++ b/SeQuant/core/tensor_network.hpp
@@ -5,10 +5,10 @@
 #ifndef SEQUANT_TENSOR_NETWORK_H
 #define SEQUANT_TENSOR_NETWORK_H
 
-#include "abstract_tensor.hpp"
-#include "container.hpp"
-#include "expr.hpp"
-#include "index.hpp"
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
 
 #include <cassert>
 #include <cstdlib>

--- a/SeQuant/core/utility/string.cpp
+++ b/SeQuant/core/utility/string.cpp
@@ -1,5 +1,5 @@
-#include "SeQuant/core/utility/string.hpp"
-#include "SeQuant/core/utility/macros.hpp"
+#include <SeQuant/core/utility/string.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 
 #include <codecvt>
 #include <locale>

--- a/SeQuant/core/wick.hpp
+++ b/SeQuant/core/wick.hpp
@@ -9,11 +9,11 @@
 #include <mutex>
 #include <utility>
 
-#include "SeQuant/core/math.hpp"
-#include "op.hpp"
-#include "ranges.hpp"
-#include "runtime.hpp"
-#include "tensor.hpp"
+#include <SeQuant/core/math.hpp>
+#include <SeQuant/core/op.hpp>
+#include <SeQuant/core/ranges.hpp>
+#include <SeQuant/core/runtime.hpp>
+#include <SeQuant/core/tensor.hpp>
 
 namespace sequant {
 
@@ -1484,6 +1484,6 @@ using FWickTheorem = WickTheorem<Statistics::FermiDirac>;
 
 }  // namespace sequant
 
-#include "wick.impl.hpp"
+#include <SeQuant/core/wick.impl.hpp>
 
 #endif  // SEQUANT_WICK_HPP

--- a/SeQuant/core/wick.impl.hpp
+++ b/SeQuant/core/wick.impl.hpp
@@ -5,9 +5,9 @@
 #ifndef SEQUANT_WICK_IMPL_HPP
 #define SEQUANT_WICK_IMPL_HPP
 
-#include "bliss.hpp"
-#include "logger.hpp"
-#include "tensor_network.hpp"
+#include <SeQuant/core/bliss.hpp>
+#include <SeQuant/core/logger.hpp>
+#include <SeQuant/core/tensor_network.hpp>
 
 #ifdef SEQUANT_HAS_EXECUTION_HEADER
 #include <execution>

--- a/SeQuant/core/wolfram.hpp
+++ b/SeQuant/core/wolfram.hpp
@@ -5,8 +5,11 @@
 #ifndef SEQUANT_WOLFRAM_HPP
 #define SEQUANT_WOLFRAM_HPP
 
-#include <type_traits>
 #include "meta.hpp"
+#include "wstring.hpp"
+
+#include <string>
+#include <type_traits>
 
 namespace sequant {
 

--- a/SeQuant/core/wolfram.hpp
+++ b/SeQuant/core/wolfram.hpp
@@ -5,8 +5,8 @@
 #ifndef SEQUANT_WOLFRAM_HPP
 #define SEQUANT_WOLFRAM_HPP
 
-#include "meta.hpp"
-#include "wstring.hpp"
+#include <SeQuant/core/meta.hpp>
+#include <SeQuant/core/wstring.hpp>
 
 #include <string>
 #include <type_traits>

--- a/SeQuant/core/wstring.hpp
+++ b/SeQuant/core/wstring.hpp
@@ -5,7 +5,7 @@
 #ifndef SEQUANT_WSTRING_HPP
 #define SEQUANT_WSTRING_HPP
 
-#include "SeQuant/core/utility/macros.hpp"
+#include <SeQuant/core/utility/macros.hpp>
 
 #include <cmath>
 #include <string>

--- a/SeQuant/domain/eval/cache_manager.cpp
+++ b/SeQuant/domain/eval/cache_manager.cpp
@@ -2,7 +2,7 @@
 // Created by Bimal Gaudel on 9/26/23.
 //
 
-#include "cache_manager.hpp"
+#include <SeQuant/domain/eval/cache_manager.hpp>
 
 #include <SeQuant/core/eval_node.hpp>
 

--- a/SeQuant/domain/eval/eval.cpp
+++ b/SeQuant/domain/eval/eval.cpp
@@ -1,4 +1,4 @@
-#include "eval.hpp"
+#include <SeQuant/domain/eval/eval.hpp>
 
 #include <TiledArray/expressions/index_list.h>
 #include <TiledArray/expressions/permopt.h>

--- a/SeQuant/domain/eval/eval.hpp
+++ b/SeQuant/domain/eval/eval.hpp
@@ -1,14 +1,13 @@
 #ifndef SEQUANT_EVAL_EVAL_HPP
 #define SEQUANT_EVAL_EVAL_HPP
 
-#include "eval_result.hpp"
-
 #include <SeQuant/core/container.hpp>
 #include <SeQuant/core/eval_node.hpp>
 #include <SeQuant/core/logger.hpp>
-#include <SeQuant/core/tensor.hpp>
 #include <SeQuant/core/meta.hpp>
+#include <SeQuant/core/tensor.hpp>
 #include <SeQuant/domain/eval/cache_manager.hpp>
+#include <SeQuant/domain/eval/eval_result.hpp>
 
 #include <btas/btas.h>
 #include <tiledarray.h>

--- a/SeQuant/domain/eval/eval_result.cpp
+++ b/SeQuant/domain/eval/eval_result.cpp
@@ -1,4 +1,4 @@
-#include "eval_result.hpp"
+#include <SeQuant/domain/eval/eval_result.hpp>
 
 namespace sequant {
 

--- a/SeQuant/domain/mbpt/context.cpp
+++ b/SeQuant/domain/mbpt/context.cpp
@@ -1,4 +1,4 @@
-#include "SeQuant/domain/mbpt/context.hpp"
+#include <SeQuant/domain/mbpt/context.hpp>
 
 namespace sequant::mbpt {
 

--- a/SeQuant/domain/mbpt/context.hpp
+++ b/SeQuant/domain/mbpt/context.hpp
@@ -2,7 +2,7 @@
 #ifndef SEQUANT_DOMAIN_MBPT_CONTEXT_HPP
 #define SEQUANT_DOMAIN_MBPT_CONTEXT_HPP
 
-#include "SeQuant/core/utility/context.hpp"
+#include <SeQuant/core/utility/context.hpp>
 
 namespace sequant::mbpt {
 

--- a/SeQuant/domain/mbpt/convention.cpp
+++ b/SeQuant/domain/mbpt/convention.cpp
@@ -3,9 +3,18 @@
 //
 
 #include "convention.hpp"
-#include "SeQuant/core/index.hpp"
-#include "SeQuant/core/tensor.hpp"
 #include "op.hpp"
+
+#include "SeQuant/core/abstract_tensor.hpp"
+#include "SeQuant/core/index.hpp"
+#include "SeQuant/core/space.hpp"
+
+#include <cassert>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
 
 namespace sequant {
 namespace mbpt {

--- a/SeQuant/domain/mbpt/convention.cpp
+++ b/SeQuant/domain/mbpt/convention.cpp
@@ -2,12 +2,12 @@
 // Created by Eduard Valeyev on 2019-04-01.
 //
 
-#include "convention.hpp"
-#include "op.hpp"
+#include <SeQuant/domain/mbpt/convention.hpp>
+#include <SeQuant/domain/mbpt/op.hpp>
 
-#include "SeQuant/core/abstract_tensor.hpp"
-#include "SeQuant/core/index.hpp"
-#include "SeQuant/core/space.hpp"
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/space.hpp>
 
 #include <cassert>
 #include <cstdlib>

--- a/SeQuant/domain/mbpt/fwd.hpp
+++ b/SeQuant/domain/mbpt/fwd.hpp
@@ -5,7 +5,7 @@
 #ifndef SEQUANT_DOMAIN_MBPT_FWD_HPP
 #define SEQUANT_DOMAIN_MBPT_FWD_HPP
 
-#include "SeQuant/core/fwd.hpp"
+#include <SeQuant/core/fwd.hpp>
 
 #include <cstdint>
 

--- a/SeQuant/domain/mbpt/models/cc.cpp
+++ b/SeQuant/domain/mbpt/models/cc.cpp
@@ -1,18 +1,15 @@
-#include <SeQuant/domain/mbpt/context.hpp>
 #include <SeQuant/domain/mbpt/models/cc.hpp>
-
-#include <clocale>
-#include <iostream>
-
-#include <SeQuant/core/math.hpp>
-
-#include <SeQuant/core/op.hpp>
-#include <SeQuant/core/parse_expr.hpp>
-#include <SeQuant/core/runtime.hpp>
-#include <SeQuant/domain/mbpt/convention.hpp>
-#include <SeQuant/domain/mbpt/spin.hpp>
-
 #include <SeQuant/domain/mbpt/sr.hpp>
+#include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/runtime.hpp>
+#include "SeQuant/core/expr.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <new>
+#include <stdexcept>
 
 namespace sequant::mbpt::sr {
 

--- a/SeQuant/domain/mbpt/models/cc.cpp
+++ b/SeQuant/domain/mbpt/models/cc.cpp
@@ -2,7 +2,7 @@
 #include <SeQuant/domain/mbpt/sr.hpp>
 #include <SeQuant/core/rational.hpp>
 #include <SeQuant/core/runtime.hpp>
-#include "SeQuant/core/expr.hpp"
+#include <SeQuant/core/expr.hpp>
 
 #include <cassert>
 #include <cstdint>

--- a/SeQuant/domain/mbpt/models/cc.hpp
+++ b/SeQuant/domain/mbpt/models/cc.hpp
@@ -1,10 +1,13 @@
 #ifndef SEQUANT_DOMAIN_MBPT_MODELS_CC_HPP
 #define SEQUANT_DOMAIN_MBPT_MODELS_CC_HPP
 
-#include <SeQuant/core/container.hpp>
-#include <SeQuant/core/expr_fwd.hpp>
-#include <SeQuant/core/index.hpp>
-#include <SeQuant/core/timer.hpp>
+#include <cstddef>
+#include <limits>
+#include <vector>
+
+namespace sequant {
+class ExprPtr;
+}
 
 namespace sequant::mbpt::sr {
 

--- a/SeQuant/domain/mbpt/mr.cpp
+++ b/SeQuant/domain/mbpt/mr.cpp
@@ -3,13 +3,39 @@
 //
 
 #include "SeQuant/domain/mbpt/mr.hpp"
+#include "SeQuant/domain/mbpt/fwd.hpp"
 
+#include "SeQuant/core/abstract_tensor.hpp"
+#include "SeQuant/core/container.hpp"
+#include "SeQuant/core/context.hpp"
 #include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/math.hpp"
+#include "SeQuant/core/expr_fwd.hpp"
+#include "SeQuant/core/index.hpp"
+#include "SeQuant/core/logger.hpp"
 #include "SeQuant/core/op.hpp"
 #include "SeQuant/core/tensor.hpp"
 #include "SeQuant/core/wick.hpp"
-#include "SeQuant/domain/mbpt/context.hpp"
+
+#include <atomic>
+#include <algorithm>
+#include <map>
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <stdexcept>
+
+#include "range/v3/algorithm/for_each.hpp"
+#include "range/v3/functional/identity.hpp"
+#include "range/v3/iterator/basic_iterator.hpp"
+#include "range/v3/iterator/reverse_iterator.hpp"
+#include "range/v3/range/conversion.hpp"
+#include "range/v3/view/filter.hpp"
+#include "range/v3/view/map.hpp"
+#include "range/v3/view/reverse.hpp"
+#include "range/v3/view/transform.hpp"
+#include "range/v3/view/view.hpp"
 
 namespace sequant {
 namespace mbpt {

--- a/SeQuant/domain/mbpt/mr.cpp
+++ b/SeQuant/domain/mbpt/mr.cpp
@@ -2,19 +2,19 @@
 // Created by Eduard Valeyev on 2019-02-19.
 //
 
-#include "SeQuant/domain/mbpt/mr.hpp"
-#include "SeQuant/domain/mbpt/fwd.hpp"
+#include <SeQuant/domain/mbpt/mr.hpp>
+#include <SeQuant/domain/mbpt/fwd.hpp>
 
-#include "SeQuant/core/abstract_tensor.hpp"
-#include "SeQuant/core/container.hpp"
-#include "SeQuant/core/context.hpp"
-#include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/expr_fwd.hpp"
-#include "SeQuant/core/index.hpp"
-#include "SeQuant/core/logger.hpp"
-#include "SeQuant/core/op.hpp"
-#include "SeQuant/core/tensor.hpp"
-#include "SeQuant/core/wick.hpp"
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/context.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/expr_fwd.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/logger.hpp>
+#include <SeQuant/core/op.hpp>
+#include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/wick.hpp>
 
 #include <atomic>
 #include <algorithm>
@@ -26,16 +26,16 @@
 #include <set>
 #include <stdexcept>
 
-#include "range/v3/algorithm/for_each.hpp"
-#include "range/v3/functional/identity.hpp"
-#include "range/v3/iterator/basic_iterator.hpp"
-#include "range/v3/iterator/reverse_iterator.hpp"
-#include "range/v3/range/conversion.hpp"
-#include "range/v3/view/filter.hpp"
-#include "range/v3/view/map.hpp"
-#include "range/v3/view/reverse.hpp"
-#include "range/v3/view/transform.hpp"
-#include "range/v3/view/view.hpp"
+#include <range/v3/algorithm/for_each.hpp>
+#include <range/v3/functional/identity.hpp>
+#include <range/v3/iterator/basic_iterator.hpp>
+#include <range/v3/iterator/reverse_iterator.hpp>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/map.hpp>
+#include <range/v3/view/reverse.hpp>
+#include <range/v3/view/transform.hpp>
+#include <range/v3/view/view.hpp>
 
 namespace sequant {
 namespace mbpt {
@@ -179,7 +179,7 @@ OpMaker::OpMaker(OpType op, std::size_t nbra, std::size_t nket)
   }
 }
 
-#include "../mbpt/mr/op.impl.cpp"
+#include <SeQuant/domain/mbpt/mr/op.impl.cpp>
 
 ExprPtr H_(std::size_t k) {
   assert(k > 0 && k <= 2);
@@ -639,7 +639,7 @@ bool can_change_qns(const ExprPtr& op_or_op_product, const qns_t target_qns,
 
 using mbpt::mr::vac_av;
 
-#include "SeQuant/domain/mbpt/vac_av.ipp"
+#include <SeQuant/domain/mbpt/vac_av.ipp>
 
 }  // namespace op
 
@@ -721,7 +721,7 @@ std::wstring to_latex(const mbpt::Operator<mbpt::mr::qns_t, S>& op) {
 
 }  // namespace sequant
 
-#include "SeQuant/domain/mbpt/op.ipp"
+#include <SeQuant/domain/mbpt/op.ipp>
 
 namespace sequant {
 namespace mbpt {

--- a/SeQuant/domain/mbpt/mr.hpp
+++ b/SeQuant/domain/mbpt/mr.hpp
@@ -5,14 +5,14 @@
 #ifndef SEQUANT_DOMAIN_MBPT_MR_HPP
 #define SEQUANT_DOMAIN_MBPT_MR_HPP
 
-#include "SeQuant/domain/mbpt/op.hpp"
+#include <SeQuant/domain/mbpt/op.hpp>
 
-#include "SeQuant/core/attr.hpp"
-#include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/hash.hpp"
-#include "SeQuant/core/interval.hpp"
-#include "SeQuant/core/latex.hpp"
-#include "SeQuant/core/space.hpp"
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/interval.hpp>
+#include <SeQuant/core/latex.hpp>
+#include <SeQuant/core/space.hpp>
 
 #include <array>
 #include <cstddef>
@@ -156,7 +156,7 @@ class OpMaker : public mbpt::OpMaker<Statistics::FermiDirac> {
   using base_type::operator();
 };
 
-#include "mr/op.impl.hpp"
+#include <SeQuant/domain/mbpt/mr/op.impl.hpp>
 
 /// @name tensor-level operators
 /// @{
@@ -220,7 +220,7 @@ ExprPtr Λ_(std::size_t K);
 /// \p K
 ExprPtr Λ(std::size_t K);
 
-#include "SeQuant/domain/mbpt/vac_av.hpp"
+#include <SeQuant/domain/mbpt/vac_av.hpp>
 
 }  // namespace op
 

--- a/SeQuant/domain/mbpt/mr.hpp
+++ b/SeQuant/domain/mbpt/mr.hpp
@@ -5,15 +5,26 @@
 #ifndef SEQUANT_DOMAIN_MBPT_MR_HPP
 #define SEQUANT_DOMAIN_MBPT_MR_HPP
 
-#include "SeQuant/domain/mbpt/fwd.hpp"
-
-#include "SeQuant/core/context.hpp"
-#include "SeQuant/core/expr_fwd.hpp"
-#include "SeQuant/core/space.hpp"
 #include "SeQuant/domain/mbpt/op.hpp"
 
+#include "SeQuant/core/attr.hpp"
+#include "SeQuant/core/expr.hpp"
+#include "SeQuant/core/hash.hpp"
+#include "SeQuant/core/interval.hpp"
+#include "SeQuant/core/latex.hpp"
+#include "SeQuant/core/space.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
 #include <limits>
+#include <string>
+#include <string_view>
 #include <utility>
+#include <vector>
 
 namespace sequant {
 namespace mbpt {
@@ -145,7 +156,7 @@ class OpMaker : public mbpt::OpMaker<Statistics::FermiDirac> {
   using base_type::operator();
 };
 
-#include "../mbpt/mr/op.impl.hpp"
+#include "mr/op.impl.hpp"
 
 /// @name tensor-level operators
 /// @{

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -1,16 +1,16 @@
-#include "SeQuant/domain/mbpt/op.hpp"
-#include "SeQuant/domain/mbpt/context.hpp"
+#include <SeQuant/domain/mbpt/op.hpp>
+#include <SeQuant/domain/mbpt/context.hpp>
 
-#include "SeQuant/core/tensor.hpp"
-#include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/interval.hpp"
-#include "SeQuant/core/op.hpp"
-#include "SeQuant/core/attr.hpp"
-#include "SeQuant/core/container.hpp"
-#include "SeQuant/core/hash.hpp"
-#include "SeQuant/core/latex.hpp"
-#include "SeQuant/core/op.hpp"
-#include "SeQuant/core/space.hpp"
+#include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/interval.hpp>
+#include <SeQuant/core/op.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/latex.hpp>
+#include <SeQuant/core/op.hpp>
+#include <SeQuant/core/space.hpp>
 
 #include <stdexcept>
 
@@ -157,7 +157,7 @@ std::wstring to_latex(const mbpt::Operator<mbpt::qns_t, S>& op) {
 
 }  // namespace sequant
 
-#include "SeQuant/domain/mbpt/op.ipp"
+#include <SeQuant/domain/mbpt/op.ipp>
 
 namespace sequant::mbpt {
 

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -1,11 +1,20 @@
 #include "SeQuant/domain/mbpt/op.hpp"
 #include "SeQuant/domain/mbpt/context.hpp"
 
-#include "SeQuant/core/math.hpp"
-#include "SeQuant/core/op.hpp"
 #include "SeQuant/core/tensor.hpp"
+#include "SeQuant/core/expr.hpp"
+#include "SeQuant/core/interval.hpp"
+#include "SeQuant/core/op.hpp"
+#include "SeQuant/core/attr.hpp"
+#include "SeQuant/core/container.hpp"
+#include "SeQuant/core/hash.hpp"
+#include "SeQuant/core/latex.hpp"
+#include "SeQuant/core/op.hpp"
+#include "SeQuant/core/space.hpp"
 
 #include <stdexcept>
+
+#include <range/v3/view/reverse.hpp>
 
 namespace sequant::mbpt {
 

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -34,13 +34,13 @@
 #include <SeQuant/core/rational.hpp>
 #include <SeQuant/core/space.hpp>
 
-#include "range/v3/iterator/basic_iterator.hpp"
-#include "range/v3/range/conversion.hpp"
-#include "range/v3/range/primitives.hpp"
-#include "range/v3/view/map.hpp"
-#include "range/v3/view/transform.hpp"
-#include "range/v3/view/view.hpp"
-#include "range/v3/view/zip.hpp"
+#include <range/v3/iterator/basic_iterator.hpp>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/range/primitives.hpp>
+#include <range/v3/view/map.hpp>
+#include <range/v3/view/transform.hpp>
+#include <range/v3/view/view.hpp>
+#include <range/v3/view/zip.hpp>
 
 namespace sequant {
 namespace mbpt {

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -5,16 +5,42 @@
 #ifndef SEQUANT_DOMAIN_MBPT_OP_HPP
 #define SEQUANT_DOMAIN_MBPT_OP_HPP
 
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <map>
+#include <optional>
+#include <stdexcept>
 #include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
-#include <SeQuant/core/abstract_tensor.hpp>
 #include <SeQuant/core/attr.hpp>
-#include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/interval.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/context.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/index.hpp>
 #include <SeQuant/core/math.hpp>
 #include <SeQuant/core/op.hpp>
-#include <SeQuant/domain/mbpt/context.hpp>
+#include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/space.hpp>
+
+#include "range/v3/iterator/basic_iterator.hpp"
+#include "range/v3/range/conversion.hpp"
+#include "range/v3/range/primitives.hpp"
+#include "range/v3/view/map.hpp"
+#include "range/v3/view/transform.hpp"
+#include "range/v3/view/view.hpp"
+#include "range/v3/view/zip.hpp"
 
 namespace sequant {
 namespace mbpt {

--- a/SeQuant/domain/mbpt/rdm.hpp
+++ b/SeQuant/domain/mbpt/rdm.hpp
@@ -6,7 +6,7 @@
 #define SEQUANT_DOMAIN_MBPT_RDM_HPP
 
 #include <SeQuant/domain/mbpt/antisymmetrizer.hpp>
-#include "SeQuant/domain/mbpt/op.hpp"
+#include <SeQuant/domain/mbpt/op.hpp>
 
 namespace sequant {
 namespace mbpt {

--- a/SeQuant/domain/mbpt/spin.cpp
+++ b/SeQuant/domain/mbpt/spin.cpp
@@ -1,15 +1,45 @@
 #include <SeQuant/domain/mbpt/spin.hpp>
 
+#include <SeQuant/core/algorithm.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/expr_algorithm.hpp>
+#include <SeQuant/core/expr_operator.hpp>
 #include <SeQuant/core/math.hpp>
+#include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/space.hpp>
 #include <SeQuant/core/tensor.hpp>
 
 #ifdef SEQUANT_HAS_EIGEN
 #include <Eigen/Eigenvalues>
 #endif
 
+#include <range/v3/algorithm/any_of.hpp>
+#include <range/v3/algorithm/contains.hpp>
+#include <range/v3/algorithm/count_if.hpp>
 #include <range/v3/algorithm/for_each.hpp>
+#include <range/v3/detail/variant.hpp>
+#include <range/v3/functional/identity.hpp>
+#include <range/v3/iterator/basic_iterator.hpp>
+#include <range/v3/utility/get.hpp>
+#include <range/v3/view/concat.hpp>
+#include <range/v3/view/interface.hpp>
+#include <range/v3/view/transform.hpp>
+#include <range/v3/view/view.hpp>
 
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <new>
+#include <numeric>
+#include <stdexcept>
+#include <string_view>
 #include <unordered_map>
+#include <utility>
 
 namespace sequant {
 

--- a/SeQuant/domain/mbpt/spin.hpp
+++ b/SeQuant/domain/mbpt/spin.hpp
@@ -5,10 +5,15 @@
 #ifndef SEQUANT_SPIN_HPP
 #define SEQUANT_SPIN_HPP
 
-#include <SeQuant/core/tensor_network.hpp>
+#include "SeQuant/core/container.hpp"
+#include "SeQuant/core/expr.hpp"
+#include "SeQuant/core/index.hpp"
 #include "SeQuant/core/tensor.hpp"
 
-#include <unordered_map>
+#include <cstddef>
+#include <initializer_list>
+#include <string>
+#include <vector>
 
 namespace sequant {
 

--- a/SeQuant/domain/mbpt/spin.hpp
+++ b/SeQuant/domain/mbpt/spin.hpp
@@ -5,10 +5,10 @@
 #ifndef SEQUANT_SPIN_HPP
 #define SEQUANT_SPIN_HPP
 
-#include "SeQuant/core/container.hpp"
-#include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/index.hpp"
-#include "SeQuant/core/tensor.hpp"
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/tensor.hpp>
 
 #include <cstddef>
 #include <initializer_list>

--- a/SeQuant/domain/mbpt/sr.cpp
+++ b/SeQuant/domain/mbpt/sr.cpp
@@ -3,13 +3,30 @@
 //
 
 #include "SeQuant/domain/mbpt/sr.hpp"
+#include "SeQuant/domain/mbpt/context.hpp"
 
+#include "SeQuant/core/container.hpp"
+#include "SeQuant/core/context.hpp"
 #include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/math.hpp"
+#include "SeQuant/core/index.hpp"
+#include "SeQuant/core/logger.hpp"
 #include "SeQuant/core/op.hpp"
 #include "SeQuant/core/tensor.hpp"
 #include "SeQuant/core/wick.hpp"
-#include "SeQuant/domain/mbpt/context.hpp"
+
+#include <atomic>
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <stdexcept>
+
+#include "range/v3/iterator/basic_iterator.hpp"
+#include "range/v3/iterator/reverse_iterator.hpp"
+#include "range/v3/view/reverse.hpp"
+#include "range/v3/view/view.hpp"
 
 namespace sequant {
 namespace mbpt {

--- a/SeQuant/domain/mbpt/sr.cpp
+++ b/SeQuant/domain/mbpt/sr.cpp
@@ -2,17 +2,17 @@
 // Created by Eduard Valeyev on 2019-02-19.
 //
 
-#include "SeQuant/domain/mbpt/sr.hpp"
-#include "SeQuant/domain/mbpt/context.hpp"
+#include <SeQuant/domain/mbpt/sr.hpp>
+#include <SeQuant/domain/mbpt/context.hpp>
 
-#include "SeQuant/core/container.hpp"
-#include "SeQuant/core/context.hpp"
-#include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/index.hpp"
-#include "SeQuant/core/logger.hpp"
-#include "SeQuant/core/op.hpp"
-#include "SeQuant/core/tensor.hpp"
-#include "SeQuant/core/wick.hpp"
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/context.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/logger.hpp>
+#include <SeQuant/core/op.hpp>
+#include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/wick.hpp>
 
 #include <atomic>
 #include <algorithm>
@@ -23,10 +23,10 @@
 #include <memory>
 #include <stdexcept>
 
-#include "range/v3/iterator/basic_iterator.hpp"
-#include "range/v3/iterator/reverse_iterator.hpp"
-#include "range/v3/view/reverse.hpp"
-#include "range/v3/view/view.hpp"
+#include <range/v3/iterator/basic_iterator.hpp>
+#include <range/v3/iterator/reverse_iterator.hpp>
+#include <range/v3/view/reverse.hpp>
+#include <range/v3/view/view.hpp>
 
 namespace sequant {
 namespace mbpt {
@@ -136,7 +136,7 @@ OpMaker::OpMaker(OpType op, std::size_t nbra, std::size_t nket)
   }
 }
 
-#include "../mbpt/sr/op.impl.cpp"
+#include <SeQuant/domain/mbpt/sr/op.impl.cpp>
 
 ExprPtr H0mp() { return F(); }
 
@@ -516,7 +516,7 @@ bool lowers_rank_to_vacuum(const ExprPtr& op_or_op_product,
 
 using mbpt::sr::vac_av;
 
-#include "SeQuant/domain/mbpt/vac_av.ipp"
+#include <SeQuant/domain/mbpt/vac_av.ipp>
 
 }  // namespace op
 
@@ -598,7 +598,7 @@ std::wstring to_latex(const mbpt::Operator<mbpt::sr::qns_t, S>& op) {
 
 }  // namespace sequant
 
-#include "SeQuant/domain/mbpt/op.ipp"
+#include <SeQuant/domain/mbpt/op.ipp>
 
 namespace sequant {
 namespace mbpt {

--- a/SeQuant/domain/mbpt/sr.hpp
+++ b/SeQuant/domain/mbpt/sr.hpp
@@ -18,13 +18,13 @@
 #include <utility>
 #include <vector>
 
-#include "SeQuant/core/attr.hpp"
-#include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/hash.hpp"
-#include "SeQuant/core/interval.hpp"
-#include "SeQuant/core/latex.hpp"
-#include "SeQuant/core/space.hpp"
-#include "SeQuant/domain/mbpt/op.hpp"
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/interval.hpp>
+#include <SeQuant/core/latex.hpp>
+#include <SeQuant/core/space.hpp>
+#include <SeQuant/domain/mbpt/op.hpp>
 
 namespace sequant {
 namespace mbpt {
@@ -146,7 +146,7 @@ class OpMaker : public mbpt::OpMaker<Statistics::FermiDirac> {
   using base_type::operator();
 };
 
-#include "sr/op.impl.hpp"
+#include <SeQuant/domain/mbpt/sr/op.impl.hpp>
 
 /// @name tensor-level SR MBPT operators
 /// @{
@@ -294,7 +294,7 @@ bool lowers_rank_to_vacuum(const ExprPtr& op_or_op_product,
 bool lowers_rank_or_lower_to_vacuum(const ExprPtr& op_or_op_product,
                                     const unsigned long k);
 
-#include "SeQuant/domain/mbpt/vac_av.hpp"
+#include <SeQuant/domain/mbpt/vac_av.hpp>
 
 }  // namespace op
 

--- a/SeQuant/domain/mbpt/sr.hpp
+++ b/SeQuant/domain/mbpt/sr.hpp
@@ -5,11 +5,24 @@
 #ifndef SEQUANT_DOMAIN_MBPT_SR_HPP
 #define SEQUANT_DOMAIN_MBPT_SR_HPP
 
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
 #include <limits>
+#include <string>
+#include <string_view>
 #include <utility>
+#include <vector>
 
-#include "SeQuant/core/context.hpp"
-#include "SeQuant/core/expr_fwd.hpp"
+#include "SeQuant/core/attr.hpp"
+#include "SeQuant/core/expr.hpp"
+#include "SeQuant/core/hash.hpp"
+#include "SeQuant/core/interval.hpp"
+#include "SeQuant/core/latex.hpp"
 #include "SeQuant/core/space.hpp"
 #include "SeQuant/domain/mbpt/op.hpp"
 
@@ -133,7 +146,7 @@ class OpMaker : public mbpt::OpMaker<Statistics::FermiDirac> {
   using base_type::operator();
 };
 
-#include "../mbpt/sr/op.impl.hpp"
+#include "sr/op.impl.hpp"
 
 /// @name tensor-level SR MBPT operators
 /// @{

--- a/examples/eval/btas/data_world_btas.hpp
+++ b/examples/eval/btas/data_world_btas.hpp
@@ -5,8 +5,8 @@
 #ifndef SEQUANT_EVAL_DATA_WORLD_BTAS_HPP
 #define SEQUANT_EVAL_DATA_WORLD_BTAS_HPP
 
-#include "examples/eval/data_info.hpp"
-#include "examples/eval/eval_utils.hpp"
+#include <examples/eval/data_info.hpp>
+#include <examples/eval/eval_utils.hpp>
 
 #include <btas/btas.h>
 #include <SeQuant/core/container.hpp>

--- a/examples/eval/btas/main.cpp
+++ b/examples/eval/btas/main.cpp
@@ -9,8 +9,8 @@
 #include <SeQuant/domain/mbpt/context.hpp>
 #include <SeQuant/domain/mbpt/convention.hpp>
 
-#include "examples/eval/btas/scf_btas.hpp"
-#include "examples/eval/calc_info.hpp"
+#include <examples/eval/btas/scf_btas.hpp>
+#include <examples/eval/calc_info.hpp>
 
 ///
 /// excitation (2 = ccsd (default) through 6 supported)

--- a/examples/eval/btas/scf_btas.hpp
+++ b/examples/eval/btas/scf_btas.hpp
@@ -5,10 +5,10 @@
 #ifndef SEQUANT_EVAL_SCF_BTAS_HPP
 #define SEQUANT_EVAL_SCF_BTAS_HPP
 
-#include "examples/eval/btas/data_world_btas.hpp"
-#include "examples/eval/calc_info.hpp"
-#include "examples/eval/data_info.hpp"
-#include "examples/eval/scf.hpp"
+#include <examples/eval/btas/data_world_btas.hpp>
+#include <examples/eval/calc_info.hpp>
+#include <examples/eval/data_info.hpp>
+#include <examples/eval/scf.hpp>
 
 #include <SeQuant/domain/eval/cache_manager.hpp>
 #include <SeQuant/domain/eval/eval.hpp>

--- a/examples/eval/calc_info.cpp
+++ b/examples/eval/calc_info.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "calc_info.hpp"
+
 #include <SeQuant/domain/mbpt/models/cc.hpp>
 
 namespace sequant::eval {

--- a/examples/eval/calc_info.hpp
+++ b/examples/eval/calc_info.hpp
@@ -5,8 +5,8 @@
 #ifndef SEQUANT_EVAL_CALC_INFO_HPP
 #define SEQUANT_EVAL_CALC_INFO_HPP
 
-#include "examples/eval/data_info.hpp"
-#include "examples/eval/options.hpp"
+#include <examples/eval/data_info.hpp>
+#include <examples/eval/options.hpp>
 
 #include <SeQuant/core/container.hpp>
 #include <SeQuant/core/eval_node.hpp>

--- a/examples/eval/scf.hpp
+++ b/examples/eval/scf.hpp
@@ -8,7 +8,7 @@
 #include <cstddef>
 #include <iostream>
 
-#include "examples/eval/calc_info.hpp"
+#include <examples/eval/calc_info.hpp>
 
 namespace sequant::eval {
 

--- a/examples/eval/ta/data_world_ta.hpp
+++ b/examples/eval/ta/data_world_ta.hpp
@@ -5,8 +5,8 @@
 #ifndef SEQUANT_EVAL_DATA_WORLD_TA_HPP
 #define SEQUANT_EVAL_DATA_WORLD_TA_HPP
 
-#include "examples/eval/data_info.hpp"
-#include "examples/eval/eval_utils.hpp"
+#include <examples/eval/data_info.hpp>
+#include <examples/eval/eval_utils.hpp>
 
 #include <SeQuant/core/container.hpp>
 #include <SeQuant/core/tensor.hpp>

--- a/examples/eval/ta/main.cpp
+++ b/examples/eval/ta/main.cpp
@@ -9,8 +9,8 @@
 #include <SeQuant/domain/mbpt/context.hpp>
 #include <SeQuant/domain/mbpt/convention.hpp>
 
-#include "examples/eval/calc_info.hpp"
-#include "examples/eval/ta/scf_ta.hpp"
+#include <examples/eval/calc_info.hpp>
+#include <examples/eval/ta/scf_ta.hpp>
 
 template <typename Os>
 Os& operator<<(Os& os, sequant::eval::CalcInfo const& info) {

--- a/examples/eval/ta/scf_ta.hpp
+++ b/examples/eval/ta/scf_ta.hpp
@@ -11,10 +11,10 @@
 #include <SeQuant/core/eval_node.hpp>
 #include <SeQuant/core/parse_expr.hpp>
 
-#include "examples/eval/calc_info.hpp"
-#include "examples/eval/data_info.hpp"
-#include "examples/eval/scf.hpp"
-#include "examples/eval/ta/data_world_ta.hpp"
+#include <examples/eval/calc_info.hpp>
+#include <examples/eval/data_info.hpp>
+#include <examples/eval/scf.hpp>
+#include <examples/eval/ta/data_world_ta.hpp>
 
 #include <chrono>
 

--- a/examples/synopsis/synopsis1.cpp
+++ b/examples/synopsis/synopsis1.cpp
@@ -1,3 +1,7 @@
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/latex.hpp>
+#include <SeQuant/core/op.hpp>
 #include <SeQuant/core/wick.hpp>
 
 int main() {

--- a/examples/synopsis/synopsis2.cpp
+++ b/examples/synopsis/synopsis2.cpp
@@ -1,5 +1,7 @@
 #include <SeQuant/core/context.hpp>
 
+#include <cassert>
+
 int main() {
   using namespace sequant;
 

--- a/examples/synopsis/synopsis3.cpp
+++ b/examples/synopsis/synopsis3.cpp
@@ -1,3 +1,8 @@
+#include <SeQuant/core/context.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/latex.hpp>
+#include <SeQuant/core/op.hpp>
+#include <SeQuant/core/space.hpp>
 #include <SeQuant/core/wick.hpp>
 
 int main() {

--- a/python/src/sequant/_sequant.cc
+++ b/python/src/sequant/_sequant.cc
@@ -1,8 +1,13 @@
 #include <SeQuant/core/complex.hpp>
 #include <SeQuant/core/context.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/space.hpp>
 #include <SeQuant/core/tensor.hpp>
 
 #include <iostream>
+#include <string>
+#include <vector>
 
 #include "mbpt.h"
 

--- a/python/src/sequant/mbpt.h
+++ b/python/src/sequant/mbpt.h
@@ -4,6 +4,10 @@
 #include <SeQuant/domain/mbpt/convention.hpp>
 #include <SeQuant/domain/mbpt/sr.hpp>
 
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/context.hpp>
+#include <SeQuant/core/expr.hpp>
+
 #include "python.h"
 
 #include <cstdint>

--- a/tests/unit/test_asy_cost.cpp
+++ b/tests/unit/test_asy_cost.cpp
@@ -1,9 +1,11 @@
 #include "catch.hpp"
 
 #include <SeQuant/core/asy_cost.hpp>
-#include <SeQuant/core/math.hpp>
+#include <SeQuant/core/rational.hpp>
 
-#include <sstream>
+#include <cstddef>
+#include <cmath>
+#include <string>
 
 struct MatFlops {
   double occ_range_size;

--- a/tests/unit/test_binary_node.cpp
+++ b/tests/unit/test_binary_node.cpp
@@ -1,9 +1,13 @@
 #include "catch.hpp"
 
 #include <SeQuant/core/binary_node.hpp>
+
 #include <array>
-#include <range/v3/view.hpp>
 #include <string>
+#include <cstddef>
+#include <utility>
+
+#include <range/v3/all.hpp>
 
 TEST_CASE("TEST BINARY_NODE", "[FullBinaryNode]") {
   using ranges::views::iota;

--- a/tests/unit/test_bliss.cpp
+++ b/tests/unit/test_bliss.cpp
@@ -4,8 +4,8 @@
 
 #include "catch.hpp"
 
-#include "SeQuant/external/bliss/graph.hh"
-#include "SeQuant/external/bliss/utils.hh"
+#include <SeQuant/external/bliss/graph.hh>
+#include <SeQuant/external/bliss/utils.hh>
 
 #include <cstdio>
 #include <vector>

--- a/tests/unit/test_bliss.cpp
+++ b/tests/unit/test_bliss.cpp
@@ -8,9 +8,9 @@
 #include "SeQuant/external/bliss/utils.hh"
 
 #include <cstdio>
-#include <iostream>
-#include <numeric>
 #include <vector>
+#include <cassert>
+#include <initializer_list>
 
 constexpr const bool use_colors = true;
 

--- a/tests/unit/test_canonicalize.cpp
+++ b/tests/unit/test_canonicalize.cpp
@@ -1,9 +1,19 @@
-#include <iostream>
+#include "catch.hpp"
 
 #include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/expr_algorithm.hpp"
 #include "SeQuant/core/tensor.hpp"
-#include "catch.hpp"
+#include "SeQuant/core/abstract_tensor.hpp"
+#include "SeQuant/core/attr.hpp"
+#include "SeQuant/core/hash.hpp"
+#include "SeQuant/core/index.hpp"
+#include "SeQuant/core/latex.hpp"
+#include "SeQuant/core/rational.hpp"
+
+#include <memory>
+#include <string>
+#include <type_traits>
+
+#include <range/v3/all.hpp>
 
 TEST_CASE("Canonicalizer", "[algorithms]") {
   using namespace sequant;

--- a/tests/unit/test_canonicalize.cpp
+++ b/tests/unit/test_canonicalize.cpp
@@ -1,13 +1,13 @@
 #include "catch.hpp"
 
-#include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/tensor.hpp"
-#include "SeQuant/core/abstract_tensor.hpp"
-#include "SeQuant/core/attr.hpp"
-#include "SeQuant/core/hash.hpp"
-#include "SeQuant/core/index.hpp"
-#include "SeQuant/core/latex.hpp"
-#include "SeQuant/core/rational.hpp"
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/latex.hpp>
+#include <SeQuant/core/rational.hpp>
 
 #include <memory>
 #include <string>

--- a/tests/unit/test_eval_expr.cpp
+++ b/tests/unit/test_eval_expr.cpp
@@ -1,8 +1,21 @@
+#include "catch.hpp"
+
 #include <SeQuant/core/context.hpp>
 #include <SeQuant/core/eval_expr.hpp>
 #include <SeQuant/core/parse_expr.hpp>
+#include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
 
-#include "catch.hpp"
+#include <string_view>
+#include <initializer_list>
+#include <memory>
+#include <string>
+
+#include <range/v3/all.hpp>
 
 template <typename Iterable1, typename Iterable2>
 bool same_index_labels(Iterable1 const& indices1,

--- a/tests/unit/test_eval_node.cpp
+++ b/tests/unit/test_eval_node.cpp
@@ -2,6 +2,23 @@
 
 #include <SeQuant/core/eval_node.hpp>
 #include <SeQuant/core/parse_expr.hpp>
+#include <SeQuant/core/asy_cost.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/binary_node.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/eval_expr.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/rational.hpp>
+
+#include <cassert>
+#include <initializer_list>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <range/v3/all.hpp>
 
 namespace {
 

--- a/tests/unit/test_expr.cpp
+++ b/tests/unit/test_expr.cpp
@@ -4,13 +4,13 @@
 
 #include "catch.hpp"
 
-#include "SeQuant/core/hash.hpp"
-#include "SeQuant/core/complex.hpp"
-#include "SeQuant/core/container.hpp"
-#include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/latex.hpp"
-#include "SeQuant/core/meta.hpp"
-#include "SeQuant/core/wolfram.hpp"
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/complex.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/latex.hpp>
+#include <SeQuant/core/meta.hpp>
+#include <SeQuant/core/wolfram.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/tests/unit/test_expr.cpp
+++ b/tests/unit/test_expr.cpp
@@ -4,9 +4,28 @@
 
 #include "catch.hpp"
 
-#include <iostream>
 #include "SeQuant/core/hash.hpp"
-#include "SeQuant/core/wick.hpp"
+#include "SeQuant/core/complex.hpp"
+#include "SeQuant/core/container.hpp"
+#include "SeQuant/core/expr.hpp"
+#include "SeQuant/core/latex.hpp"
+#include "SeQuant/core/meta.hpp"
+#include "SeQuant/core/wolfram.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <algorithm>
+#include <initializer_list>
+#include <iterator>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <range/v3/all.hpp>
 
 struct Dummy : public sequant::Expr {
   virtual ~Dummy() = default;

--- a/tests/unit/test_fusion.cpp
+++ b/tests/unit/test_fusion.cpp
@@ -1,6 +1,14 @@
+#include "catch.hpp"
+
 #include <SeQuant/core/optimize/fusion.hpp>
 #include <SeQuant/core/parse_expr.hpp>
-#include "catch.hpp"
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/expr.hpp>
+
+#include <array>
+#include <memory>
+#include <string_view>
+#include <vector>
 
 TEST_CASE("TEST_FUSION", "[Fusion]") {
   using sequant::opt::Fusion;

--- a/tests/unit/test_index.cpp
+++ b/tests/unit/test_index.cpp
@@ -1,12 +1,12 @@
 //
 // Created by Eduard Valeyev on 3/20/18.
 //
-#include <iostream>
-
 #include "catch.hpp"
 
+#include "SeQuant/core/attr.hpp"
 #include "SeQuant/core/index.hpp"
 #include "SeQuant/core/latex.hpp"
+#include "SeQuant/core/wolfram.hpp"
 
 TEST_CASE("Index", "[elements][index]") {
   using namespace sequant;

--- a/tests/unit/test_index.cpp
+++ b/tests/unit/test_index.cpp
@@ -3,10 +3,10 @@
 //
 #include "catch.hpp"
 
-#include "SeQuant/core/attr.hpp"
-#include "SeQuant/core/index.hpp"
-#include "SeQuant/core/latex.hpp"
-#include "SeQuant/core/wolfram.hpp"
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/latex.hpp>
+#include <SeQuant/core/wolfram.hpp>
 
 TEST_CASE("Index", "[elements][index]") {
   using namespace sequant;

--- a/tests/unit/test_iterator.cpp
+++ b/tests/unit/test_iterator.cpp
@@ -4,9 +4,9 @@
 
 #include "catch.hpp"
 
-#include "SeQuant/core/op.hpp"
-#include "SeQuant/core/ranges.hpp"
-#include "SeQuant/core/algorithm.hpp"
+#include <SeQuant/core/op.hpp>
+#include <SeQuant/core/ranges.hpp>
+#include <SeQuant/core/algorithm.hpp>
 
 #include <algorithm>
 #include <initializer_list>

--- a/tests/unit/test_iterator.cpp
+++ b/tests/unit/test_iterator.cpp
@@ -6,6 +6,14 @@
 
 #include "SeQuant/core/op.hpp"
 #include "SeQuant/core/ranges.hpp"
+#include "SeQuant/core/algorithm.hpp"
+
+#include <algorithm>
+#include <initializer_list>
+#include <iterator>
+#include <vector>
+
+#include <range/v3/all.hpp>
 
 TEST_CASE("Iterators", "[elements]") {
 

--- a/tests/unit/test_latex.cpp
+++ b/tests/unit/test_latex.cpp
@@ -5,6 +5,10 @@
 #include "catch.hpp"
 
 #include "SeQuant/core/latex.hpp"
+#include "SeQuant/core/meta.hpp"
+
+#include <stdexcept>
+#include <string>
 
 TEST_CASE("latex", "[util]") {
   using namespace sequant;

--- a/tests/unit/test_latex.cpp
+++ b/tests/unit/test_latex.cpp
@@ -4,8 +4,8 @@
 
 #include "catch.hpp"
 
-#include "SeQuant/core/latex.hpp"
-#include "SeQuant/core/meta.hpp"
+#include <SeQuant/core/latex.hpp>
+#include <SeQuant/core/meta.hpp>
 
 #include <stdexcept>
 #include <string>

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -4,12 +4,12 @@
 
 #define CATCH_CONFIG_RUNNER
 #include <clocale>
-#include "SeQuant/core/logger.hpp"
-#include "SeQuant/core/op.hpp"
-#include "SeQuant/core/runtime.hpp"
-#include "SeQuant/core/space.hpp"
-#include "SeQuant/domain/mbpt/context.hpp"
-#include "SeQuant/domain/mbpt/convention.hpp"
+#include <SeQuant/core/logger.hpp>
+#include <SeQuant/core/op.hpp>
+#include <SeQuant/core/runtime.hpp>
+#include <SeQuant/core/space.hpp>
+#include <SeQuant/domain/mbpt/context.hpp>
+#include <SeQuant/domain/mbpt/convention.hpp>
 #include "catch.hpp"
 
 #ifdef SEQUANT_HAS_TILEDARRAY

--- a/tests/unit/test_math.cpp
+++ b/tests/unit/test_math.cpp
@@ -4,12 +4,20 @@
 
 #include "catch.hpp"
 
-#include <iostream>
-
 #include "SeQuant/core/math.hpp"
 #include "SeQuant/core/rational.hpp"
 #include "SeQuant/core/runtime.hpp"
 #include "SeQuant/core/wstring.hpp"
+#include "SeQuant/core/meta.hpp"
+
+#include <iostream>
+#include <cmath>
+#include <new>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include <range/v3/all.hpp>
 
 TEST_CASE("Rational", "[elements]") {
   using namespace sequant;

--- a/tests/unit/test_math.cpp
+++ b/tests/unit/test_math.cpp
@@ -4,11 +4,11 @@
 
 #include "catch.hpp"
 
-#include "SeQuant/core/math.hpp"
-#include "SeQuant/core/rational.hpp"
-#include "SeQuant/core/runtime.hpp"
-#include "SeQuant/core/wstring.hpp"
-#include "SeQuant/core/meta.hpp"
+#include <SeQuant/core/math.hpp>
+#include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/runtime.hpp>
+#include <SeQuant/core/wstring.hpp>
+#include <SeQuant/core/meta.hpp>
 
 #include <iostream>
 #include <cmath>

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -10,9 +10,28 @@
 #include "SeQuant/domain/mbpt/op.hpp"
 #include "SeQuant/domain/mbpt/spin.hpp"
 #include "SeQuant/domain/mbpt/sr.hpp"
+#include "SeQuant/core/abstract_tensor.hpp"
+#include "SeQuant/core/algorithm.hpp"
+#include "SeQuant/core/attr.hpp"
+#include "SeQuant/core/context.hpp"
+#include "SeQuant/core/expr.hpp"
+#include "SeQuant/core/index.hpp"
+#include "SeQuant/core/latex.hpp"
 
 #include "catch.hpp"
 #include "test_config.hpp"
+
+#include <iostream>
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include<vector>
+
+#include <range/v3/all.hpp>
 
 TEST_CASE("NBodyOp", "[mbpt]") {
   using namespace sequant;

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -2,21 +2,21 @@
 // Created by Eduard Valeyev on 2019-02-19.
 //
 
-#include "SeQuant/core/op.hpp"
-#include "SeQuant/core/tensor.hpp"
-#include "SeQuant/core/timer.hpp"
-#include "SeQuant/domain/mbpt/context.hpp"
-#include "SeQuant/domain/mbpt/mr.hpp"
-#include "SeQuant/domain/mbpt/op.hpp"
-#include "SeQuant/domain/mbpt/spin.hpp"
-#include "SeQuant/domain/mbpt/sr.hpp"
-#include "SeQuant/core/abstract_tensor.hpp"
-#include "SeQuant/core/algorithm.hpp"
-#include "SeQuant/core/attr.hpp"
-#include "SeQuant/core/context.hpp"
-#include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/index.hpp"
-#include "SeQuant/core/latex.hpp"
+#include <SeQuant/core/op.hpp>
+#include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/timer.hpp>
+#include <SeQuant/domain/mbpt/context.hpp>
+#include <SeQuant/domain/mbpt/mr.hpp>
+#include <SeQuant/domain/mbpt/op.hpp>
+#include <SeQuant/domain/mbpt/spin.hpp>
+#include <SeQuant/domain/mbpt/sr.hpp>
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/algorithm.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/context.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/latex.hpp>
 
 #include "catch.hpp"
 #include "test_config.hpp"

--- a/tests/unit/test_mbpt_cc.cpp
+++ b/tests/unit/test_mbpt_cc.cpp
@@ -2,9 +2,9 @@
 // Created by Eduard Valeyev on 2023-12-06
 //
 
-#include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/timer.hpp"
-#include "SeQuant/domain/mbpt/models/cc.hpp"
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/timer.hpp>
+#include <SeQuant/domain/mbpt/models/cc.hpp>
 
 #include "catch.hpp"
 #include "test_config.hpp"

--- a/tests/unit/test_mbpt_cc.cpp
+++ b/tests/unit/test_mbpt_cc.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "SeQuant/core/expr.hpp"
+#include "SeQuant/core/timer.hpp"
 #include "SeQuant/domain/mbpt/models/cc.hpp"
 
 #include "catch.hpp"

--- a/tests/unit/test_op.cpp
+++ b/tests/unit/test_op.cpp
@@ -4,7 +4,11 @@
 
 #include "catch.hpp"
 
-#include <iostream>
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
 
 #include "SeQuant/core/op.hpp"
 

--- a/tests/unit/test_op.cpp
+++ b/tests/unit/test_op.cpp
@@ -10,7 +10,7 @@
 #include <type_traits>
 #include <utility>
 
-#include "SeQuant/core/op.hpp"
+#include <SeQuant/core/op.hpp>
 
 TEST_CASE("Op", "[elements]") {
   using namespace sequant;

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -2,6 +2,18 @@
 
 #include <SeQuant/core/optimize.hpp>
 #include <SeQuant/core/parse_expr.hpp>
+#include <SeQuant/core/algorithm.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/space.hpp>
+
+#include <cstddef>
+#include <initializer_list>
+#include <memory>
+#include <stdexcept>
+
+#include <range/v3/all.hpp>
 
 sequant::ExprPtr extract(sequant::ExprPtr expr,
                          std::initializer_list<size_t> const& idxs) {

--- a/tests/unit/test_parse_expr.cpp
+++ b/tests/unit/test_parse_expr.cpp
@@ -2,11 +2,23 @@
 
 #include <SeQuant/core/parse_expr.hpp>
 #include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/complex.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/rational.hpp>
 
 #include <algorithm>
 #include <locale>
 #include <sstream>
 #include <string>
+#include <cstddef>
+#include <memory>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <range/v3/all.hpp>
 
 namespace Catch {
 template <>

--- a/tests/unit/test_runtime.cpp
+++ b/tests/unit/test_runtime.cpp
@@ -4,8 +4,8 @@
 
 #include "catch.hpp"
 
-#include "SeQuant/core/context.hpp"
-#include "SeQuant/core/attr.hpp"
+#include <SeQuant/core/context.hpp>
+#include <SeQuant/core/attr.hpp>
 
 TEST_CASE("Context", "[runtime]") {
   using namespace sequant;

--- a/tests/unit/test_runtime.cpp
+++ b/tests/unit/test_runtime.cpp
@@ -2,11 +2,10 @@
 // Created by Eduard Valeyev on 10/12/22.
 //
 
-#include <iostream>
-
 #include "catch.hpp"
 
 #include "SeQuant/core/context.hpp"
+#include "SeQuant/core/attr.hpp"
 
 TEST_CASE("Context", "[runtime]") {
   using namespace sequant;

--- a/tests/unit/test_space.cpp
+++ b/tests/unit/test_space.cpp
@@ -4,7 +4,7 @@
 
 #include "catch.hpp"
 
-#include "SeQuant/core/space.hpp"
+#include <SeQuant/core/space.hpp>
 
 TEST_CASE("IndexSpace", "[elements]") {
   using namespace sequant;

--- a/tests/unit/test_spin.cpp
+++ b/tests/unit/test_spin.cpp
@@ -4,9 +4,31 @@
 
 #include "SeQuant/core/parse_expr.hpp"
 #include "SeQuant/domain/mbpt/spin.hpp"
+#include "SeQuant/core/abstract_tensor.hpp"
+#include "SeQuant/core/attr.hpp"
+#include "SeQuant/core/container.hpp"
+#include "SeQuant/core/expr.hpp"
+#include "SeQuant/core/hash.hpp"
+#include "SeQuant/core/index.hpp"
+#include "SeQuant/core/latex.hpp"
+#include "SeQuant/core/rational.hpp"
+#include "SeQuant/core/space.hpp"
+#include "SeQuant/core/tensor.hpp"
 
 #include "catch.hpp"
 #include "test_config.hpp"
+
+#include <cassert>
+#include <cstddef>
+#include <initializer_list>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+#include <range/v3/all.hpp>
 
 TEST_CASE("Spin", "[spin]") {
   using namespace sequant;

--- a/tests/unit/test_spin.cpp
+++ b/tests/unit/test_spin.cpp
@@ -2,18 +2,18 @@
 // Created by Nakul Teke on 12/20/19.
 //
 
-#include "SeQuant/core/parse_expr.hpp"
-#include "SeQuant/domain/mbpt/spin.hpp"
-#include "SeQuant/core/abstract_tensor.hpp"
-#include "SeQuant/core/attr.hpp"
-#include "SeQuant/core/container.hpp"
-#include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/hash.hpp"
-#include "SeQuant/core/index.hpp"
-#include "SeQuant/core/latex.hpp"
-#include "SeQuant/core/rational.hpp"
-#include "SeQuant/core/space.hpp"
-#include "SeQuant/core/tensor.hpp"
+#include <SeQuant/core/parse_expr.hpp>
+#include <SeQuant/domain/mbpt/spin.hpp>
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/latex.hpp>
+#include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/space.hpp>
+#include <SeQuant/core/tensor.hpp>
 
 #include "catch.hpp"
 #include "test_config.hpp"

--- a/tests/unit/test_string.cpp
+++ b/tests/unit/test_string.cpp
@@ -6,6 +6,9 @@
 
 #include "SeQuant/core/wstring.hpp"
 
+#include <memory>
+#include <type_traits>
+
 TEST_CASE("string", "[util]") {
   using namespace sequant;
 

--- a/tests/unit/test_string.cpp
+++ b/tests/unit/test_string.cpp
@@ -4,7 +4,7 @@
 
 #include "catch.hpp"
 
-#include "SeQuant/core/wstring.hpp"
+#include <SeQuant/core/wstring.hpp>
 
 #include <memory>
 #include <type_traits>

--- a/tests/unit/test_tensor.cpp
+++ b/tests/unit/test_tensor.cpp
@@ -4,8 +4,23 @@
 
 #include "catch.hpp"
 
-#include <iostream>
-#include "SeQuant/core/wick.hpp"
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/latex.hpp>
+#include <SeQuant/core/meta.hpp>
+#include <SeQuant/core/op.hpp>
+#include <SeQuant/core/tag.hpp>
+#include <SeQuant/core/tensor.hpp>
+
+#include <cstddef>
+#include <initializer_list>
+#include <map>
+#include <string>
+#include <string_view>
+#include <type_traits>
 
 TEST_CASE("Tensor", "[elements]") {
   using namespace sequant;

--- a/tests/unit/test_tensor_network.cpp
+++ b/tests/unit/test_tensor_network.cpp
@@ -4,14 +4,36 @@
 
 #include "catch.hpp"
 
-#include <iostream>
-
 #include "SeQuant/core/bliss.hpp"
 #include "SeQuant/core/op.hpp"
+#include "SeQuant/core/tensor.hpp"
 #include "SeQuant/core/tensor_network.hpp"
 #include "SeQuant/domain/mbpt/sr.hpp"
-
 #include "SeQuant/core/timer.hpp"
+#include "SeQuant/core/abstract_tensor.hpp"
+#include "SeQuant/core/algorithm.hpp"
+#include "SeQuant/core/attr.hpp"
+#include "SeQuant/core/context.hpp"
+#include "SeQuant/core/expr.hpp"
+#include "SeQuant/core/hash.hpp"
+#include "SeQuant/core/index.hpp"
+
+#include <iostream>
+#include <cstdlib>
+#include <algorithm>
+#include <cmath>
+#include <initializer_list>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <range/v3/all.hpp>
 
 TEST_CASE("TensorNetwork", "[elements]") {
   using namespace sequant;

--- a/tests/unit/test_tensor_network.cpp
+++ b/tests/unit/test_tensor_network.cpp
@@ -4,19 +4,19 @@
 
 #include "catch.hpp"
 
-#include "SeQuant/core/bliss.hpp"
-#include "SeQuant/core/op.hpp"
-#include "SeQuant/core/tensor.hpp"
-#include "SeQuant/core/tensor_network.hpp"
-#include "SeQuant/domain/mbpt/sr.hpp"
-#include "SeQuant/core/timer.hpp"
-#include "SeQuant/core/abstract_tensor.hpp"
-#include "SeQuant/core/algorithm.hpp"
-#include "SeQuant/core/attr.hpp"
-#include "SeQuant/core/context.hpp"
-#include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/hash.hpp"
-#include "SeQuant/core/index.hpp"
+#include <SeQuant/core/bliss.hpp>
+#include <SeQuant/core/op.hpp>
+#include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/tensor_network.hpp>
+#include <SeQuant/domain/mbpt/sr.hpp>
+#include <SeQuant/core/timer.hpp>
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/algorithm.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/context.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/index.hpp>
 
 #include <iostream>
 #include <cstdlib>

--- a/tests/unit/test_wick.cpp
+++ b/tests/unit/test_wick.cpp
@@ -2,20 +2,20 @@
 // Created by Eduard Valeyev on 3/23/18.
 //
 
-#include "SeQuant/core/timer.hpp"
-#include "SeQuant/core/abstract_tensor.hpp"
-#include "SeQuant/core/attr.hpp"
-#include "SeQuant/core/context.hpp"
-#include "SeQuant/core/expr.hpp"
-#include "SeQuant/core/hash.hpp"
-#include "SeQuant/core/index.hpp"
-#include "SeQuant/core/latex.hpp"
-#include "SeQuant/core/op.hpp"
-#include "SeQuant/core/rational.hpp"
-#include "SeQuant/core/tensor.hpp"
-#include "SeQuant/core/utility/macros.hpp"
-#include "SeQuant/core/utility/nodiscard.hpp"
-#include "SeQuant/core/wick.hpp"
+#include <SeQuant/core/timer.hpp>
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/context.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/hash.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/latex.hpp>
+#include <SeQuant/core/op.hpp>
+#include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/utility/macros.hpp>
+#include <SeQuant/core/utility/nodiscard.hpp>
+#include <SeQuant/core/wick.hpp>
 
 #include "catch.hpp"
 #include "test_config.hpp"

--- a/tests/unit/test_wick.cpp
+++ b/tests/unit/test_wick.cpp
@@ -3,6 +3,16 @@
 //
 
 #include "SeQuant/core/timer.hpp"
+#include "SeQuant/core/abstract_tensor.hpp"
+#include "SeQuant/core/attr.hpp"
+#include "SeQuant/core/context.hpp"
+#include "SeQuant/core/expr.hpp"
+#include "SeQuant/core/hash.hpp"
+#include "SeQuant/core/index.hpp"
+#include "SeQuant/core/latex.hpp"
+#include "SeQuant/core/op.hpp"
+#include "SeQuant/core/rational.hpp"
+#include "SeQuant/core/tensor.hpp"
 #include "SeQuant/core/utility/macros.hpp"
 #include "SeQuant/core/utility/nodiscard.hpp"
 #include "SeQuant/core/wick.hpp"
@@ -10,7 +20,15 @@
 #include "catch.hpp"
 #include "test_config.hpp"
 
+#include <range/v3/all.hpp>
+
 #include <iostream>
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <vector>
 
 namespace sequant {
 struct WickAccessor {};


### PR DESCRIPTION
This adds missing includes such that each file should now be
self-contained, which will hopefully avoid any issues in the future
where changing one header somewhere breaks seemingly completely
unrelated sources.
This has been done with the help of the include-what-you-use tool.