### PR TITLE
Use a default-constructed IndexSpaceRegistry instead of nullptr

### DIFF
--- a/SeQuant/core/context.cpp
+++ b/SeQuant/core/context.cpp
@@ -97,7 +97,7 @@ Context::Context(IndexSpaceRegistry isr, Vacuum vac, IndexSpaceMetric m,
 
 Context::Context(Vacuum vac, IndexSpaceMetric m, BraKetSymmetry bks,
                  SPBasis spb, std::size_t fdio)
-    : idx_space_reg_{},
+    : idx_space_reg_(std::make_shared<IndexSpaceRegistry>()),
       vacuum_(vac),
       metric_(m),
       braket_symmetry_(bks),


### PR DESCRIPTION
The docs claim that this was already the case, but the implementation used a default constructed pointer (which is nullptr) instead of a pointer to a default-constructed registry.