### PR TITLE
Make TensorBlockIndexComparer compare tensor blocks (slots) again

### DIFF
--- a/SeQuant/core/tensor_canonicalizer.cpp
+++ b/SeQuant/core/tensor_canonicalizer.cpp
@@ -49,20 +49,80 @@ struct TensorBlockIndexComparer {
       static_assert(std::is_same_v<std::decay_t<decltype(rhs_second)>, Index>,
                     "TensorBlockIndexComparer can only work with indices");
 
-      int res = lhs_first < rhs_first ? -1 : (rhs_first < lhs_first ? 1 : 0);
+      // First compare only index spaces of equivalent pairs
+      int res = compare_spaces(lhs_first, rhs_first);
       if (res != 0) {
         return res;
       }
 
-      res = lhs_second < rhs_second ? -1 : (rhs_second < lhs_second ? 1 : 0);
+      res = compare_spaces(lhs_second, rhs_second);
+      if (res != 0) {
+        return res;
+      }
+
+      // Then consider tags of equivalent pairs
+      res = compare_tags(lhs_first, rhs_first);
+      if (res != 0) {
+        return res;
+      }
+
+      res = compare_tags(lhs_second, rhs_second);
       return res;
     } else {
       static_assert(std::is_same_v<std::decay_t<T>, Index>,
                     "TensorBlockIndexComparer can only work with indices");
 
-      int res = lhs < rhs ? -1 : (rhs < lhs ? 1 : 0);
+      int res = compare_spaces(lhs, rhs);
+      if (res != 0) {
+        return res;
+      }
+
+      res = compare_tags(lhs, rhs);
       return res;
     }
+  }
+
+  int compare_spaces(const Index& lhs, const Index& rhs) const {
+    if (lhs.space() != rhs.space()) {
+      return lhs.space() < rhs.space() ? -1 : 1;
+    }
+
+    if (lhs.has_proto_indices() != rhs.has_proto_indices()) {
+      return lhs.has_proto_indices() ? -1 : 1;
+    }
+
+    if (lhs.proto_indices().size() != rhs.proto_indices().size()) {
+      return lhs.proto_indices().size() < rhs.proto_indices().size() ? -1 : 1;
+    }
+
+    for (std::size_t i = 0; i < lhs.proto_indices().size(); ++i) {
+      const auto& lhs_proto = lhs.proto_indices()[i];
+      const auto& rhs_proto = rhs.proto_indices()[i];
+
+      int res = compare_spaces(lhs_proto, rhs_proto);
+      if (res != 0) {
+        return res;
+      }
+    }
+
+    // Index spaces are equal
+    return 0;
+  }
+
+  int compare_tags(const Index& lhs, const Index& rhs) const {
+    if (!lhs.tag().has_value() || !rhs.tag().has_value()) {
+      // We only compare tags if both indices have a tag
+      return 0;
+    }
+
+    const int lhs_tag = lhs.tag().value<int>();
+    const int rhs_tag = rhs.tag().value<int>();
+
+    if (lhs_tag != rhs_tag) {
+      return lhs_tag < rhs_tag ? -1 : 1;
+    }
+
+    return 0;
   }
 };
 

