### PR TITLE
Implement ITF translator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,8 @@ set(SeQuant_src
         SeQuant/core/eval_expr.cpp
         SeQuant/core/eval_expr.hpp
         SeQuant/core/eval_node.hpp
+        SeQuant/core/export/itf.cpp
+        SeQuant/core/export/itf.hpp
         SeQuant/core/expr.cpp
         SeQuant/core/expr.hpp
         SeQuant/core/expr_algorithm.hpp
@@ -227,6 +229,7 @@ set(SeQuant_src
         SeQuant/core/tensor_network.hpp
         SeQuant/core/timer.hpp
         SeQuant/core/utility/context.hpp
+        SeQuant/core/utility/indices.hpp
         SeQuant/core/utility/macros.hpp
         SeQuant/core/utility/nodiscard.hpp
         SeQuant/core/utility/singleton.hpp
@@ -422,6 +425,8 @@ if (BUILD_TESTING)
             tests/unit/test_math.cpp
             tests/unit/test_string.cpp
             tests/unit/test_latex.cpp
+            tests/unit/test_utilities.cpp
+            tests/unit/test_export.cpp
             )
 
     if (TARGET tiledarray)

--- a/SeQuant/core/export/itf.cpp
+++ b/SeQuant/core/export/itf.cpp
@@ -1,0 +1,620 @@
+//
+// Created by Robert Adam on 2023-09-04
+//
+
+#include "itf.hpp"
+
+#include <SeQuant/core/utility/indices.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cwchar>
+#include <functional>
+#include <map>
+#include <unordered_map>
+
+namespace sequant {
+
+std::wstring to_itf(const itf::CodeBlock &block) {
+  itf::detail::ITFGenerator generator;
+  generator.addBlock(block);
+  return generator.generate();
+}
+
+namespace itf {
+
+// TODO: Get rid of hard-coded index assignments
+static IndexSpace::Type occ = IndexSpace::active_occupied;
+static IndexSpace::Type virt = IndexSpace::active_unoccupied;
+
+struct IndexTypeComparer {
+  bool operator()(const IndexSpace::Type &lhs,
+                  const IndexSpace::Type &rhs) const {
+    assert(occ < virt);
+    return lhs < rhs;
+  }
+};
+
+Result::Result(ExprPtr expression, Tensor resultTensor, bool importResultTensor)
+    : expression(std::move(expression)),
+      resultTensor(std::move(resultTensor)),
+      importResultTensor(importResultTensor) {}
+
+Tensor generateResultTensor(ExprPtr expr) {
+  // This (same as ITF itself) assumes that all indices that are repeated in the
+  // expression are also contracted (summed) over and therefore don't contribute
+  // to the result of the expression
+  IndexGroups externals = get_unique_indices(expr);
+
+  return Tensor(L"Result", std::move(externals.bra), std::move(externals.ket));
+}
+
+Result::Result(ExprPtr expression, bool importResultTensor)
+    : expression(std::move(expression)),
+      resultTensor(generateResultTensor(expression)),
+      importResultTensor(importResultTensor) {}
+
+CodeBlock::CodeBlock(std::wstring blockName, Result result)
+    : CodeBlock(std::move(blockName), std::vector<Result>{std::move(result)}) {}
+
+CodeBlock::CodeBlock(std::wstring blockName, std::vector<Result> results)
+    : name(std::move(blockName)), results(std::move(results)) {}
+
+namespace detail {
+
+bool TensorBlockCompare::operator()(const Tensor &lhs,
+                                    const Tensor &rhs) const {
+  if (lhs.label() != rhs.label()) {
+    return lhs.label() < rhs.label();
+  }
+  if (lhs.braket().size() != rhs.braket().size()) {
+    return lhs.braket().size() < rhs.braket().size();
+  }
+  auto lhsBraket = lhs.braket();
+  auto rhsBraket = rhs.braket();
+
+  for (std::size_t i = 0; i < lhsBraket.size(); ++i) {
+    if (lhsBraket.at(i).space() != rhsBraket.at(i).space()) {
+      return lhsBraket.at(i).space() < rhsBraket.at(i).space();
+    }
+  }
+
+  return false;
+}
+
+std::vector<Contraction> to_contractions(const ExprPtr &expression,
+                                         const Tensor &resultTensor);
+
+std::vector<Contraction> to_contractions(const Product &product,
+                                         const Tensor &resultTensor) {
+  static std::size_t intermediateCounter = 1;
+
+  if (product.factors().size() == 1) {
+    assert(product.factor(0).is<Tensor>());
+    assert(product.scalar().imag() == 0);
+
+    return {Contraction{product.scalar().real(),
+                        resultTensor,
+                        product.factor(0).as<Tensor>(),
+                        {}}};
+  }
+
+  // We assume that we're dealing with a binary tree
+  assert(product.factors().size() == 2);
+
+  std::unordered_map<const ExprPtr::element_type *, Tensor> intermediates;
+  std::vector<Contraction> contractions;
+
+  // Handle intermediates
+  for (const ExprPtr &factor : product.factors()) {
+    if (factor.is<Product>()) {
+      // Create intermediate that computes this nested product
+      // This (same as ITF itself) assumes that all indices that are repeated in
+      // the expression are also contracted (summed) over and therefore don't
+      // contribute to the result of the expression
+      IndexGroups intermediateIndexGroups = get_unique_indices(factor);
+
+      // Collect all intermediate indices and sort them such that the order of
+      // index spaces is the canonical one within ITF (largest space leftmost).
+      // This is possible, because the index ordering of intermediates is
+      // arbitrary
+      std::vector<Index> intermediateIndices;
+      intermediateIndices.reserve(intermediateIndexGroups.bra.size() +
+                                  intermediateIndexGroups.ket.size());
+      intermediateIndices.insert(intermediateIndices.end(),
+                                 intermediateIndexGroups.bra.begin(),
+                                 intermediateIndexGroups.bra.end());
+      intermediateIndices.insert(intermediateIndices.end(),
+                                 intermediateIndexGroups.ket.begin(),
+                                 intermediateIndexGroups.ket.end());
+      std::sort(intermediateIndices.begin(), intermediateIndices.end(),
+                [](const Index &lhs, const Index &rhs) {
+                  IndexTypeComparer cmp;
+                  if (cmp(lhs.space().type(), rhs.space().type())) {
+                    return false;
+                  } else if (cmp(rhs.space().type(), lhs.space().type())) {
+                    return true;
+                  } else {
+                    // Indices are of same space
+                    return lhs < rhs;
+                  }
+                });
+
+      std::array<wchar_t, 64> intermediateName;
+      swprintf(intermediateName.data(), intermediateName.size(), L"INTER%06u",
+               intermediateCounter++);
+
+      // There is no notion of bra and ket for intermediates, so we dump all
+      // indices in the bra for now
+      Tensor intermediate(intermediateName.data(),
+                          std::move(intermediateIndices), std::vector<Index>{});
+
+      std::vector<Contraction> intermediateContractions =
+          to_contractions(factor, intermediate);
+      contractions.reserve(contractions.size() +
+                           intermediateContractions.size());
+      contractions.insert(
+          contractions.end(),
+          std::make_move_iterator(intermediateContractions.begin()),
+          std::make_move_iterator(intermediateContractions.end()));
+
+      intermediates.insert({factor.get(), std::move(intermediate)});
+    } else if (factor.is<Sum>()) {
+      // TODO: Handle on-the-fly antisymmetrization (K[abij] - K[baij])
+      throw std::invalid_argument(
+          "Products of sums can not yet be translated to ITF");
+    }
+  }
+
+  // Now create the contraction for the two factors
+  auto lhsIntermediate = intermediates.find(product.factor(0).get());
+  auto rhsIntermediate = intermediates.find(product.factor(1).get());
+
+  assert(product.scalar().imag() == 0);
+  contractions.push_back(Contraction{
+      product.scalar().real(), resultTensor,
+      lhsIntermediate == intermediates.end() ? product.factor(0).as<Tensor>()
+                                             : lhsIntermediate->second,
+      rhsIntermediate == intermediates.end() ? product.factor(1).as<Tensor>()
+                                             : rhsIntermediate->second});
+
+  return contractions;
+}
+
+std::vector<Contraction> to_contractions(const ExprPtr &expression,
+                                         const Tensor &resultTensor) {
+  std::wstring itfCode;
+
+  if (expression.is<Constant>()) {
+    throw std::invalid_argument("Can't transform constants into contractions");
+  } else if (expression.is<Tensor>()) {
+    return {Contraction{1, resultTensor, expression.as<Tensor>(), {}}};
+  } else if (expression.is<Product>()) {
+    // Separate into binary contractions
+    return to_contractions(expression.as<Product>(), resultTensor);
+  } else if (expression.is<Sum>()) {
+    // Process each summand
+    std::vector<Contraction> contractions;
+
+    for (const ExprPtr &summand : expression.as<Sum>().summands()) {
+      std::vector<Contraction> currentContractions =
+          to_contractions(summand, resultTensor);
+
+      contractions.reserve(contractions.size() + currentContractions.size());
+      contractions.insert(contractions.end(),
+                          std::make_move_iterator(currentContractions.begin()),
+                          std::make_move_iterator(currentContractions.end()));
+    }
+
+    return contractions;
+  } else {
+    throw std::invalid_argument(
+        "Unhandled expression type in to_contractions function");
+  }
+}
+
+template <typename IndexContainer, typename SpaceTypeContainer>
+bool isSpacePattern(const IndexContainer &indices,
+                    const SpaceTypeContainer &pattern) {
+  static_assert(std::is_same_v<typename IndexContainer::value_type, Index>);
+  static_assert(std::is_same_v<typename SpaceTypeContainer::value_type,
+                               IndexSpace::Type>);
+  assert(indices.size() == pattern.size());
+
+  auto indexIter = indices.cbegin();
+  auto typeIter = pattern.cbegin();
+
+  while (indexIter != indices.cend() && typeIter != pattern.cend()) {
+    if (indexIter->space().type() != *typeIter) {
+      return false;
+    }
+
+    ++indexIter;
+    ++typeIter;
+  }
+
+  return true;
+}
+
+void one_electron_integral_remapper(
+    ExprPtr &expr, const std::wstring_view integralTensorLabel) {
+  if (!expr.is<Tensor>()) {
+    return;
+  }
+
+  const Tensor &tensor = expr.as<Tensor>();
+
+  if (tensor.label() != integralTensorLabel || tensor.bra().size() != 1 ||
+      tensor.ket().size() != 1) {
+    return;
+  }
+
+  assert(tensor.bra().size() == 1);
+  assert(tensor.ket().size() == 1);
+
+  auto braIndices = tensor.bra();
+  auto ketIndices = tensor.ket();
+
+  IndexTypeComparer cmp;
+
+  // Use the bra-ket (hermitian) symmetry of the integrals to exchange creators
+  // and annihilators such that the larger index space is on the left (in the
+  // bra)
+  if (cmp(braIndices[0].space().type(), ketIndices[0].space().type())) {
+    std::swap(braIndices[0], ketIndices[0]);
+  } else if (braIndices[0].space().type() == ketIndices[0].space().type() &&
+             ketIndices[0] < braIndices[0]) {
+    // Cosmetic exchange to arrive at a more canonical index ordering
+    std::swap(braIndices[0], ketIndices[0]);
+  }
+
+  expr =
+      ex<Tensor>(tensor.label(), std::move(braIndices), std::move(ketIndices));
+}
+
+template <typename Container>
+bool isExceptionalJ(const Container &braIndices, const Container &ketIndices) {
+  assert(braIndices.size() == 2);
+  assert(ketIndices.size() == 2);
+  // integrals with 3 external (virtual) indices ought to be converted to
+  // J-integrals
+  return braIndices[0].space().type() == virt &&
+         braIndices[1].space().type() == virt &&
+         ketIndices[0].space().type() == virt &&
+         ketIndices[1].space().type() != virt;
+}
+
+void two_electron_integral_remapper(
+    ExprPtr &expr, const std::wstring_view integralTensorLabel) {
+  if (!expr.is<Tensor>()) {
+    return;
+  }
+
+  const Tensor &tensor = expr.as<Tensor>();
+
+  if (tensor.label() != integralTensorLabel || tensor.bra().size() != 2 ||
+      tensor.ket().size() != 2) {
+    return;
+  }
+
+  assert(tensor.bra().size() == 2);
+  assert(tensor.ket().size() == 2);
+
+  // Copy indices as we might have to mutate them
+  auto braIndices = tensor.bra();
+  auto ketIndices = tensor.ket();
+
+  IndexTypeComparer cmp;
+
+  // Step 1: Use 8-fold permutational symmetry of spin-summed integrals
+  // to bring indices into a canonical order in terms of the index
+  // spaces they belong to. Note: This symmetry is generated by the two
+  // individual bra-ket symmetries for indices for particle one and two
+  // as well as the particle-1,2-symmetry (column-symmetry)
+  //
+  // The final goal is to order the indices in descending index space
+  // size, where the assumed relative sizes are
+  // occ < virt
+
+  // Step 1a: Particle-intern bra-ket symmetry
+  for (std::size_t i = 0; i < braIndices.size(); ++i) {
+    if (cmp(braIndices.at(i).space().type(), ketIndices.at(i).space().type())) {
+      // This bra index belongs to a smaller space than the ket index ->
+      // swap them
+      std::swap(braIndices[i], ketIndices[i]);
+    }
+  }
+
+  // Step 1b: Particle-1,2-symmetry
+  bool switchColumns = false;
+  if (braIndices[0].space().type() != braIndices[1].space().type()) {
+    switchColumns =
+        cmp(braIndices[0].space().type(), braIndices[1].space().type());
+  } else if (ketIndices[0].space().type() != ketIndices[1].space().type()) {
+    switchColumns =
+        cmp(ketIndices[0].space().type(), ketIndices[1].space().type());
+  }
+
+  if (switchColumns) {
+    std::swap(braIndices[0], braIndices[1]);
+    std::swap(ketIndices[0], ketIndices[1]);
+  }
+
+  // Step 2: Look at the index space patterns to figure out whether
+  // this is a K or a J integral. If the previously attempted sorting
+  // of index spaces can be improved by switching the second and third
+  // index, do that and thereby produce a J tensor. Otherwise, we retain
+  // the index sequence as-is and thereby produce a K tensor.
+  // There are some explicit exceptions for J-tensors though.
+  std::wstring tensorLabel;
+  Index *particle1_1 = nullptr;
+  Index *particle1_2 = nullptr;
+  Index *particle2_1 = nullptr;
+  Index *particle2_2 = nullptr;
+
+  if (isExceptionalJ(braIndices, ketIndices) ||
+      cmp(braIndices[1].space().type(), ketIndices[0].space().type())) {
+    std::swap(braIndices[1], ketIndices[0]);
+    tensorLabel = L"J";
+
+    particle1_1 = &braIndices[0];
+    particle1_2 = &braIndices[1];
+    particle2_1 = &ketIndices[0];
+    particle2_2 = &ketIndices[1];
+  } else {
+    tensorLabel = L"K";
+
+    particle1_1 = &braIndices[0];
+    particle1_2 = &ketIndices[0];
+    particle2_1 = &braIndices[1];
+    particle2_2 = &ketIndices[1];
+  }
+
+  // Go through the symmetries again to try and produce the most canonical
+  // index ordering possible without breaking the index-space ordering
+  // established up to this point.
+  // This is a purely cosmetic change, but it is very useful for testing
+  // purposes to have  unique representation of the integrals.
+  if (particle1_1->space().type() == particle1_2->space().type() &&
+      *particle1_2 < *particle1_1) {
+    std::swap(*particle1_1, *particle1_2);
+  }
+  if (particle2_1->space().type() == particle2_2->space().type() &&
+      *particle2_2 < *particle2_1) {
+    std::swap(*particle2_1, *particle2_2);
+  }
+  if (particle1_1->space().type() == particle2_1->space().type() &&
+      particle1_2->space().type() == particle2_2->space().type()) {
+    if (*particle2_1 < *particle1_1 ||
+        (*particle1_1 == *particle2_1 && *particle2_2 < *particle1_2)) {
+      std::swap(*particle1_1, *particle2_1);
+      std::swap(*particle1_2, *particle2_2);
+    }
+  }
+
+  expr = ex<Tensor>(std::move(tensorLabel), std::move(braIndices),
+                    std::move(ketIndices));
+}
+
+void integral_remapper(ExprPtr &expr, std::wstring_view oneElectronIntegralName,
+                       std::wstring_view twoElectronIntegralName) {
+  two_electron_integral_remapper(expr, twoElectronIntegralName);
+  one_electron_integral_remapper(expr, oneElectronIntegralName);
+}
+
+void remap_integrals(ExprPtr &expr, std::wstring_view oneElectronIntegralName,
+                     std::wstring_view twoElectronIntegralName) {
+  auto remapper = std::bind(integral_remapper, std::placeholders::_1,
+                            oneElectronIntegralName, twoElectronIntegralName);
+
+  const bool visitedRoot = expr->visit(remapper, true);
+
+  if (!visitedRoot) {
+    remapper(expr);
+  }
+}
+
+void ITFGenerator::addBlock(const itf::CodeBlock &block) {
+  m_codes.reserve(m_codes.size() + block.results.size());
+
+  std::vector<std::vector<Contraction>> contractionBlocks;
+
+  for (const Result &currentResult : block.results) {
+    ExprPtr expression = currentResult.expression;
+    remap_integrals(expression);
+
+    contractionBlocks.push_back(
+        to_contractions(expression, currentResult.resultTensor));
+
+    if (currentResult.importResultTensor) {
+      m_importedTensors.insert(currentResult.resultTensor);
+    } else {
+      m_createdTensors.insert(currentResult.resultTensor);
+    }
+
+    // If we encounter a tensor in an expression that we have not yet seen
+    // before, it must be an imported tensor (otherwise the expression would be
+    // invalid)
+    expression->visit(
+        [this](const ExprPtr &expr) {
+          if (expr.is<Tensor>()) {
+            const Tensor &tensor = expr.as<Tensor>();
+            if (m_createdTensors.find(tensor) == m_createdTensors.end()) {
+              m_importedTensors.insert(tensor);
+            }
+            m_encounteredIndices.insert(tensor.braket().begin(),
+                                        tensor.braket().end());
+          }
+        },
+        true);
+
+    // Now go through all result tensors of the contractions that we have
+    // produced and add all new tensors to the set of created tensors
+    for (const Contraction &currentContraction : contractionBlocks.back()) {
+      if (m_importedTensors.find(currentContraction.result) ==
+          m_importedTensors.end()) {
+        m_createdTensors.insert(currentContraction.result);
+      }
+    }
+  }
+
+  m_codes.push_back(CodeSection{block.name, std::move(contractionBlocks)});
+}
+
+struct IndexComponents {
+  IndexSpace space;
+  std::size_t id;
+};
+
+IndexComponents decomposeIndex(const Index &idx) {
+  // The labels are of the form <letter>_<number> and we want <number>
+  // Note that SeQuant uses 1-based indexing, but we want 0-based
+  int num =
+      std::stoi(std::wstring(idx.label().substr(idx.label().find('_') + 1))) -
+      1;
+  assert(num >= 0 && num <= 6);
+
+  return {idx.space(), static_cast<std::size_t>(num)};
+}
+
+std::map<IndexSpace, std::set<std::size_t>> indicesBySpace(
+    const std::set<Index> &indices) {
+  std::map<IndexSpace, std::set<std::size_t>> indexMap;
+
+  for (const Index &current : indices) {
+    IndexComponents components = decomposeIndex(current);
+
+    indexMap[components.space].insert(components.id);
+  }
+
+  return indexMap;
+}
+
+std::wstring to_itf(const Tensor &tensor, bool includeIndexing = true) {
+  std::wstring tags;
+  std::wstring indices;
+
+  for (const Index &current : tensor.braket()) {
+    IndexComponents components = decomposeIndex(current);
+
+    assert(components.id <= 7);
+
+    if (components.space.type() == IndexSpace::active_occupied) {
+      tags += L"c";
+      indices += static_cast<wchar_t>(L'i' + components.id);
+    } else if (components.space.type() == IndexSpace::active_unoccupied) {
+      tags += L"e";
+      indices += static_cast<wchar_t>(L'a' + components.id);
+    } else {
+      std::runtime_error("Encountered unhandled index space type");
+    }
+  }
+
+  return std::wstring(tensor.label()) + (tags.empty() ? L"" : L":" + tags) +
+         (includeIndexing ? L"[" + indices + L"]" : L"");
+}
+
+std::wstring ITFGenerator::generate() const {
+  std::wstring itf =
+      L"// This ITF algo file has been generated via SeQuant's ITF export\n\n";
+
+  itf += L"---- decl\n";
+
+  // Index declarations
+  std::map<IndexSpace, std::set<std::size_t>> indexGroups =
+      indicesBySpace(m_encounteredIndices);
+  for (auto iter = indexGroups.begin(); iter != indexGroups.end(); ++iter) {
+    wchar_t baseLabel;
+    std::wstring spaceLabel;
+    std::wstring spaceTag;
+    if (iter->first.type() == IndexSpace::active_occupied) {
+      baseLabel = L'i';
+      spaceLabel = L"Closed";
+      spaceTag = L"c";
+    } else if (iter->first.type() == IndexSpace::active_unoccupied) {
+      baseLabel = L'a';
+      spaceLabel = L"External";
+      spaceTag = L"e";
+    } else {
+      std::runtime_error("Encountered unhandled index space type");
+    }
+
+    itf += L"index-space: ";
+    for (std::size_t i : iter->second) {
+      assert(i <= 7);
+      itf += static_cast<wchar_t>(baseLabel + i);
+    }
+    itf += L", " + spaceLabel + L", " + spaceTag + L"\n";
+  }
+
+  itf += L"\n";
+
+  // Tensor declarations
+  for (const Tensor &current : m_importedTensors) {
+    itf +=
+        L"tensor: " + to_itf(current) + L", " + to_itf(current, false) + L"\n";
+  }
+  itf += L"\n";
+  for (const Tensor &current : m_createdTensors) {
+    itf += L"tensor: " + to_itf(current) + L", !Create{type:disk}\n";
+  }
+  itf += L"\n\n";
+
+  // Actual code
+  for (const CodeSection &currentSection : m_codes) {
+    itf += L"---- code(\"" + currentSection.name + L"\")\n";
+
+    std::set<Tensor, TensorBlockCompare> allocatedTensors;
+
+    for (const std::vector<Contraction> &currentBlock :
+         currentSection.contractionBlocks) {
+      for (const Contraction &currentContraction : currentBlock) {
+        // For now we'll do a really silly contribution-by-contribution
+        // load-process-store strategy
+        if (allocatedTensors.find(currentContraction.result) ==
+            allocatedTensors.end()) {
+          itf += L"alloc " + to_itf(currentContraction.result) + L"\n";
+          allocatedTensors.insert(currentContraction.result);
+        } else {
+          itf += L"load " + to_itf(currentContraction.result) + L"\n";
+        }
+        itf += L"load " + to_itf(currentContraction.lhs) + L"\n";
+        if (currentContraction.rhs.has_value()) {
+          itf += L"load " + to_itf(currentContraction.rhs.value()) + L"\n";
+        }
+
+        itf += L"." + to_itf(currentContraction.result) + L" ";
+        int sign = currentContraction.factor < 0 ? -1 : 1;
+
+        itf += (sign < 0 ? L"-= " : L"+= ");
+        if (currentContraction.factor * sign != 1) {
+          itf += to_wstring(currentContraction.factor * sign) + L" * ";
+        }
+        itf += to_itf(currentContraction.lhs) +
+               (currentContraction.rhs.has_value()
+                    ? L" " + to_itf(currentContraction.rhs.value())
+                    : L"") +
+               L"\n";
+
+        if (currentContraction.rhs.has_value()) {
+          itf += L"drop " + to_itf(currentContraction.rhs.value()) + L"\n";
+        }
+        itf += L"drop " + to_itf(currentContraction.lhs) + L"\n";
+        itf += L"store " + to_itf(currentContraction.result) + L"\n";
+      }
+
+      itf += L"\n";
+    }
+
+    itf += L"\n---- end\n";
+  }
+
+  return itf;
+}
+
+}  // namespace detail
+
+}  // namespace itf
+
+}  // namespace sequant

--- a/SeQuant/core/export/itf.cpp
+++ b/SeQuant/core/export/itf.cpp
@@ -507,7 +507,7 @@ std::wstring to_itf(const Tensor &tensor, bool includeIndexing = true) {
       tags += L"e";
       indices += static_cast<wchar_t>(L'a' + components.id);
     } else {
-      std::runtime_error("Encountered unhandled index space type");
+      throw std::runtime_error("Encountered unhandled index space type");
     }
   }
 
