### PR TITLE
Introduce a general operator

### DIFF
--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -341,6 +341,9 @@ std::wstring to_latex(const mbpt::Operator<mbpt::qns_t, S>& op) {
   if (it != label2optype.end()) {  // handle special cases
     optype = it->second;
     if (to_class(optype) == OpClass::gen) {
+      if (optype == OpType::θ) {  // special case for θ
+        result += L"_{" + std::to_wstring(op()[0].upper()) + L"}";
+      }
       result += L"}";
       return result;
     }
@@ -1061,7 +1064,7 @@ ExprPtr vac_av(ExprPtr expr, std::vector<std::pair<int, int>> nop_connections,
   wick.full_contractions(full_contractions);
   auto result = wick.compute();
   simplify(result);
-  // std::wcout << "post wick: " << to_latex_align(result,20,1) << std::endl;
+
   if (Logger::instance().wick_stats) {
     std::wcout << "WickTheorem stats: # of contractions attempted = "
                << wick.stats().num_attempted_contractions

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -11,22 +11,10 @@
 namespace sequant::mbpt {
 
 std::vector<std::wstring> cardinal_tensor_labels() {
-  return {L"κ",  L"γ",
-          L"Γ",  L"A",
-          L"S",  L"P",
-          L"L",  L"λ",
-          L"λ¹", L"h",
-          L"f",  L"f̃",
-          L"g",  L"θ",
-          L"t",  L"t¹",
-          L"R",  L"F",
-          L"X",  L"μ",
-          L"V",  L"Ṽ",
-          L"B",  L"U",
-          L"GR", L"C",
-          overlap_label(), L"a",
-          L"ã",  L"b",
-          L"b̃",  L"E"};
+  return {L"κ", L"γ", L"Γ", L"A", L"S", L"P", L"L",  L"λ", L"λ¹",
+          L"h", L"f", L"f̃", L"g", L"θ", L"t", L"t¹", L"R", L"F",
+          L"X", L"μ", L"V", L"Ṽ", L"B", L"U", L"GR", L"C", overlap_label(),
+          L"a", L"ã", L"b", L"b̃", L"E"};
 }
 
 std::wstring to_wstring(OpType op) {

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -17,16 +17,16 @@ std::vector<std::wstring> cardinal_tensor_labels() {
           L"L",  L"λ",
           L"λ¹", L"h",
           L"f",  L"f̃",
-          L"g",  L"t",
-          L"t¹", L"R",
-          L"F",  L"X",
-          L"μ",  L"V",
-          L"Ṽ",  L"B",
-          L"U",  L"GR",
-          L"C",  overlap_label(),
-          L"a",  L"ã",
-          L"b",  L"b̃",
-          L"E"};
+          L"g",  L"θ",
+          L"t",  L"t¹",
+          L"R",  L"F",
+          L"X",  L"μ",
+          L"V",  L"Ṽ",
+          L"B",  L"U",
+          L"GR", L"C",
+          overlap_label(), L"a",
+          L"ã",  L"b",
+          L"b̃",  L"E"};
 }
 
 std::wstring to_wstring(OpType op) {
@@ -49,6 +49,7 @@ OpClass to_class(OpType op) {
     case OpType::A:
     case OpType::S:
     case OpType::h_1:
+    case OpType::θ:
       return OpClass::gen;
     case OpType::t:
     case OpType::R:
@@ -560,6 +561,10 @@ ExprPtr F(bool use_tensor, IndexSpace reference_occupied) {
   }
 }
 
+ExprPtr θ(std::size_t K) {
+  return OpMaker<Statistics::FermiDirac>(OpType::θ, K)();
+}
+
 ExprPtr T_(std::size_t K) {
   return OpMaker<Statistics::FermiDirac>(OpType::t, K)();
 }
@@ -753,6 +758,16 @@ ExprPtr H_(std::size_t k) {
 ExprPtr H(std::size_t k) {
   assert(k > 0 && k <= 2);
   return k == 1 ? H_(1) : H_(1) + H_(2);
+}
+
+ExprPtr θ(std::size_t K) {
+  assert(K > 0);
+  return ex<op_t>([]() -> std::wstring_view { return L"θ"; },
+                  [=]() -> ExprPtr { return tensor::θ(K); },
+                  [=](qnc_t& qns) {
+                    qnc_t op_qnc_t = general_type_qns(K);
+                    qns = combine(op_qnc_t, qns);
+                  });
 }
 
 ExprPtr T_(std::size_t K) {

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -74,6 +74,7 @@ enum class OpType {
   f,    //!< Fock operator
   f̃,    //!< closed Fock operator (i.e. Fock operator due to fully-occupied
         //!< orbitals)
+  θ,    //!< general fock space operator
   g,    //!< 2-body Coulomb
   t,    //!< cluster amplitudes
   λ,    //!< deexcitation cluster amplitudes
@@ -99,6 +100,7 @@ inline const std::map<OpType, std::wstring> optype2label{
     {OpType::f, L"f"},
     {OpType::f̃, L"f̃"},
     {OpType::g, L"g"},
+    {OpType::θ, L"θ"},
     {OpType::t, L"t"},
     {OpType::λ, L"λ"},
     {OpType::A, L"A"},
@@ -787,6 +789,9 @@ ExprPtr H(std::size_t k = 2);
 /// orbitals which may have non-zero density.
 ExprPtr F(bool use_tensor = true, IndexSpace reference_occupied = {L"", 0});
 
+/// A general operator of rank \p K
+ExprPtr θ(std::size_t K);
+
 /// Makes particle-conserving excitation operator of rank \p K based on the
 /// defined context
 ExprPtr T_(std::size_t K);
@@ -913,6 +918,9 @@ ExprPtr H(std::size_t k = 2);
 /// construction requires user to specify the IndexSpace corresponding to all
 /// orbitals which may have non-zero density.
 ExprPtr F(bool use_tensor = true, IndexSpace reference_occupied = {L"", 0});
+
+/// A general operator of rank \p K
+ExprPtr θ(std::size_t K);
 
 /// Makes particle-conserving excitation operator of rank \p K
 ExprPtr T_(std::size_t K);

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -161,7 +161,9 @@ TEST_CASE("NBodyOp", "[mbpt]") {
     auto lambda2 = Λ_(2);
     auto r_2_1 = R_(nₚ(1), nₕ(2));
     auto r_1_2 = R_(nₚ(2), nₕ(1));
+    auto theta2 = θ(2);
 
+    REQUIRE(to_latex(theta2) == L"{\\hat{\\theta}_{2}}");
     REQUIRE(to_latex(f) == L"{\\hat{f}}");
     REQUIRE(to_latex(t1) == L"{\\hat{t}_{1}}");
     REQUIRE(to_latex(t2) == L"{\\hat{t}_{2}}");
@@ -290,6 +292,11 @@ TEST_CASE("NBodyOp", "[mbpt]") {
 
   SECTION("operators") {
     using namespace sequant::mbpt;
+
+    auto theta1 = θ(1)->as<op_t>();
+    // std::wcout << "theta1: " << to_latex(simplify(theta1.tensor_form()));
+    REQUIRE(to_latex(simplify(theta1.tensor_form())) ==
+            L"{{\\theta^{{p_1}}_{{p_2}}}{\\tilde{a}^{{p_2}}_{{p_1}}}}");
 
     auto R_2 = R_(2)->as<op_t>();
     //    std::wcout << "R_2: " << to_latex(simplify(R_2.tensor_form())) <<


### PR DESCRIPTION
#### Introduces a general operator with a non-reserved label. Useful in LR-CC calculations.
I used $\theta$ for the label, other suggestions are welcome. 

- Minor change to `to_latex()` behaviour for Operator class: `to_latex(θ(1))` will produce $\theta_{1}$ instead of just $\theta$
- Unit tests