### PR TITLE
MBPT Misc Changes

### DIFF
--- a/SeQuant/domain/mbpt/mr.cpp
+++ b/SeQuant/domain/mbpt/mr.cpp
@@ -450,11 +450,11 @@ ExprPtr H_(std::size_t k) {
           [vacuum = get_default_context().vacuum()]() -> std::wstring_view {
             switch (vacuum) {
               case Vacuum::Physical:
-                return L"h";
+                return optype2label.at(OpType::h);
               case Vacuum::SingleProduct:
-                return L"f̃";
+                return optype2label.at(OpType::f̃);
               case Vacuum::MultiProduct:
-                return L"f";
+                return optype2label.at(OpType::f);
               default:
                 abort();
             }
@@ -467,7 +467,7 @@ ExprPtr H_(std::size_t k) {
 
     case 2:
       return ex<op_t>(
-          []() -> std::wstring_view { return L"g"; },
+          []() -> std::wstring_view { return optype2label.at(OpType::g); },
           [=]() -> ExprPtr { return mbpt::mr::H_(2); },
           [=](qnc_t& qns) {
             qns = combine(qnc_t{{0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}, {0, 2}},
@@ -487,7 +487,7 @@ ExprPtr H(std::size_t k) {
 ExprPtr T_(std::size_t K) {
   assert(K > 0);
   return ex<op_t>(
-      []() -> std::wstring_view { return L"t"; },
+      []() -> std::wstring_view { return optype2label.at(OpType::t); },
       [=]() -> ExprPtr {
         using namespace sequant::mbpt::sr;
         return mr::T_(K);
@@ -513,7 +513,7 @@ ExprPtr T(std::size_t K) {
 ExprPtr Λ_(std::size_t K) {
   assert(K > 0);
   return ex<op_t>(
-      []() -> std::wstring_view { return L"λ"; },
+      []() -> std::wstring_view { return optype2label.at(OpType::λ); },
       [=]() -> ExprPtr {
         using namespace sequant::mbpt::sr;
         return mr::Λ_(K);
@@ -538,30 +538,31 @@ ExprPtr Λ(std::size_t K) {
 
 ExprPtr A(std::int64_t K) {
   assert(K != 0);
-  return ex<op_t>([]() -> std::wstring_view { return L"A"; },
-                  [=]() -> ExprPtr {
-                    using namespace sequant::mbpt::sr;
-                    return mr::A(K, K);
-                  },
-                  [=](qnc_t& qns) {
-                    const std::size_t abs_K = std::abs(K);
-                    if (K < 0)
-                      qns = combine(qnc_t{{0ul, abs_K},
-                                          {0ul, 0ul},
-                                          {0ul, abs_K},
-                                          {0ul, abs_K},
-                                          {0ul, 0ul},
-                                          {0ul, abs_K}},
-                                    qns);
-                    else
-                      qns = combine(qnc_t{{0ul, 0ul},
-                                          {0ul, abs_K},
-                                          {0ul, abs_K},
-                                          {0ul, abs_K},
-                                          {0ul, abs_K},
-                                          {0ul, 0ul}},
-                                    qns);
-                  });
+  return ex<op_t>(
+      []() -> std::wstring_view { return optype2label.at(OpType::A); },
+      [=]() -> ExprPtr {
+        using namespace sequant::mbpt::sr;
+        return mr::A(K, K);
+      },
+      [=](qnc_t& qns) {
+        const std::size_t abs_K = std::abs(K);
+        if (K < 0)
+          qns = combine(qnc_t{{0ul, abs_K},
+                              {0ul, 0ul},
+                              {0ul, abs_K},
+                              {0ul, abs_K},
+                              {0ul, 0ul},
+                              {0ul, abs_K}},
+                        qns);
+        else
+          qns = combine(qnc_t{{0ul, 0ul},
+                              {0ul, abs_K},
+                              {0ul, abs_K},
+                              {0ul, abs_K},
+                              {0ul, abs_K},
+                              {0ul, 0ul}},
+                        qns);
+      });
 }
 
 // ExprPtr S(std::int64_t K) {

--- a/SeQuant/domain/mbpt/sr.cpp
+++ b/SeQuant/domain/mbpt/sr.cpp
@@ -232,7 +232,7 @@ namespace op {
 
 ExprPtr H2_oo_vv() {
   return ex<op_t>(
-      []() -> std::wstring_view { return L"g"; },
+      []() -> std::wstring_view { return optype2label.at(OpType::g); },
       [=]() -> ExprPtr {
         using namespace sequant::mbpt::sr;
         return OpMaker(
@@ -247,7 +247,7 @@ ExprPtr H2_oo_vv() {
 
 ExprPtr H2_vv_vv() {
   return ex<op_t>(
-      []() -> std::wstring_view { return L"g"; },
+      []() -> std::wstring_view { return optype2label.at(OpType::g); },
       [=]() -> ExprPtr {
         using namespace sequant::mbpt::sr;
         return OpMaker(
@@ -268,9 +268,9 @@ ExprPtr H_(std::size_t k) {
           [vacuum = get_default_context().vacuum()]() -> std::wstring_view {
             switch (vacuum) {
               case Vacuum::Physical:
-                return L"h";
+                return optype2label.at(OpType::h);
               case Vacuum::SingleProduct:
-                return L"f";
+                return optype2label.at(OpType::f);
               case Vacuum::MultiProduct:
                 abort();
               default:
@@ -287,7 +287,7 @@ ExprPtr H_(std::size_t k) {
 
     case 2:
       return ex<op_t>(
-          []() -> std::wstring_view { return L"g"; },
+          []() -> std::wstring_view { return optype2label.at(OpType::g); },
           [=]() -> ExprPtr {
             using namespace sequant::mbpt::sr;
             return sr::H_(2);
@@ -308,14 +308,15 @@ ExprPtr H(std::size_t k) {
 
 ExprPtr T_(std::size_t K) {
   assert(K > 0);
-  return ex<op_t>([]() -> std::wstring_view { return L"t"; },
-                  [=]() -> ExprPtr {
-                    using namespace sequant::mbpt::sr;
-                    return sr::T_(K);
-                  },
-                  [=](qnc_t& qns) {
-                    qns = combine(qnc_t{0ul, K, K, 0ul}, qns);
-                  });
+  return ex<op_t>(
+      []() -> std::wstring_view { return optype2label.at(OpType::t); },
+      [=]() -> ExprPtr {
+        using namespace sequant::mbpt::sr;
+        return sr::T_(K);
+      },
+      [=](qnc_t& qns) {
+        qns = combine(qnc_t{0ul, K, K, 0ul}, qns);
+      });
 }
 
 ExprPtr T(std::size_t K) {
@@ -330,14 +331,15 @@ ExprPtr T(std::size_t K) {
 
 ExprPtr Λ_(std::size_t K) {
   assert(K > 0);
-  return ex<op_t>([]() -> std::wstring_view { return L"λ"; },
-                  [=]() -> ExprPtr {
-                    using namespace sequant::mbpt::sr;
-                    return sr::Λ_(K);
-                  },
-                  [=](qnc_t& qns) {
-                    qns = combine(qnc_t{K, 0ul, 0ul, K}, qns);
-                  });
+  return ex<op_t>(
+      []() -> std::wstring_view { return optype2label.at(OpType::λ); },
+      [=]() -> ExprPtr {
+        using namespace sequant::mbpt::sr;
+        return sr::Λ_(K);
+      },
+      [=](qnc_t& qns) {
+        qns = combine(qnc_t{K, 0ul, 0ul, K}, qns);
+      });
 }
 
 ExprPtr Λ(std::size_t K) {
@@ -352,34 +354,36 @@ ExprPtr Λ(std::size_t K) {
 
 ExprPtr A(std::int64_t K) {
   assert(K != 0);
-  return ex<op_t>([]() -> std::wstring_view { return L"A"; },
-                  [=]() -> ExprPtr {
-                    using namespace sequant::mbpt::sr;
-                    return sr::A(K, K);
-                  },
-                  [=](qnc_t& qns) {
-                    const std::size_t abs_K = std::abs(K);
-                    if (K < 0)
-                      qns = combine(qnc_t{abs_K, 0ul, 0ul, abs_K}, qns);
-                    else
-                      qns = combine(qnc_t{0ul, abs_K, abs_K, 0ul}, qns);
-                  });
+  return ex<op_t>(
+      []() -> std::wstring_view { return optype2label.at(OpType::A); },
+      [=]() -> ExprPtr {
+        using namespace sequant::mbpt::sr;
+        return sr::A(K, K);
+      },
+      [=](qnc_t& qns) {
+        const std::size_t abs_K = std::abs(K);
+        if (K < 0)
+          qns = combine(qnc_t{abs_K, 0ul, 0ul, abs_K}, qns);
+        else
+          qns = combine(qnc_t{0ul, abs_K, abs_K, 0ul}, qns);
+      });
 }
 
 ExprPtr S(std::int64_t K) {
   assert(K != 0);
-  return ex<op_t>([]() -> std::wstring_view { return L"S"; },
-                  [=]() -> ExprPtr {
-                    using namespace sequant::mbpt::sr;
-                    return sr::S(K, K);
-                  },
-                  [=](qnc_t& qns) {
-                    const std::size_t abs_K = std::abs(K);
-                    if (K < 0)
-                      qns = combine(qnc_t{abs_K, 0ul, 0ul, abs_K}, qns);
-                    else
-                      qns = combine(qnc_t{0ul, abs_K, abs_K, 0ul}, qns);
-                  });
+  return ex<op_t>(
+      []() -> std::wstring_view { return optype2label.at(OpType::S); },
+      [=]() -> ExprPtr {
+        using namespace sequant::mbpt::sr;
+        return sr::S(K, K);
+      },
+      [=](qnc_t& qns) {
+        const std::size_t abs_K = std::abs(K);
+        if (K < 0)
+          qns = combine(qnc_t{abs_K, 0ul, 0ul, abs_K}, qns);
+        else
+          qns = combine(qnc_t{0ul, abs_K, abs_K, 0ul}, qns);
+      });
 }
 
 ExprPtr P(std::int64_t K) {
@@ -390,7 +394,7 @@ ExprPtr H_pt(std::size_t order, std::size_t R) {
   assert(R > 0);
   assert(order == 1 && "only first order perturbation is supported now");
   return ex<op_t>(
-      []() -> std::wstring_view { return L"h¹"; },
+      []() -> std::wstring_view { return optype2label.at(OpType::h_1); },
       [=]() -> ExprPtr {
         using namespace sequant::mbpt::sr;
         return sr::H_pt(1, R);
@@ -403,14 +407,15 @@ ExprPtr H_pt(std::size_t order, std::size_t R) {
 ExprPtr T_pt_(std::size_t order, std::size_t K) {
   assert(K > 0);
   assert(order == 1 && "only first order perturbation is supported now");
-  return ex<op_t>([]() -> std::wstring_view { return L"t¹"; },
-                  [=]() -> ExprPtr {
-                    using namespace sequant::mbpt::sr;
-                    return sr::T_pt_(order, K);
-                  },
-                  [=](qnc_t& qns) {
-                    qns = combine(qnc_t{0ul, K, K, 0ul}, qns);
-                  });
+  return ex<op_t>(
+      []() -> std::wstring_view { return optype2label.at(OpType::t_1); },
+      [=]() -> ExprPtr {
+        using namespace sequant::mbpt::sr;
+        return sr::T_pt_(order, K);
+      },
+      [=](qnc_t& qns) {
+        qns = combine(qnc_t{0ul, K, K, 0ul}, qns);
+      });
 }
 
 ExprPtr T_pt(std::size_t order, std::size_t K) {
@@ -425,14 +430,15 @@ ExprPtr T_pt(std::size_t order, std::size_t K) {
 ExprPtr Λ_pt_(std::size_t order, std::size_t K) {
   assert(K > 0);
   assert(order == 1 && "only first order perturbation is supported now");
-  return ex<op_t>([]() -> std::wstring_view { return L"λ¹"; },
-                  [=]() -> ExprPtr {
-                    using namespace sequant::mbpt::sr;
-                    return sr::Λ_pt_(order, K);
-                  },
-                  [=](qnc_t& qns) {
-                    qns = combine(qnc_t{K, 0ul, 0ul, K}, qns);
-                  });
+  return ex<op_t>(
+      []() -> std::wstring_view { return optype2label.at(OpType::λ_1); },
+      [=]() -> ExprPtr {
+        using namespace sequant::mbpt::sr;
+        return sr::Λ_pt_(order, K);
+      },
+      [=](qnc_t& qns) {
+        qns = combine(qnc_t{K, 0ul, 0ul, K}, qns);
+      });
 }
 
 ExprPtr Λ_pt(std::size_t order, std::size_t K) {

--- a/examples/srcc/srcc.cpp
+++ b/examples/srcc/srcc.cpp
@@ -129,6 +129,14 @@ class compute_cceqvec {
           if (R == 3 && N == 3) runtime_assert(eqvec[R]->size() == 47);
           if (R == 4 && N == 4) runtime_assert(eqvec[R]->size() == 74);
           if (R == 5 && N == 5) runtime_assert(eqvec[R]->size() == 99);
+        } else if (type == EqnType::λ) {
+          if (R == 1 && N == 1) runtime_assert(eqvec[R]->size() == 14);
+          if (R == 1 && N == 2) runtime_assert(eqvec[R]->size() == 45);
+          if (R == 2 && N == 2) runtime_assert(eqvec[R]->size() == 32);
+          if (R == 1 && N == 3) runtime_assert(eqvec[R]->size() == 83);
+          if (R == 2 && N == 3) runtime_assert(eqvec[R]->size() == 71);
+          if (R == 3 && N == 3) runtime_assert(eqvec[R]->size() == 32);
+          if (R == 1 && N == 4) runtime_assert(eqvec[R]->size() == 134);
         }
       } else {  // spin-free
         if (type == EqnType::t) {


### PR DESCRIPTION
- `mbpt::{sr,mr}::Operator` use `optype2label` for labels
- Added checks for λ residual number of terms  in `srcc`