### PR TITLE
inlclude boost numeric cast header.

### DIFF
--- a/SeQuant/core/rational.hpp
+++ b/SeQuant/core/rational.hpp
@@ -5,6 +5,7 @@
 #include <SeQuant/core/wstring.hpp>
 
 #include <boost/multiprecision/cpp_int.hpp>
+#include <boost/numeric/conversion/cast.hpp>
 
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
Required since Boost 1.85