### PR TITLE
[CI] Cancel duplicate workflows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,6 +2,10 @@ name: Linux/MacOS Build
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master'}} # don't cancel jobs on master
+
 #env:
 
 jobs:


### PR DESCRIPTION
If a branch is updated, cancel in-progress workflows. 

See GitHub's [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-using-concurrency-and-the-default-behavior)