### PR TITLE
Rename Lambda() functions to Λ()

### DIFF
--- a/SeQuant/domain/mbpt/models/cc.cpp
+++ b/SeQuant/domain/mbpt/models/cc.cpp
@@ -108,7 +108,7 @@ std::vector<ExprPtr> CC::λ(bool screen, bool use_topology,
   auto hbar = sim_tr(op::H(), 3);
 
   const auto One = ex<Constant>(1);
-  auto lhbar = simplify((One + op::Lambda(N)) * hbar);
+  auto lhbar = simplify((One + op::Λ(N)) * hbar);
 
   std::vector<std::pair<std::wstring, std::wstring>> op_connect = {
       {L"h", L"t"}, {L"f", L"t"}, {L"g", L"t"}, {L"h", L"A"}, {L"f", L"A"},

--- a/SeQuant/domain/mbpt/mr.cpp
+++ b/SeQuant/domain/mbpt/mr.cpp
@@ -510,13 +510,13 @@ ExprPtr T(std::size_t K) {
   return result;
 }
 
-ExprPtr Lambda_(std::size_t K) {
+ExprPtr Λ_(std::size_t K) {
   assert(K > 0);
   return ex<op_t>(
       []() -> std::wstring_view { return L"λ"; },
       [=]() -> ExprPtr {
         using namespace sequant::mbpt::sr;
-        return mr::Lambda_(K);
+        return mr::Λ_(K);
       },
       [=](qnc_t& qns) {
         qns = combine(
@@ -526,12 +526,12 @@ ExprPtr Lambda_(std::size_t K) {
       });
 }
 
-ExprPtr Lambda(std::size_t K) {
+ExprPtr Λ(std::size_t K) {
   assert(K > 0);
 
   ExprPtr result;
   for (auto k = 1ul; k <= K; ++k) {
-    result = k > 1 ? result + Lambda_(k) : Lambda_(k);
+    result = k > 1 ? result + Λ_(k) : Λ_(k);
   }
   return result;
 }

--- a/SeQuant/domain/mbpt/mr.hpp
+++ b/SeQuant/domain/mbpt/mr.hpp
@@ -203,12 +203,12 @@ ExprPtr T_(std::size_t K);
 ExprPtr T(std::size_t K);
 
 /// makes particle-conserving deexcitation operator of rank \p K
-ExprPtr Lambda_(std::size_t K);
+ExprPtr Λ_(std::size_t K);
 
 /// makes sum of particle-conserving deexcitation operators of all ranks up to
 /// \p
 /// K
-ExprPtr Lambda(std::size_t K);
+ExprPtr Λ(std::size_t K);
 
 /// computes the vacuum expectation value (VEV)
 

--- a/SeQuant/domain/mbpt/mr/op.impl.cpp
+++ b/SeQuant/domain/mbpt/mr/op.impl.cpp
@@ -4,7 +4,7 @@ ExprPtr T_(std::size_t Nbra, std::size_t Nket) {
   return OpMaker(OpType::t, Nbra, Nket)();
 }
 
-ExprPtr Lambda_(std::size_t Nbra, std::size_t Nket) {
+ExprPtr Λ_(std::size_t Nbra, std::size_t Nket) {
   assert(Nbra > 0);
   assert(Nket > 0);
   return OpMaker(OpType::λ, Nbra, Nket)();

--- a/SeQuant/domain/mbpt/mr/op.impl.hpp
+++ b/SeQuant/domain/mbpt/mr/op.impl.hpp
@@ -3,8 +3,8 @@ ExprPtr T_(std::size_t Nbra,
            std::size_t Nket = std::numeric_limits<std::size_t>::max());
 
 /// makes lambda deexcitation operator of bra/ket ranks @c Nbra/Nket
-ExprPtr Lambda_(std::size_t Nbra,
-                std::size_t Nket = std::numeric_limits<std::size_t>::max());
+ExprPtr Λ_(std::size_t Nbra,
+           std::size_t Nket = std::numeric_limits<std::size_t>::max());
 
 /// makes excitation operator of all bra/ket ranks up to (and including) @c
 /// Nbra/Nket

--- a/SeQuant/domain/mbpt/sr.cpp
+++ b/SeQuant/domain/mbpt/sr.cpp
@@ -328,24 +328,24 @@ ExprPtr T(std::size_t K) {
   return result;
 }
 
-ExprPtr Lambda_(std::size_t K) {
+ExprPtr Λ_(std::size_t K) {
   assert(K > 0);
   return ex<op_t>([]() -> std::wstring_view { return L"λ"; },
                   [=]() -> ExprPtr {
                     using namespace sequant::mbpt::sr;
-                    return sr::Lambda_(K);
+                    return sr::Λ_(K);
                   },
                   [=](qnc_t& qns) {
                     qns = combine(qnc_t{K, 0ul, 0ul, K}, qns);
                   });
 }
 
-ExprPtr Lambda(std::size_t K) {
+ExprPtr Λ(std::size_t K) {
   assert(K > 0);
 
   ExprPtr result;
   for (auto k = 1ul; k <= K; ++k) {
-    result = k > 1 ? result + Lambda_(k) : Lambda_(k);
+    result = k > 1 ? result + Λ_(k) : Λ_(k);
   }
   return result;
 }

--- a/SeQuant/domain/mbpt/sr.hpp
+++ b/SeQuant/domain/mbpt/sr.hpp
@@ -203,12 +203,12 @@ ExprPtr T_(std::size_t K);
 ExprPtr T(std::size_t K);
 
 /// makes particle-conserving deexcitation operator of rank \p K
-ExprPtr Lambda_(std::size_t K);
+ExprPtr Λ_(std::size_t K);
 
 /// makes sum of particle-conserving deexcitation operators of all ranks up to
 /// \p
 /// K
-ExprPtr Lambda(std::size_t K);
+ExprPtr Λ(std::size_t K);
 
 /// makes generic bra/ket-antisymmetric excitation (if \p K > 0) or
 /// deexcitation (if \p K < 0) operator of rank `|K|`

--- a/SeQuant/domain/mbpt/sr/op.impl.cpp
+++ b/SeQuant/domain/mbpt/sr/op.impl.cpp
@@ -6,7 +6,7 @@ ExprPtr T_(std::size_t Nbra, std::size_t Nket) {
 }
 
 /// makes lambda deexcitation operator of bra/ket ranks @c Nbra/Nket
-ExprPtr Lambda_(std::size_t Nbra, std::size_t Nket) {
+ExprPtr Λ_(std::size_t Nbra, std::size_t Nket) {
   assert(Nbra > 0);
   assert(Nket > 0);
   return OpMaker(OpType::λ, Nbra, Nket)();
@@ -45,7 +45,7 @@ class op_impl {
     if (op_ == OpType::t)
       result = result ? result + T_(nbra_, nket_) : T_(nbra_, nket_);
     else if (op_ == OpType::λ)
-      result = result ? result + Lambda_(nbra_, nket_) : Lambda_(nbra_, nket_);
+      result = result ? result + Λ_(nbra_, nket_) : Λ_(nbra_, nket_);
     else if (op_ == OpType::R)
       result = result ? result + R_(nbra_, nket_) : R_(nbra_, nket_);
     else if (op_ == OpType::L)
@@ -75,7 +75,7 @@ ExprPtr T(std::size_t Nbra, std::size_t Nket) {
 
 /// makes deexcitation operator of all bra/ket ranks up to (and including)
 /// @c Nbra/Nket
-ExprPtr Lambda(std::size_t Nbra, std::size_t Nket) {
+ExprPtr Λ(std::size_t Nbra, std::size_t Nket) {
   assert(Nbra > 0 && Nbra < std::numeric_limits<std::size_t>::max());
   const auto Nket_ =
       Nket == std::numeric_limits<std::size_t>::max() ? Nbra : Nket;

--- a/SeQuant/domain/mbpt/sr/op.impl.hpp
+++ b/SeQuant/domain/mbpt/sr/op.impl.hpp
@@ -3,8 +3,8 @@ ExprPtr T_(std::size_t Nbra,
            std::size_t Nket = std::numeric_limits<std::size_t>::max());
 
 /// makes lambda deexcitation operator of bra/ket ranks @c Nbra/Nket
-ExprPtr Lambda_(std::size_t Nbra,
-                std::size_t Nket = std::numeric_limits<std::size_t>::max());
+ExprPtr Λ_(std::size_t Nbra,
+           std::size_t Nket = std::numeric_limits<std::size_t>::max());
 
 /// makes generic excitation (right-hand eigenvector) operator of bra/ket ranks
 /// @c Nbra/Nket
@@ -23,8 +23,8 @@ ExprPtr T(std::size_t Nbra,
 
 /// makes deexcitation operator of all bra/ket ranks up to (and including) @c
 /// Nbra/Nket
-ExprPtr Lambda(std::size_t Nbra,
-               std::size_t Nket = std::numeric_limits<std::size_t>::max());
+ExprPtr Λ(std::size_t Nbra,
+          std::size_t Nket = std::numeric_limits<std::size_t>::max());
 
 /// makes generic bra/ket-antisymmetrizer
 /// \param Kh if <0, annihilates this many holes, else creates this many

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -174,7 +174,7 @@ TEST_CASE("NBodyOp", "[mbpt]") {
     auto lambda1 = ex<op_t>([]() -> std::wstring_view { return L"λ"; },
                             []() -> ExprPtr {
                               using namespace sequant::mbpt::sr;
-                              return Lambda_(1);
+                              return Λ_(1);
                             },
                             [](qns_t& qns) {
                               qns += qns_t{1, 0, 0, 1};
@@ -182,7 +182,7 @@ TEST_CASE("NBodyOp", "[mbpt]") {
     auto lambda2 = ex<op_t>([]() -> std::wstring_view { return L"λ"; },
                             []() -> ExprPtr {
                               using namespace sequant::mbpt::sr;
-                              return Lambda_(2);
+                              return Λ_(2);
                             },
                             [](qns_t& qns) {
                               qns += qns_t{2, 0, 0, 2};
@@ -236,7 +236,7 @@ TEST_CASE("NBodyOp", "[mbpt]") {
     auto l1 = ex<op_t>([]() -> std::wstring_view { return L"λ"; },
                        []() -> ExprPtr {
                          using namespace sequant::mbpt::sr;
-                         return Lambda_(1);
+                         return Λ_(1);
                        },
                        [](qns_t& qns) {
                          qns += qns_t{1, 0, 0, 1};
@@ -252,7 +252,7 @@ TEST_CASE("NBodyOp", "[mbpt]") {
     auto l2 = ex<op_t>([]() -> std::wstring_view { return L"λ"; },
                        []() -> ExprPtr {
                          using namespace sequant::mbpt::sr;
-                         return Lambda_(2);
+                         return Λ_(2);
                        },
                        [](qns_t& qns) {
                          qns += qns_t{2, 0, 0, 2};
@@ -326,7 +326,7 @@ TEST_CASE("NBodyOp", "[mbpt]") {
     op_t lambda2([]() -> std::wstring_view { return L"λ"; },
                  []() -> ExprPtr {
                    using namespace sequant::mbpt::sr;
-                   return Lambda_(2);
+                   return Λ_(2);
                  },
                  [](qns_t& qns) {
                    qns += qns_t{2, 0, 0, 2};

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -381,7 +381,7 @@ TEST_CASE("NBodyOp", "[mbpt]") {
     auto g_t2 = H_(2) * T_(2);
     REQUIRE(raises_vacuum_to_rank(g_t2, 3));
 
-    auto lambda2_f = Lambda_(2) * H_(1);
+    auto lambda2_f = Λ_(2) * H_(1);
     REQUIRE(lowers_rank_to_vacuum(lambda2_f, 2));
 
   }  // SECTION("screen")


### PR DESCRIPTION
- `Lambda()` functions in `mbpt::sr`, `mbpt::mr` and corresponding `op` namespaces renamed to `Λ()`
- Similar changes to perturbed Λ operators in #141 