### PR TITLE
Prevent optimize::reorder from swallowing terms

### DIFF
--- a/SeQuant/core/optimize/optimize.cpp
+++ b/SeQuant/core/optimize/optimize.cpp
@@ -42,6 +42,17 @@ void pull_scalar(ExprPtr expr) noexcept {
   prod.scale(scal);
 }
 
+bool has_only_single_atom(const ExprPtr& term) {
+  if (term->is_atom()) {
+    return true;
+  }
+
+  // Recursively check that all elements in the expression tree have only a
+  // single element in them. At this point this means checking for Sum or
+  // Product objects that only have a single addend or factor respectively.
+  return term->size() == 1 && has_only_single_atom(*term->begin());
+}
+
 container::vector<container::vector<size_t>> clusters(Sum const& expr) {
   using ranges::views::tail;
   using ranges::views::transform;
@@ -63,7 +74,7 @@ container::vector<container::vector<size_t>> clusters(Sum const& expr) {
 
     for (auto const& term : expr) {
       auto const node = eval_node<EvalExpr>(term);
-      if (term->is_atom()) {
+      if (has_only_single_atom(term)) {
         visitor(node);
       } else {
         node.visit_internal(visitor);

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -123,4 +123,14 @@ TEST_CASE("TEST_OPTIMIZE", "[optimize]") {
     REQUIRE(extract(res6, {3, 1}) == prod6.at(5));
     REQUIRE(extract(res6, {4}) == prod6.at(4));
   }
+
+  SECTION("Ensure single-value sums/products are not discarded") {
+    auto sum = ex<Sum>();
+    sum->as<Sum>().append(ex<Product>(ExprPtrList{parse_expr(L"f{a_1;i_1}")}));
+    REQUIRE(sum->as<Sum>().summand(0).as<Product>().factors().size() == 1);
+    auto optimized = optimize(sum, idx2size);
+    REQUIRE(optimized->is<Sum>());
+    REQUIRE(optimized->as<Sum>().summands().size() == 1);
+    REQUIRE(sum->as<Sum>().summand(0).as<Product>().factors().size() == 1);
+  }
 }


### PR DESCRIPTION
If the expression fed into the optimize function is a sum that contains an addend which is either a sum or a product itself, but only contains a single element (e.g. a single addend or a single factor), the visiting mechanism inside the cluster function would end up not visiting those terms and thereby preventing them from being processed (aka: they are swallowed and never see the light of day again).

A test case checking for the expected (non-swallowing) behavior is added as well.