@@ -537,7 +537,7 @@ std::wstring ITFGenerator::generate() const {
       spaceLabel = L"External";
       spaceTag = L"e";
     } else {
-      std::runtime_error("Encountered unhandled index space type");
+      throw std::runtime_error("Encountered unhandled index space type");
     }
 
     itf += L"index-space: ";

--- a/SeQuant/core/export/itf.hpp
+++ b/SeQuant/core/export/itf.hpp
@@ -1,0 +1,142 @@
+//
+// Created by Robert Adam on 2023-09-04
+//
+
+#ifndef SEQUANT_CORE_EXPORT_ITF_HPP
+#define SEQUANT_CORE_EXPORT_ITF_HPP
+
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/tensor.hpp>
+
+#include <optional>
+#include <set>
+#include <string>
+#include <type_traits>
+#include <unordered_set>
+#include <vector>
+
+namespace sequant {
+
+namespace itf {
+
+/// A result consists of a single result tensor along with an expression tree
+/// that contains the expressions needed to build the aforementioned result
+/// tensor
+struct Result {
+  ExprPtr expression;
+  Tensor resultTensor;
+  bool importResultTensor;
+
+  Result(ExprPtr expression, Tensor resultTensor,
+         bool importResultTensor = true);
+  Result(ExprPtr expression, bool importResultTensor = false);
+};
+
+/// A code block groups one or multiple Results together. Upon ITF code
+/// generation a CodeBlock object will be mapped to a single '---- code("xyz")'
+/// block in ITF. The individual results will be computed serially inside the
+/// code block and the computation of individual results will be separated in
+/// different "paragraphs" in the generated code.
+struct CodeBlock {
+  std::wstring name;
+  std::vector<Result> results;
+
+  CodeBlock(std::wstring blockName, Result result);
+  CodeBlock(std::wstring blockName, std::vector<Result> results);
+};
+
+namespace detail {
+
+/// Comparator that identifies Tensors only by their "block", which is defined
+/// by its name, the amount of its indices as well as the space these indices
+/// belong to. Note that it explicitly does not depend on the explicit index
+/// labelling.
+struct TensorBlockCompare {
+  bool operator()(const Tensor &lhs, const Tensor &rhs) const;
+};
+
+/// Replaces one- and two-electron integrals in the given expression with
+/// versions that use the index ordering and tensor naming as expected in ITF
+void remap_integrals(ExprPtr &expr,
+                     std::wstring_view oneElectronIntegralName = L"f",
+                     std::wstring_view twoElectronIntegralName = L"g");
+
+/// Represents a single contraction where the contraction of lhs with rhs,
+/// multiplied by the given factor contributes to the given result. If rhs is
+/// not given, this implies that the contribution is only lhs scaled with the
+/// provided factor.
+struct Contraction {
+  rational factor;
+
+  Tensor result;
+  Tensor lhs;
+  std::optional<Tensor> rhs;
+};
+
+/// This is essentially a low-level representation of a CodeBlock object, where
+/// all expressions have been broken down into binary contractions, which leads
+/// to the creation of intermediate result tensors.
+struct CodeSection {
+  std::wstring name;
+  std::vector<std::vector<Contraction>> contractionBlocks;
+};
+
+/// This is stateful object that is used to implement the actual ITF code
+/// generating capabilities
+class ITFGenerator {
+ public:
+  ITFGenerator() = default;
+
+  void addBlock(const itf::CodeBlock &block);
+
+  std::wstring generate() const;
+
+ private:
+  std::set<Index> m_encounteredIndices;
+  std::set<Tensor, TensorBlockCompare> m_importedTensors;
+  std::set<Tensor, TensorBlockCompare> m_createdTensors;
+  std::vector<CodeSection> m_codes;
+};
+
+}  // namespace detail
+
+}  // namespace itf
+
+/// Translates the given ITF CodeBlock to executable ITF code
+std::wstring to_itf(const itf::CodeBlock &block);
+
+/// Translates the given collection/range of ITF CodeBlocks or Results to
+/// executable ITF code
+template <typename Container,
+          typename = std::enable_if_t<!std::is_same_v<
+              std::remove_const_t<std::remove_reference_t<Container>>,
+              itf::CodeBlock>>>
+std::wstring to_itf(Container &&container) {
+  static_assert(
+      std::is_same_v<typename Container::value_type, itf::CodeBlock> ||
+      std::is_same_v<std::remove_const_t<typename Container::value_type>,
+                     ExprPtr>);
+  itf::detail::ITFGenerator generator;
+
+  if constexpr (std::is_same_v<typename Container::value_type,
+                               itf::CodeBlock>) {
+    for (const itf::CodeBlock &current : container) {
+      generator.addBlock(current);
+    }
+  } else {
+    static_assert(
+        std::is_same_v<typename Container::value_type, itf::Result>,
+        "Container::value_type must either be itf::CodeBlock or itf::Result");
+
+    itf::CodeBlock block(L"Generate_Results",
+                         std::forward<Container>(container));
+
+    generator.addBlock(block);
+  }
+
+  return generator.generate();
+}
+
+}  // namespace sequant
+
+#endif  // SEQUANT_CORE_EXPORT_ITF_HPP

