### PR TITLE
Support evaluation of non-particle-conserving tensors

### DIFF
--- a/SeQuant/core/eval_expr.cpp
+++ b/SeQuant/core/eval_expr.cpp
@@ -263,35 +263,30 @@ target_braket(Tensor const& t1, Tensor const& t2) noexcept {
   using ranges::views::filter;
   using idx_container = container::svector<Index>;
 
-  const auto left_bra = t1.bra() | ranges::to_vector;
-  const auto left_ket = t1.ket() | ranges::to_vector;
-  const auto right_bra = t2.bra() | ranges::to_vector;
-  const auto right_ket = t2.ket() | ranges::to_vector;
-
   // find contracted indices
   const auto contracted_indices =
-      concat(left_bra | filter([&](const auto& idx) {
-               return contains(right_ket, idx);
+      concat(t1.bra() | filter([&](const auto& idx) {
+               return contains(t2.ket(), idx);
              }),
-             left_ket | filter([&](const auto& idx) {
-               return contains(right_bra, idx);
+             t1.ket() | filter([&](const auto& idx) {
+               return contains(t2.bra(), idx);
              })) |
-      ranges::to_vector;
+      ranges::to<idx_container>();
 
   // combine free bra indices
-  const auto result_bra = concat(left_bra | filter([&](const auto& idx) {
+  const auto result_bra = concat(t1.bra() | filter([&](const auto& idx) {
                                    return !contains(contracted_indices, idx);
                                  }),
-                                 right_bra | filter([&](const auto& idx) {
+                                 t2.bra() | filter([&](const auto& idx) {
                                    return !contains(contracted_indices, idx);
                                  })) |
                           ranges::to<idx_container>();
 
   // combine free ket indices
-  const auto result_ket = concat(left_ket | filter([&](const auto& idx) {
+  const auto result_ket = concat(t1.ket() | filter([&](const auto& idx) {
                                    return !contains(contracted_indices, idx);
                                  }),
-                                 right_ket | filter([&](const auto& idx) {
+                                 t2.ket() | filter([&](const auto& idx) {
                                    return !contains(contracted_indices, idx);
                                  })) |
                           ranges::to<idx_container>();

--- a/SeQuant/core/eval_expr.cpp
+++ b/SeQuant/core/eval_expr.cpp
@@ -258,48 +258,45 @@ std::pair<container::svector<Index>,  // bra
           container::svector<Index>   // ket
           >
 target_braket(Tensor const& t1, Tensor const& t2) noexcept {
-  using ranges::views::keys;
-  using ranges::views::values;
-  using ranges::views::zip;
-  using index_container = container::svector<Index>;
+  using ranges::contains;
+  using ranges::views::concat;
+  using ranges::views::filter;
+  using idx_container = container::svector<Index>;
 
-  auto remove_item = [](auto& vec, size_t pos) -> void {
-    std::swap(vec[pos], vec.back());
-    vec.pop_back();
-  };
+  const auto left_bra = t1.bra() | ranges::to_vector;
+  const auto left_ket = t1.ket() | ranges::to_vector;
+  const auto right_bra = t2.bra() | ranges::to_vector;
+  const auto right_ket = t2.ket() | ranges::to_vector;
 
-  auto left = zip(t1.bra(), t1.ket()) | ranges::to_vector;
-  auto right = zip(t2.bra(), t2.ket()) | ranges::to_vector;
+  // find contracted indices
+  const auto contracted_indices =
+      concat(left_bra | filter([&](const auto& idx) {
+               return contains(right_ket, idx);
+             }),
+             left_ket | filter([&](const auto& idx) {
+               return contains(right_bra, idx);
+             })) |
+      ranges::to_vector;
 
-  while (!right.empty()) {
-    for (std::size_t rr = 0; rr < right.size(); ++rr) {
-      auto& [rb, rk] = right[rr];
-      for (std::size_t ll = 0; ll < left.size(); ++ll) {
-        auto& [lb, lk] = left[ll];
-        if (lb == rk && rb == lk) {
-          remove_item(left, ll);
-          remove_item(right, rr);
-          goto next_contract;
-        } else if (lb == rk) {
-          std::swap(lk, rk);
-          remove_item(left, ll);
-          goto next_contract;
-        } else if (lk == rb) {
-          std::swap(lb, rb);
-          remove_item(left, ll);
-          goto next_contract;
-        }
-      }  // ll
-      left.emplace_back(rb, rk);
-      remove_item(right, rr);
-    }  // rr
-  next_contract:
-      /* just point to the start of the while loop */;
-  }
-  // the result is now in left
+  // combine free bra indices
+  const auto result_bra = concat(left_bra | filter([&](const auto& idx) {
+                                   return !contains(contracted_indices, idx);
+                                 }),
+                                 right_bra | filter([&](const auto& idx) {
+                                   return !contains(contracted_indices, idx);
+                                 })) |
+                          ranges::to<idx_container>();
 
-  return {keys(left) | ranges::to<index_container>,
-          values(left) | ranges::to<index_container>};
+  // combine free ket indices
+  const auto result_ket = concat(left_ket | filter([&](const auto& idx) {
+                                   return !contains(contracted_indices, idx);
+                                 }),
+                                 right_ket | filter([&](const auto& idx) {
+                                   return !contains(contracted_indices, idx);
+                                 })) |
+                          ranges::to<idx_container>();
+
+  return std::make_pair(result_bra, result_ket);
 }
 
 Symmetry tensor_symmetry_sum(EvalExpr const& left,

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -310,6 +310,22 @@ TEST_CASE("TEST_EVAL_USING_TA", "[eval]") {
                                yield(L"t{a1,a3;i3,i4}")("a1,a3,i3,i4");
 
     REQUIRE(norm(prod2_man) == Catch::Approx(norm(prod2_eval)));
+
+    auto expr3 = sequant::parse_expr(L"R_{a1}^{i1,i3} * f_{i3}^{i2}");
+    auto prod3_eval = eval(expr3, "a_1,i_1,i_2");
+    auto prod3_man = TArrayD{};
+    prod3_man("a1,i1,i2") =
+        yield(L"R{a1;i1,i3}")("a1,i1,i3") * yield(L"f{i3;i2}")("i3,i2");
+    REQUIRE(norm(prod3_man) == Catch::Approx(norm(prod3_eval)));
+
+    auto expr4 =
+        sequant::parse_expr(L"1/4 * R_{a1,a2,a3}^{i2,i3} * g_{i2,i3}^{i1,a3}");
+    auto prod4_eval = eval(expr4, "i_1,a_1,a_2");
+    auto prod4_man = TArrayD{};
+    prod4_man("i1,a1,a2") = 1 / 4.0 *
+                            yield(L"R{a1,a2,a3;i2,i3}")("a1,a2,a3,i2,i3") *
+                            yield(L"g{i2,i3;i1,a3}")("i2,i3,i1,a3");
+    REQUIRE(norm(prod4_man) == Catch::Approx(norm(prod4_eval)));
   }
 
   SECTION("sum and product") {
@@ -328,6 +344,19 @@ TEST_CASE("TEST_EVAL_USING_TA", "[eval]") {
                               yield(L"t{a3,a4;i1,i2}")("a3,a4,i1,i2");
 
     REQUIRE(norm(man1) == Catch::Approx(norm(eval1)));
+
+    auto expr2 = sequant::parse_expr(
+        L"1/4 * R_{a1,a2,a3}^{i2,i3} * g_{i2,i3}^{i1,a3} + R_{a1,a3}^{i1} * "
+        L"f_{i2}^{a3} * t_{a2}^{i2}");
+    auto eval2 = eval(expr2, "i_1,a_1,a_2");
+
+    auto man2 = TArrayD{};
+    man2("i1,a1,a2") = 1 / 4.0 * yield(L"R{a1,a2,a3;i2,i3}")("a1,a2,a3,i2,i3") *
+                           yield(L"g{i2,i3;i1,a3}")("i2,i3,i1,a3") +
+                       yield(L"R{a1,a3;i1}")("a1,a3,i1") *
+                           yield(L"f{i2;a3}")("i2,a3") *
+                           yield(L"t{a2;i2}")("a2,i2");
+    REQUIRE(norm(man2) == Catch::Approx(norm(eval2)));
   }
 
   SECTION("variable at leaves") {
@@ -533,6 +562,22 @@ TEST_CASE("TEST_EVAL_USING_TA_COMPLEX", "[eval]") {
                                yield(L"t{a1,a3;i3,i4}")("a1,a3,i3,i4");
 
     REQUIRE(norm(prod2_man) == Catch::Approx(norm(prod2_eval)));
+
+    auto expr3 = sequant::parse_expr(L"R_{a1}^{i1,i3} * f_{i3}^{i2}");
+    auto prod3_eval = eval(expr3, "a_1,i_1,i_2");
+    auto prod3_man = TArrayC{};
+    prod3_man("a1,i1,i2") =
+        yield(L"R{a1;i1,i3}")("a1,i1,i3") * yield(L"f{i3;i2}")("i3,i2");
+    REQUIRE(norm(prod3_man) == Catch::Approx(norm(prod3_eval)));
+
+    auto expr4 =
+        sequant::parse_expr(L"1/4 * R_{a1,a2,a3}^{i2,i3} * g_{i2,i3}^{i1,a3}");
+    auto prod4_eval = eval(expr4, "i_1,a_1,a_2");
+    auto prod4_man = TArrayC{};
+    prod4_man("i1,a1,a2") = 1 / 4.0 *
+                            yield(L"R{a1,a2,a3;i2,i3}")("a1,a2,a3,i2,i3") *
+                            yield(L"g{i2,i3;i1,a3}")("i2,i3,i1,a3");
+    REQUIRE(norm(prod4_man) == Catch::Approx(norm(prod4_eval)));
   }
 
   SECTION("sum and product") {
@@ -553,6 +598,19 @@ TEST_CASE("TEST_EVAL_USING_TA_COMPLEX", "[eval]") {
                               yield(L"t{a3,a4;i1,i2}")("a3,a4,i1,i2");
 
     REQUIRE(norm(man1) == Catch::Approx(norm(eval1)));
+
+    auto expr2 = sequant::parse_expr(
+        L"1/4 * R_{a1,a2,a3}^{i2,i3} * g_{i2,i3}^{i1,a3} + R_{a1,a3}^{i1} * "
+        L"f_{i2}^{a3} * t_{a2}^{i2}");
+    auto eval2 = eval(expr2, "i_1,a_1,a_2");
+
+    auto man2 = TArrayC{};
+    man2("i1,a1,a2") = 1 / 4.0 * yield(L"R{a1,a2,a3;i2,i3}")("a1,a2,a3,i2,i3") *
+                           yield(L"g{i2,i3;i1,a3}")("i2,i3,i1,a3") +
+                       yield(L"R{a1,a3;i1}")("a1,a3,i1") *
+                           yield(L"f{i2;a3}")("i2,a3") *
+                           yield(L"t{a2;i2}")("a2,i2");
+    REQUIRE(norm(man2) == Catch::Approx(norm(eval2)));
   }
 
   SECTION("Antisymmetrization") {


### PR DESCRIPTION
Support for evaluating EOM IP/EA like expressions. Refactors the logic in `target_braket` and new evaluation unit tests. 