--- a/tests/unit/test_spin.cpp
+++ b/tests/unit/test_spin.cpp
@@ -756,15 +756,15 @@ SECTION("Closed-shell spintrace CCSD") {
 
     REQUIRE(
         to_latex(result) ==
-        L"{ \\bigl( - {{g^{{a_2}{i_1}}_{{a_1}{i_2}}}{t^{{i_2}}_{{a_2}}}} + "
-        L"{{{2}}{g^{{i_1}{a_2}}_{{a_1}{i_2}}}{t^{{i_2}}_{{a_2}}}}\\bigr) }");
+        L"{ \\bigl( - {{g^{{i_1}{a_2}}_{{i_2}{a_1}}}{t^{{i_2}}_{{a_2}}}} + "
+        L"{{{2}}{g^{{a_2}{i_1}}_{{i_2}{a_1}}}{t^{{i_2}}_{{a_2}}}}\\bigr) }");
     container::map<Index, Index> idxmap = {{Index{L"i_1"}, Index{L"i_2"}},
                                            {Index{L"i_2"}, Index{L"i_1"}}};
     auto transformed_result = transform_expr(result, idxmap);
     REQUIRE(
         to_latex(transformed_result) ==
-        L"{ \\bigl( - {{g^{{a_2}{i_2}}_{{a_1}{i_1}}}{t^{{i_1}}_{{a_2}}}} + "
-        L"{{{2}}{g^{{i_2}{a_2}}_{{a_1}{i_1}}}{t^{{i_1}}_{{a_2}}}}\\bigr) }");
+        L"{ \\bigl( - {{g^{{i_2}{a_2}}_{{i_1}{a_1}}}{t^{{i_1}}_{{a_2}}}} + "
+        L"{{{2}}{g^{{a_2}{i_2}}_{{i_1}{a_1}}}{t^{{i_1}}_{{a_2}}}}\\bigr) }");
   }
 
   {
@@ -1295,14 +1295,13 @@ SECTION("Open-shell spin-tracing") {
     REQUIRE(result.size() == 3);
     REQUIRE(
         toUtf8(to_latex(result[0])) ==
-        toUtf8(
-            L"{{{-\\frac{1}{2}}}{\\bar{g}^{{i↑_1}{i↑_2}}_{{a↑_1}{i↑_3}}}{t^{{"
-            L"i↑_3}}_{{a↑_2}}}}"));
+        toUtf8(L"{{{\\frac{1}{2}}}{\\bar{g}^{{i↑_1}{i↑_2}}_{{i↑_3}{a↑_1}}}{t^{{"
+               L"i↑_3}}_{{a↑_2}}}}"));
     REQUIRE(to_latex(result[1]) ==
             L"{{{-\\frac{1}{2}}}{g^{{i↑_1}{i↓_2}}_{{a↑_1}{i↓_1}}}{t^{{i↓_1}}_"
             L"{{a↓_2}}}}");
     REQUIRE(to_latex(result[2]) ==
-            L"{{{-\\frac{1}{2}}}{\\bar{g}^{{i↓_1}{i↓_2}}_{{a↓_1}{i↓_3}}}{t^{{"
+            L"{{{\\frac{1}{2}}}{\\bar{g}^{{i↓_1}{i↓_2}}_{{i↓_3}{a↓_1}}}{t^{{"
             L"i↓_3}}_{{a↓_2}}}}");
   }
 

--- a/tests/unit/test_tensor_network.cpp
+++ b/tests/unit/test_tensor_network.cpp
@@ -915,7 +915,7 @@ TEST_CASE("TensorNetworkV2", "[elements]") {
           {L"g{i_1,a_1;i_2,i_3}:N * I{i_2,i_3;i_1,a_1}:N",
            L"g{i_1,a_1;i_2,i_3}:N * I{i_2,i_3;i_1,a_1}:N"},
           {L"g{a_1,i_1;i_2,i_3}:N * I{i_2,i_3;i_1,a_1}:N",
-           L"g{i_1,a_1;i_2,i_3}:N * I{i_2,i_3;a_1,i_1}:N"},
+           L"g{i_1,a_1;i_2,i_3}:N * I{i_3,i_2;i_1,a_1}:N"},
       };
 
       for (const auto& [input, expected] : inputs) {


### PR DESCRIPTION
This reverts commit ba832da3054fc181fee88d7c45f627a5ea9f1ae7.

The reason being that Index::operator< is NOT the right way to compare indices in this context. If we also account for index labels (instead of only their space), we are comparing full indexed tensor elements rather than tensor blocks (slots) as this class is supposed to do.

In order for test cases to work with this re-introduced change, this commit also reverts
"amend tests for ba832da3054fc181fee88d7c45f627a5ea9f1ae7" (commit 4a9543851105e2bae0939495986351fe74930d70)

Finally, a hand full of additional test cases had to be adapted to the changed canonicalization routine.