--- a/SeQuant/core/utility/indices.hpp
+++ b/SeQuant/core/utility/indices.hpp
@@ -1,0 +1,161 @@
+#ifndef SEQUANT_CORE_UTILITY_INDICES_HPP
+#define SEQUANT_CORE_UTILITY_INDICES_HPP
+
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/tensor.hpp>
+
+#include <set>
+#include <vector>
+
+namespace sequant {
+
+namespace detail {
+
+/// This function is equal to std::remove in case the given container
+/// contains none or only a single occurrence of the given element.
+/// If the given element is contained multiple times, only the first
+/// occurrence is removed.
+/// If it is known that there is only a single occurrence of the given
+/// element, this function can be more efficient than std::remove as it
+/// can terminate as soon as the element has been found instead of having
+/// to traverse the entire container.
+template <typename Container, typename Element>
+void remove_one(Container& container, const Element& e) {
+  auto iter = std::find(container.begin(), container.end(), e);
+
+  if (iter != container.end()) {
+    container.erase(iter);
+  }
+}
+
+}  // namespace detail
+
+/// A composite type for holding different named groups of indices
+template <typename Container = std::vector<Index>>
+struct IndexGroups {
+  Container bra;
+  Container ket;
+
+  bool operator==(const IndexGroups<Container>& other) const {
+    return bra == other.bra && ket == other.ket;
+  }
+
+  bool operator!=(const IndexGroups<Container>& other) const {
+    return !(*this == other);
+  }
+};
+
+template <typename Container = std::vector<Index>>
+IndexGroups<Container> get_unique_indices(const ExprPtr& expr);
+
+template <typename Container = std::vector<Index>>
+IndexGroups<Container> get_unique_indices(const Constant&) {
+  return {};
+}
+
+template <typename Container = std::vector<Index>>
+IndexGroups<Container> get_unique_indices(const Variable&) {
+  return {};
+}
+
+/// Obtains the set of unique (non-repeated) indices used in the given tensor
+template <typename Container = std::vector<Index>>
+IndexGroups<Container> get_unique_indices(const Tensor& tensor) {
+  IndexGroups<Container> groups;
+  std::set<Index> encounteredIndices;
+
+  for (const Index& current : tensor.bra()) {
+    if (encounteredIndices.find(current) == encounteredIndices.end()) {
+      groups.bra.push_back(current);
+      encounteredIndices.insert(current);
+    } else {
+      // There can't be indices in bra at this point, so we don't have to remove
+      // from that
+      detail::remove_one(groups.bra, current);
+    }
+  }
+
+  for (const Index& current : tensor.ket()) {
+    if (encounteredIndices.find(current) == encounteredIndices.end()) {
+      groups.ket.push_back(current);
+      encounteredIndices.insert(current);
+    } else {
+      detail::remove_one(groups.bra, current);
+      detail::remove_one(groups.ket, current);
+    }
+  }
+
+  return groups;
+}
+
+/// Obtains the set of unique (non-repeated) indices used in the given sum
+/// The assumption here is that the set of unique indices of different addends
+/// is the same (which it should be anyway as otherwise it wouldn't make sense
+/// to add these terms in the first place)
+template <typename Container = std::vector<Index>>
+IndexGroups<Container> get_unique_indices(const Sum& sum) {
+  // In order for the sum to be valid, all summands must have the same
+  // external indices, so it suffices to look only at the first one
+  return sum.summands().empty() ? IndexGroups<Container>{}
+                                : get_unique_indices<Container>(sum.summand(0));
+}
+
+/// Obtains the set of unique (non-repeated) indices used in the given product
+template <typename Container = std::vector<Index>>
+IndexGroups<Container> get_unique_indices(const Product& product) {
+  std::set<Index> encounteredIndices;
+  IndexGroups<Container> groups;
+
+  for (const ExprPtr& current : product) {
+    IndexGroups<Container> currentGroups =
+        get_unique_indices<Container>(current);
+
+    for (Index& current : currentGroups.bra) {
+      if (encounteredIndices.find(current) == encounteredIndices.end()) {
+        encounteredIndices.insert(current);
+        groups.bra.push_back(std::move(current));
+      } else {
+        detail::remove_one(groups.bra, current);
+        detail::remove_one(groups.ket, current);
+      }
+    }
+
+    // Same for ket indices
+    for (Index& current : currentGroups.ket) {
+      if (encounteredIndices.find(current) == encounteredIndices.end()) {
+        encounteredIndices.insert(current);
+        groups.ket.push_back(std::move(current));
+      } else {
+        detail::remove_one(groups.bra, current);
+        detail::remove_one(groups.ket, current);
+      }
+    }
+  }
+
+  return groups;
+}
+
+/// Obtains the set of unique (non-repeated) indices used in the given
+/// expression
+template <typename Container>
+IndexGroups<Container> get_unique_indices(const ExprPtr& expr) {
+  if (expr.is<Constant>()) {
+    return get_unique_indices<Container>(expr.as<Constant>());
+  } else if (expr.is<Variable>()) {
+    return get_unique_indices<Container>(expr.as<Variable>());
+  } else if (expr.is<Tensor>()) {
+    return get_unique_indices<Container>(expr.as<Tensor>());
+  } else if (expr.is<Sum>()) {
+    return get_unique_indices<Container>(expr.as<Sum>());
+  } else if (expr.is<Product>()) {
+    return get_unique_indices<Container>(expr.as<Product>());
+  } else {
+    throw std::runtime_error(
+        "Encountered unsupported expression type in get_unique_indices");
+  }
+}
+
+}  // namespace sequant
+
+#endif  // SEQUANT_CORE_UTILITY_INDICES_HPP

