### PR TITLE
Bugfix in `evaluate()`

### DIFF
--- a/SeQuant/domain/eval/eval.hpp
+++ b/SeQuant/domain/eval/eval.hpp
@@ -384,7 +384,6 @@ auto evaluate(NodesT const& nodes, Le const& le, Args&&... args) {
 #else
     result->add_inplace(*right);
 #endif
-    result->add_inplace(*right);
   }
 
   return result;


### PR DESCRIPTION
Fixes the issue reported in https://github.com/ValeevGroup/mpqc4/pull/521. Removes the extra `add_inplace()` call in `sequant::evaluate()`