### PR TITLE
Feature: Distinguish adjoints with labels

### DIFF
--- a/SeQuant/core/expr.hpp
+++ b/SeQuant/core/expr.hpp
@@ -596,6 +596,9 @@ using ExprPtrVector = container::svector<ExprPtr>;
 /// @return the adjoint of @p expr
 ExprPtr adjoint(const ExprPtr &expr);
 
+/// @brief the wchar used for labeling adjoints, i.e. the superscript + sign
+static const wchar_t adjoint_label = L'\u207A';
+
 /// An object with a string label that be used for defining a canonical order of
 /// expressions (defined at runtime)
 class Labeled {
@@ -734,7 +737,6 @@ class Variable : public Expr, public Labeled {
 
   Variable(std::wstring label, bool conjugated)
       : label_(std::move(label)), conjugated_(conjugated) {}
-
 
   std::wstring_view label() const override;
 

--- a/SeQuant/core/tensor.cpp
+++ b/SeQuant/core/tensor.cpp
@@ -12,7 +12,19 @@ void Tensor::assert_nonreserved_label(std::wstring_view label) const {
   // assert(label != overlap_label());
 }
 
+void Tensor::toggle_adjoint_label() {
+  if (is_adjoint_) {
+    if (label_.back() != sequant::adjoint_label)
+      label_.push_back(sequant::adjoint_label);
+  } else {
+    if (label_.back() == sequant::adjoint_label) label_.pop_back();
+  }
+}
+
 void Tensor::adjoint() {
+  // toggle adjoint flag and update label
+  is_adjoint_ = !is_adjoint_;
+  toggle_adjoint_label();
   std::swap(bra_, ket_);
   reset_hash_value();
 }

--- a/SeQuant/core/tensor.cpp
+++ b/SeQuant/core/tensor.cpp
@@ -14,13 +14,19 @@ void Tensor::assert_nonreserved_label(std::wstring_view label) const {
 
 void Tensor::adjoint() {
   std::swap(bra_, ket_);
-  // update label
-  if (!is_adjoint_ && label_.back() != sequant::adjoint_label)
-    label_.push_back(sequant::adjoint_label);
-  else if (is_adjoint_ && label_.back() == sequant::adjoint_label)
-    label_.pop_back();
-  // toggle adjoint flag
-  is_adjoint_ = !is_adjoint_;
+
+  // only track adjointness for BraKetSymmetry::nonsymm cases
+  if (braket_symmetry() == BraKetSymmetry::nonsymm) {
+    if (label_.back() == sequant::adjoint_label) {
+      assert(is_adjoint_);
+      label_.pop_back();
+    } else {
+      assert(!is_adjoint_);
+      label_.push_back(sequant::adjoint_label);
+    }
+    is_adjoint_ = !is_adjoint_;
+  }
+
   reset_hash_value();
 }
 

--- a/SeQuant/core/tensor.cpp
+++ b/SeQuant/core/tensor.cpp
@@ -12,20 +12,15 @@ void Tensor::assert_nonreserved_label(std::wstring_view label) const {
   // assert(label != overlap_label());
 }
 
-void Tensor::toggle_adjoint_label() {
-  if (is_adjoint_) {
-    if (label_.back() != sequant::adjoint_label)
-      label_.push_back(sequant::adjoint_label);
-  } else {
-    if (label_.back() == sequant::adjoint_label) label_.pop_back();
-  }
-}
-
 void Tensor::adjoint() {
-  // toggle adjoint flag and update label
-  is_adjoint_ = !is_adjoint_;
-  toggle_adjoint_label();
   std::swap(bra_, ket_);
+  // update label
+  if (!is_adjoint_ && label_.back() != sequant::adjoint_label)
+    label_.push_back(sequant::adjoint_label);
+  else if (is_adjoint_ && label_.back() == sequant::adjoint_label)
+    label_.pop_back();
+  // toggle adjoint flag
+  is_adjoint_ = !is_adjoint_;
   reset_hash_value();
 }
 

--- a/SeQuant/core/tensor.hpp
+++ b/SeQuant/core/tensor.hpp
@@ -254,9 +254,6 @@ class Tensor : public Expr, public AbstractTensor, public Labeled {
       bra_hash_value_;  // memoized byproduct of memoizing_hash()
   bool is_adjoint_ = false;
 
-  /// @brief updates the label to reflect the adjoint status
-  void toggle_adjoint_label();
-
   void validate_symmetries() {
     // (anti)symmetric bra or ket makes sense only for particle-symmetric
     // tensors

--- a/SeQuant/core/tensor.hpp
+++ b/SeQuant/core/tensor.hpp
@@ -252,6 +252,10 @@ class Tensor : public Expr, public AbstractTensor, public Labeled {
   ParticleSymmetry particle_symmetry_ = ParticleSymmetry::invalid;
   mutable std::optional<hash_type>
       bra_hash_value_;  // memoized byproduct of memoizing_hash()
+  bool is_adjoint_ = false;
+
+  /// @brief updates the label to reflect the adjoint status
+  void toggle_adjoint_label();
 
   void validate_symmetries() {
     // (anti)symmetric bra or ket makes sense only for particle-symmetric

--- a/SeQuant/core/tensor_network.cpp
+++ b/SeQuant/core/tensor_network.cpp
@@ -37,6 +37,14 @@ ExprPtr TensorNetwork::canonicalize(
       [&cardinal_tensor_labels](const auto &first_ptr, const auto &second_ptr) {
         const auto &first = *first_ptr;
         const auto &second = *second_ptr;
+        // grab base label if adjoint label is present
+        auto base_label = [](const auto &t) {
+          if (label(t).back() == adjoint_label) {
+            return label(t).substr(0, label(t).size() - 1);
+          } else {
+            return label(t);
+          }
+        };
         // tensors commute if their colors are different or either one of them
         // is a c-number
         if ((color(first) != color(second)) || is_cnumber(first) ||
@@ -44,10 +52,10 @@ ExprPtr TensorNetwork::canonicalize(
           const auto cardinal_tensor_labels_end = end(cardinal_tensor_labels);
           const auto first_cardinal_it =
               std::find(begin(cardinal_tensor_labels),
-                        end(cardinal_tensor_labels), label(first));
+                        end(cardinal_tensor_labels), base_label(first));
           const auto second_cardinal_it =
               std::find(begin(cardinal_tensor_labels),
-                        end(cardinal_tensor_labels), label(second));
+                        end(cardinal_tensor_labels), base_label(second));
           const auto first_is_cardinal =
               first_cardinal_it != cardinal_tensor_labels_end;
           const auto second_is_cardinal =

--- a/SeQuant/domain/mbpt/mr.cpp
+++ b/SeQuant/domain/mbpt/mr.cpp
@@ -631,9 +631,13 @@ std::wstring to_latex(const mbpt::Operator<mbpt::mr::qns_t, S>& op) {
   using namespace sequant::mbpt;
   using namespace sequant::mbpt::mr;
 
-  auto lbl = utf_to_latex(op.label());
-  std::wstring result = L"{\\hat{" + lbl + L"}";
-  auto it = label2optype.find(lbl);
+  auto result = L"{\\hat{" + utf_to_latex(op.label()) + L"}";
+
+  // check if operator has adjoint label, remove if present
+  auto base_lbl = sequant::to_wstring(op.label());
+  if (base_lbl.back() == adjoint_label) base_lbl.pop_back();
+
+  auto it = label2optype.find(base_lbl);
   OpType optype = OpType::invalid;
   if (it != label2optype.end()) {  // handle special cases
     optype = it->second;

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -115,7 +115,10 @@ std::wstring to_latex(const mbpt::Operator<mbpt::qns_t, S>& op) {
 
   auto lbl = utf_to_latex(op.label());
   std::wstring result = L"{\\hat{" + lbl + L"}";
-  auto it = label2optype.find(lbl);
+  // if last char is adjoint_label, remove it
+  auto base_lbl = lbl;
+  if (base_lbl.back() == adjoint_label) base_lbl.pop_back();
+  auto it = label2optype.find(base_lbl);
   if (it != label2optype.end()) {  // handle special cases
     const auto optype = it->second;
     if (to_class(optype) == OpClass::gen) {

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -113,11 +113,12 @@ template <Statistics S>
 std::wstring to_latex(const mbpt::Operator<mbpt::qns_t, S>& op) {
   using namespace sequant::mbpt;
 
-  auto lbl = utf_to_latex(op.label());
-  std::wstring result = L"{\\hat{" + lbl + L"}";
-  // if last char is adjoint_label, remove it
-  auto base_lbl = lbl;
+  auto result = L"{\\hat{" + utf_to_latex(op.label()) + L"}";
+
+  // check if operator has adjoint label, remove if present for base label
+  auto base_lbl = sequant::to_wstring(op.label());
   if (base_lbl.back() == adjoint_label) base_lbl.pop_back();
+
   auto it = label2optype.find(base_lbl);
   if (it != label2optype.end()) {  // handle special cases
     const auto optype = it->second;

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -539,10 +539,6 @@ class Operator : public Operator<void, S> {
            std::function<ExprPtr()> tensor_form_generator,
            std::function<void(QuantumNumbers&)> qn_action);
 
-  Operator(std::function<std::wstring_view()> label_generator,
-           std::function<ExprPtr()> tensor_form_generator,
-           std::function<void(QuantumNumbers&)> qn_action, bool is_adjoint);
-
   virtual ~Operator();
 
   /// evaluates the result of applying this operator to \p qns

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -538,6 +538,11 @@ class Operator : public Operator<void, S> {
   Operator(std::function<std::wstring_view()> label_generator,
            std::function<ExprPtr()> tensor_form_generator,
            std::function<void(QuantumNumbers&)> qn_action);
+
+  Operator(std::function<std::wstring_view()> label_generator,
+           std::function<ExprPtr()> tensor_form_generator,
+           std::function<void(QuantumNumbers&)> qn_action, bool is_adjoint);
+
   virtual ~Operator();
 
   /// evaluates the result of applying this operator to \p qns
@@ -568,6 +573,8 @@ class Operator : public Operator<void, S> {
   bool commutes_with_atom(const Expr& that) const override;
 
   void adjoint() override;
+
+  bool is_adjoint_ = false;
 
  private:
   std::function<void(QuantumNumbers&)> qn_action_;

--- a/SeQuant/domain/mbpt/op.ipp
+++ b/SeQuant/domain/mbpt/op.ipp
@@ -47,8 +47,7 @@ QuantumNumbers& Operator<QuantumNumbers, S>::apply_to(
 }
 
 template <typename QuantumNumbers, Statistics S>
-bool Operator<QuantumNumbers, S>::static_less_than(
-    const Expr& that) const {
+bool Operator<QuantumNumbers, S>::static_less_than(const Expr& that) const {
   assert(that.is<this_type>());
   auto& that_op = that.as<this_type>();
 
@@ -85,8 +84,7 @@ bool Operator<QuantumNumbers, S>::static_less_than(
 }
 
 template <typename QuantumNumbers, Statistics S>
-bool Operator<QuantumNumbers, S>::commutes_with_atom(
-    const Expr& that) const {
+bool Operator<QuantumNumbers, S>::commutes_with_atom(const Expr& that) const {
   assert(that.is_cnumber() || that.is<this_type>());
   if (that.is_cnumber())
     return true;
@@ -113,10 +111,12 @@ void Operator<QuantumNumbers, S>::adjoint() {
 
   // grab label and update according to adjoint flag
   auto lbl = std::wstring(this->label());
-  if (!is_adjoint_ && lbl.back() != sequant::adjoint_label) {
-    lbl.push_back(sequant::adjoint_label);
-  } else if (is_adjoint_ && lbl.back() == sequant::adjoint_label) {
+  if (lbl.back() == sequant::adjoint_label) {
+    assert(is_adjoint_);
     lbl.pop_back();
+  } else {
+    assert(!is_adjoint_);
+    lbl.push_back(sequant::adjoint_label);
   }
 
   const auto tnsr = this->tensor_form();

--- a/SeQuant/domain/mbpt/sr.cpp
+++ b/SeQuant/domain/mbpt/sr.cpp
@@ -513,7 +513,10 @@ std::wstring to_latex(const mbpt::Operator<mbpt::sr::qns_t, S>& op) {
   using namespace sequant::mbpt::sr;
 
   auto result = L"{\\hat{" + utf_to_latex(op.label()) + L"}";
-  auto it = label2optype.find(std::wstring(op.label()));
+  const auto base_lbl = op.label().back() == adjoint_label
+                            ? op.label().substr(0, op.label().size() - 1)
+                            : op.label();
+  auto it = label2optype.find(std::wstring(base_lbl));
   OpType optype = OpType::invalid;
   if (it != label2optype.end()) {  // handle special cases
     optype = it->second;

--- a/SeQuant/domain/mbpt/sr.cpp
+++ b/SeQuant/domain/mbpt/sr.cpp
@@ -513,9 +513,11 @@ std::wstring to_latex(const mbpt::Operator<mbpt::sr::qns_t, S>& op) {
   using namespace sequant::mbpt::sr;
 
   auto result = L"{\\hat{" + utf_to_latex(op.label()) + L"}";
-  const auto base_lbl = op.label().back() == adjoint_label
-                            ? op.label().substr(0, op.label().size() - 1)
-                            : op.label();
+
+  // check if operator has adjoint label, remove if present for base label
+  auto base_lbl = sequant::to_wstring(op.label());
+  if (base_lbl.back() == adjoint_label) base_lbl.pop_back();
+
   auto it = label2optype.find(std::wstring(base_lbl));
   OpType optype = OpType::invalid;
   if (it != label2optype.end()) {  // handle special cases

--- a/tests/unit/test_canonicalize.cpp
+++ b/tests/unit/test_canonicalize.cpp
@@ -86,6 +86,34 @@ TEST_CASE("Canonicalizer", "[algorithms]") {
               L"{{p}{q1}{{q2}^*}{S^{{i_1}{i_2}}_{{a_1}{a_3}}}{f^{{i_3}}_{{"
               L"a_2}}}{t^{{a_2}}_{{i_2}}}{t^{{a_1}{a_3}}_{{i_1}{i_3}}}}");
     }
+    {  // Product containing adjoint of a Tensor
+      auto f2 =
+          ex<Tensor>(L"f", WstrList{L"i_5", L"i_2"}, WstrList{L"a_1", L"a_2"},
+                     Symmetry::nonsymm, BraKetSymmetry::nonsymm);
+      f2->adjoint();
+      auto input1 = ex<Tensor>(L"S", WstrList{L"a_1", L"a_2"},
+                               WstrList{L"i_1", L"i_2"}, Symmetry::nonsymm) *
+                    ex<Tensor>(L"f", IndexList{{L"a_5"}}, IndexList{{L"i_5"}},
+                               Symmetry::nonsymm) *
+                    ex<Tensor>(L"t", IndexList{{L"i_1"}}, IndexList{{L"a_5"}},
+                               Symmetry::nonsymm) *
+                    f2;
+      canonicalize(input1);
+      REQUIRE(to_latex(input1) ==
+              L"{{S^{{i_1}{i_2}}_{{a_1}{a_3}}}{f^{{i_3}}_{{a_2}}}{f⁺^{{i_1}{i_"
+              L"3}}_{{a_1}{a_3}}}{t^{{a_2}}_{{i_2}}}}");
+      auto input2 = ex<Tensor>(L"S", WstrList{L"a_1", L"a_2"},
+                               WstrList{L"i_1", L"i_2"}, Symmetry::nonsymm) *
+                    ex<Tensor>(L"f", IndexList{{L"a_5"}}, IndexList{{L"i_5"}},
+                               Symmetry::nonsymm) *
+                    ex<Tensor>(L"t", IndexList{{L"i_1"}}, IndexList{{L"a_5"}},
+                               Symmetry::nonsymm) *
+                    f2 * ex<Variable>(L"w") * ex<Constant>(rational{1, 2});
+      canonicalize(input2);
+      REQUIRE(to_latex(input2) ==
+              L"{{{\\frac{1}{2}}}{w}{S^{{i_1}{i_2}}_{{a_1}{a_3}}}{f^{{i_3}}_{{"
+              L"a_2}}}{f⁺^{{i_1}{i_3}}_{{a_1}{a_3}}}{t^{{a_2}}_{{i_2}}}}");
+    }
   }
 
   SECTION("sum of products") {

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -364,10 +364,19 @@ TEST_CASE("NBodyOp", "[mbpt]") {
             simplify(adjoint(r_1_2.tensor_form())));
 
     // to_latex()
-    REQUIRE(to_latex(adjoint(f).as<Expr>()) == L"{\\hat{f}}");
-    REQUIRE(to_latex(adjoint(t1).as<Expr>()) == L"{\\hat{t}^{1}}");
-    REQUIRE(to_latex(adjoint(lambda2).as<Expr>()) == L"{\\hat{\\lambda}^{2}}");
-    REQUIRE(to_latex(adjoint(r_1_2).as<Expr>()) == L"{\\hat{R}^{1,2}}");
+    REQUIRE(to_latex(adjoint(f).as<Expr>()) == L"{\\hat{f⁺}}");
+    REQUIRE(to_latex(adjoint(t1).as<Expr>()) == L"{\\hat{t⁺}^{1}}");
+    REQUIRE(to_latex(adjoint(lambda2).as<Expr>()) == L"{\\hat{\\lambda⁺}^{2}}");
+    REQUIRE(to_latex(adjoint(r_1_2).as<Expr>()) == L"{\\hat{R⁺}^{1,2}}");
+
+    // adjoint(adjoint(op)) == op
+    auto t1_adj = adjoint(t1);
+    auto r_1_2_adj = adjoint(r_1_2);
+    auto lambda2_adj = adjoint(lambda2);
+    REQUIRE(to_latex(adjoint(t1_adj).as<Expr>()) == L"{\\hat{t}_{1}}");
+    REQUIRE(to_latex(adjoint(r_1_2_adj).as<Expr>()) == L"{\\hat{R}_{1,2}}");
+    REQUIRE(to_latex(adjoint(lambda2_adj).as<Expr>()) ==
+            L"{\\hat{\\lambda}_{2}}");
 
   }  // SECTION("adjoint")
 

--- a/tests/unit/test_tensor.cpp
+++ b/tests/unit/test_tensor.cpp
@@ -115,14 +115,19 @@ TEST_CASE("Tensor", "[elements]") {
   SECTION("adjoint") {
     auto t1 = Tensor(L"F", {L"i_1", L"i_2"}, {L"i_3", L"i_4"});
     REQUIRE_NOTHROW(t1.adjoint());
-    REQUIRE(to_latex(t1) == L"{F^{{i_1}{i_2}}_{{i_3}{i_4}}}");
+    REQUIRE(to_latex(t1) == L"{F⁺^{{i_1}{i_2}}_{{i_3}{i_4}}}");
+    REQUIRE_NOTHROW(t1.adjoint());
+    REQUIRE(to_latex(t1) == L"{F^{{i_3}{i_4}}_{{i_1}{i_2}}}");
 
     auto h1 = ex<Tensor>(L"F", WstrList{L"i_1"}, WstrList{L"i_2"}) *
               ex<FNOperator>(WstrList{L"i_1"}, WstrList{L"i_2"});
     h1 = adjoint(h1);
     REQUIRE(to_latex(h1) ==
-            L"{{\\tilde{a}^{{i_2}}_{{i_1}}}{F^{{i_1}}_{{i_2}}}}");
+            L"{{\\tilde{a}^{{i_2}}_{{i_1}}}{F⁺^{{i_1}}_{{i_2}}}}");
+    h1 = adjoint(h1);
+    REQUIRE(to_latex(h1) ==
+            L"{{F^{{i_2}}_{{i_1}}}{\\tilde{a}^{{i_1}}_{{i_2}}}}");
 
-  }  // SECTION("latex")
+  }  // SECTION("adjoint")
 
 }  // TEST_CASE("Tensor")

--- a/tests/unit/test_tensor.cpp
+++ b/tests/unit/test_tensor.cpp
@@ -113,17 +113,22 @@ TEST_CASE("Tensor", "[elements]") {
   }  // SECTION("latex")
 
   SECTION("adjoint") {
-    auto t1 = Tensor(L"F", {L"i_1", L"i_2"}, {L"i_3", L"i_4"});
+    auto f1 = Tensor(L"F", {L"i_1", L"i_2"}, {L"i_3", L"i_4"});
+    REQUIRE_NOTHROW(f1.adjoint());
+    REQUIRE(to_latex(f1) == L"{F^{{i_1}{i_2}}_{{i_3}{i_4}}}");
+
+    auto t1 = Tensor(L"t", {L"a_1"}, {L"i_1"}, Symmetry::nonsymm,
+                     BraKetSymmetry::nonsymm);
     REQUIRE_NOTHROW(t1.adjoint());
-    REQUIRE(to_latex(t1) == L"{F⁺^{{i_1}{i_2}}_{{i_3}{i_4}}}");
-    REQUIRE_NOTHROW(t1.adjoint());
-    REQUIRE(to_latex(t1) == L"{F^{{i_3}{i_4}}_{{i_1}{i_2}}}");
+    REQUIRE(to_latex(t1) == L"{t⁺^{{a_1}}_{{i_1}}}");
+    t1.adjoint();
+    REQUIRE(to_latex(t1) == L"{t^{{i_1}}_{{a_1}}}");
 
     auto h1 = ex<Tensor>(L"F", WstrList{L"i_1"}, WstrList{L"i_2"}) *
               ex<FNOperator>(WstrList{L"i_1"}, WstrList{L"i_2"});
     h1 = adjoint(h1);
     REQUIRE(to_latex(h1) ==
-            L"{{\\tilde{a}^{{i_2}}_{{i_1}}}{F⁺^{{i_1}}_{{i_2}}}}");
+            L"{{\\tilde{a}^{{i_2}}_{{i_1}}}{F^{{i_1}}_{{i_2}}}}");
     h1 = adjoint(h1);
     REQUIRE(to_latex(h1) ==
             L"{{F^{{i_2}}_{{i_1}}}{\\tilde{a}^{{i_1}}_{{i_2}}}}");


### PR DESCRIPTION
This PR introduces the ability to distinguish objects (Tensor and mbpt::Operator) and their adjoints with labels. Unicode superscript character `⁺` (`U+207A`) is added as a suffix to the base label.