--- a/tests/unit/test_export.cpp
+++ b/tests/unit/test_export.cpp
@@ -1,0 +1,228 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <SeQuant/core/export/itf.hpp>
+#include <SeQuant/core/parse_expr.hpp>
+
+#include <codecvt>
+#include <locale>
+#include <vector>
+
+namespace Catch {
+
+// Note: Again, template specialization doesn't seem to be used from inside
+// ::Catch::Details::stringify for some reason
+template <>
+struct StringMaker<sequant::ExprPtr> {
+  static std::string convert(const sequant::ExprPtr &expr) {
+    using convert_type = std::codecvt_utf8<wchar_t>;
+    std::wstring_convert<convert_type, wchar_t> converter;
+
+    return converter.to_bytes(sequant::deparse_expr(expr, false));
+  }
+};
+
+}  // namespace Catch
+
+std::vector<std::vector<std::size_t>> twoElectronIntegralSymmetries() {
+  // Symmetries of spin-summed (skeleton) two-electron integrals
+  return {
+      // g^{pq}_{rs}
+      {0, 1, 2, 3},
+      // g^{ps}_{rq}
+      {0, 3, 2, 1},
+      // g^{rq}_{ps}
+      {2, 1, 0, 3},
+      // g^{rs}_{pq}
+      {2, 3, 0, 1},
+
+      // g^{qp}_{sr}
+      {1, 0, 3, 2},
+      // g^{qr}_{sp}
+      {1, 2, 3, 0},
+      // g^{sp}_{qr}
+      {3, 0, 1, 2},
+      // g^{sr}_{qp}
+      {3, 2, 1, 0},
+  };
+}
+
+#define CAPTURE_EXPR(expr) \
+  INFO(#expr " := " << ::Catch::StringMaker<sequant::ExprPtr>::convert(expr))
+
+TEST_CASE("Itf export", "[exports]") {
+  using namespace sequant;
+
+  SECTION("remap_integrals") {
+    using namespace sequant::itf::detail;
+    SECTION("Unchanged") {
+      auto expr = parse_expr(L"t{i1;a1}");
+      auto remapped = expr;
+      remap_integrals(expr);
+      REQUIRE(remapped == expr);
+
+      expr = parse_expr(L"t{i1;a1} f{a1;i1} + first{a1;i1} second{i1;a1}");
+      remapped = expr;
+      remap_integrals(expr);
+      REQUIRE(remapped == expr);
+    }
+
+    SECTION("K") {
+      SECTION("occ,occ,occ,occ") {
+        std::vector<Index> indices = {L"i_1", L"i_2", L"i_3", L"i_4"};
+        REQUIRE(indices.size() == 4);
+        const ExprPtr expected = parse_expr(L"K{i1,i2;i3,i4}");
+
+        for (const std::vector<std::size_t> &indexPerm :
+             twoElectronIntegralSymmetries()) {
+          REQUIRE(indexPerm.size() == 4);
+
+          ExprPtr integralExpr = ex<Tensor>(
+              L"g",
+              std::vector<Index>{indices[indexPerm[0]], indices[indexPerm[1]]},
+              std::vector<Index>{indices[indexPerm[2]], indices[indexPerm[3]]});
+
+          auto transformed = integralExpr;
+          remap_integrals(transformed);
+
+          CAPTURE(indexPerm);
+          CAPTURE_EXPR(integralExpr);
+          CAPTURE_EXPR(transformed);
+          CAPTURE_EXPR(expected);
+
+          REQUIRE(transformed == expected);
+        }
+      }
+
+      SECTION("virt,virt,occ,occ") {
+        std::vector<Index> indices = {L"a_1", L"a_2", L"i_1", L"i_2"};
+        REQUIRE(indices.size() == 4);
+        const ExprPtr expected = parse_expr(L"K{a1,a2;i1,i2}");
+
+        for (const std::vector<std::size_t> &indexPerm :
+             twoElectronIntegralSymmetries()) {
+          REQUIRE(indexPerm.size() == 4);
+
+          ExprPtr integralExpr = ex<Tensor>(
+              L"g",
+              std::vector<Index>{indices[indexPerm[0]], indices[indexPerm[1]]},
+              std::vector<Index>{indices[indexPerm[2]], indices[indexPerm[3]]});
+
+          auto transformed = integralExpr;
+          remap_integrals(transformed);
+
+          CAPTURE(indexPerm);
+          CAPTURE_EXPR(integralExpr);
+          CAPTURE_EXPR(transformed);
+          CAPTURE_EXPR(expected);
+
+          REQUIRE(transformed == expected);
+        }
+      }
+
+      SECTION("virt,virt,virt,virt") {
+        std::vector<Index> indices = {L"a_1", L"a_2", L"a_3", L"a_4"};
+        REQUIRE(indices.size() == 4);
+        const ExprPtr expected = parse_expr(L"K{a1,a2;a3,a4}");
+
+        for (const std::vector<std::size_t> &indexPerm :
+             twoElectronIntegralSymmetries()) {
+          REQUIRE(indexPerm.size() == 4);
+
+          ExprPtr integralExpr = ex<Tensor>(
+              L"g",
+              std::vector<Index>{indices[indexPerm[0]], indices[indexPerm[1]]},
+              std::vector<Index>{indices[indexPerm[2]], indices[indexPerm[3]]});
+
+          auto transformed = integralExpr;
+          remap_integrals(transformed);
+
+          CAPTURE(indexPerm);
+          CAPTURE_EXPR(integralExpr);
+          CAPTURE_EXPR(transformed);
+          CAPTURE_EXPR(expected);
+
+          REQUIRE(transformed == expected);
+        }
+      }
+    }
+
+    SECTION("J") {
+      SECTION("virt,occ,virt,occ") {
+        std::vector<Index> indices = {L"a_1", L"i_1", L"a_2", L"i_2"};
+        REQUIRE(indices.size() == 4);
+        const ExprPtr expected = parse_expr(L"J{a1,a2;i1,i2}");
+
+        for (const std::vector<std::size_t> &indexPerm :
+             twoElectronIntegralSymmetries()) {
+          REQUIRE(indexPerm.size() == 4);
+
+          ExprPtr integralExpr = ex<Tensor>(
+              L"g",
+              std::vector<Index>{indices[indexPerm[0]], indices[indexPerm[1]]},
+              std::vector<Index>{indices[indexPerm[2]], indices[indexPerm[3]]});
+
+          auto transformed = integralExpr;
+          remap_integrals(transformed);
+
+          CAPTURE(indexPerm);
+          CAPTURE_EXPR(integralExpr);
+          CAPTURE_EXPR(transformed);
+          CAPTURE_EXPR(expected);
+
+          REQUIRE(transformed == expected);
+        }
+      }
+
+      SECTION("virt,occ,virt,virt") {
+        std::vector<Index> indices = {L"a_1", L"i_1", L"a_2", L"a_3"};
+        REQUIRE(indices.size() == 4);
+        const ExprPtr expected = parse_expr(L"J{a1,a2;a3,i1}");
+
+        for (const std::vector<std::size_t> &indexPerm :
+             twoElectronIntegralSymmetries()) {
+          REQUIRE(indexPerm.size() == 4);
+
+          ExprPtr integralExpr = ex<Tensor>(
+              L"g",
+              std::vector<Index>{indices[indexPerm[0]], indices[indexPerm[1]]},
+              std::vector<Index>{indices[indexPerm[2]], indices[indexPerm[3]]});
+
+          auto transformed = integralExpr;
+          remap_integrals(transformed);
+
+          CAPTURE(indexPerm);
+          CAPTURE_EXPR(integralExpr);
+          CAPTURE_EXPR(transformed);
+          CAPTURE_EXPR(expected);
+
+          REQUIRE(transformed == expected);
+        }
+      }
+    }
+
+    SECTION("f") {
+      SECTION("same_space") {
+        ExprPtr expr = parse_expr(L"f{i2;i1} + f{a1;a2}");
+        const ExprPtr expected = parse_expr(L"f{i1;i2} + f{a1;a2}");
+
+        remap_integrals(expr);
+
+        CAPTURE_EXPR(expr);
+        CAPTURE_EXPR(expected);
+
+        REQUIRE(expr == expected);
+      }
+      SECTION("different_space") {
+        ExprPtr expr = parse_expr(L"f{a1;i1} + f{i1;a1}");
+        const ExprPtr expected = parse_expr(L"f{a1;i1} + f{a1;i1}");
+
+        remap_integrals(expr);
+
+        CAPTURE_EXPR(expr);
+        CAPTURE_EXPR(expected);
+
+        REQUIRE(expr == expected);
+      }
+    }
+  }
+}

--- a/tests/unit/test_utilities.cpp
+++ b/tests/unit/test_utilities.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
 
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>

--- a/tests/unit/test_utilities.cpp
+++ b/tests/unit/test_utilities.cpp
@@ -1,0 +1,109 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/parse_expr.hpp>
+#include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/utility/indices.hpp>
+
+#include <codecvt>
+#include <iostream>
+#include <locale>
+#include <string>
+
+namespace Catch {
+
+// Note: For some reason this template specialization is never used. It works
+// for custom types but not for sequant::Index.
+template <>
+struct StringMaker<sequant::Index> {
+  static std::string convert(const sequant::Index &idx) {
+    using convert_type = std::codecvt_utf8<wchar_t>;
+    std::wstring_convert<convert_type, wchar_t> converter;
+
+    return converter.to_bytes(sequant::to_latex(idx));
+  }
+};
+
+}  // namespace Catch
+
+TEST_CASE("get_unique_indices", "[utilities]") {
+  using namespace sequant;
+  using namespace Catch::Matchers;
+
+  SECTION("Constant") {
+    auto const expression = parse_expr(L"5");
+
+    auto const indices = get_unique_indices(expression);
+
+    REQUIRE(indices.bra.empty());
+    REQUIRE(indices.ket.empty());
+    REQUIRE(indices == get_unique_indices(expression->as<Constant>()));
+  }
+  SECTION("Tensor") {
+    auto expression = parse_expr(L"t{i1;a1,a2}");
+
+    auto indices = get_unique_indices(expression);
+
+    REQUIRE_THAT(indices.bra, UnorderedEquals(std::vector<Index>{{L"i_1"}}));
+    REQUIRE_THAT(indices.ket,
+                 UnorderedEquals(std::vector<Index>{{L"a_1", L"a_2"}}));
+    REQUIRE(indices == get_unique_indices(expression->as<Tensor>()));
+
+    expression = parse_expr(L"t{i1,i2;a1,a2}");
+
+    indices = get_unique_indices(expression);
+
+    REQUIRE_THAT(indices.bra,
+                 UnorderedEquals(std::vector<Index>{{L"i_1"}, {L"i_2"}}));
+    REQUIRE_THAT(indices.ket,
+                 UnorderedEquals(std::vector<Index>{{L"a_1", L"a_2"}}));
+    REQUIRE(indices == get_unique_indices(expression->as<Tensor>()));
+
+    expression = parse_expr(L"t{i1,i2;a1,i1}");
+
+    indices = get_unique_indices(expression);
+
+    REQUIRE_THAT(indices.bra, UnorderedEquals(std::vector<Index>{{L"i_2"}}));
+    REQUIRE_THAT(indices.ket, UnorderedEquals(std::vector<Index>{{L"a_1"}}));
+    REQUIRE(indices == get_unique_indices(expression->as<Tensor>()));
+  }
+  SECTION("Product") {
+    auto expression = parse_expr(L"t{i1;a1,a2} p{a2;i2}");
+
+    auto indices = get_unique_indices(expression);
+
+    REQUIRE_THAT(indices.bra, UnorderedEquals(std::vector<Index>{{L"i_1"}}));
+    REQUIRE_THAT(indices.ket,
+                 UnorderedEquals(std::vector<Index>{{L"a_1", L"i_2"}}));
+    REQUIRE(indices == get_unique_indices(expression->as<Product>()));
+
+    expression = parse_expr(L"1/8 g{a3,a4;i3,i4} t{a1,a4;i1,i4}");
+
+    indices = get_unique_indices(expression);
+
+    REQUIRE_THAT(indices.bra,
+                 UnorderedEquals(std::vector<Index>{{L"a_3"}, {L"a_1"}}));
+    REQUIRE_THAT(indices.ket,
+                 UnorderedEquals(std::vector<Index>{{L"i_3", L"i_1"}}));
+    REQUIRE(indices == get_unique_indices(expression->as<Product>()));
+  }
+  SECTION("Sum") {
+    auto expression = parse_expr(L"t{i1;a2} + g{i1;a2}");
+
+    auto indices = get_unique_indices(expression);
+
+    REQUIRE_THAT(indices.bra, UnorderedEquals(std::vector<Index>{{L"i_1"}}));
+    REQUIRE_THAT(indices.ket, UnorderedEquals(std::vector<Index>{{L"a_2"}}));
+    REQUIRE(indices == get_unique_indices(expression->as<Sum>()));
+
+    expression = parse_expr(L"t{i1;a2} t{i1;a1} + t{i1;a1} g{i1;a2}");
+
+    indices = get_unique_indices(expression);
+
+    REQUIRE(indices.bra.empty());
+    REQUIRE_THAT(indices.ket,
+                 UnorderedEquals(std::vector<Index>{{L"a_1"}, {L"a_2"}}));
+    REQUIRE(indices == get_unique_indices(expression->as<Sum>()));
+  }
+}


### PR DESCRIPTION
This commit implements functionality that allows to translate a SeQuant expression tree to executable ITF code. The assumption being that said expression tree has been factorized into a binary tree first.

The Integrated Tensor Framework (ITF) is a domain-specific language (DSL) for writing down tensor contractions. The code is interpreted by the Molpro quantum chemistry program package.
For more information see

H.-J. Werner et al., WIREs Comput. Mol. Sci., Vol. 2, No. 2 p. 242-253 (https://doi.org/10.1002/wcms.82)