### PR TITLE
Get rid of grand_index_list_ member variable

### DIFF
--- a/SeQuant/core/tensor_network.cpp
+++ b/SeQuant/core/tensor_network.cpp
@@ -16,6 +16,7 @@
 #include <SeQuant/core/tag.hpp>
 #include <SeQuant/core/tensor_network.hpp>
 #include <SeQuant/core/tensor_network/vertex_painter.hpp>
+#include <SeQuant/core/tensor_network_v2.hpp>
 #include <SeQuant/core/utility/tuple.hpp>
 #include <SeQuant/core/wstring.hpp>
 
@@ -33,10 +34,6 @@
 #include <range/v3/view/view.hpp>
 
 namespace sequant {
-
-auto edge2index(const TensorNetwork::Edge &e) -> const Index & {
-  return e.idx();
-};
 
 ExprPtr TensorNetwork::canonicalize(
     const container::vector<std::wstring> &cardinal_tensor_labels, bool fast,
@@ -905,7 +902,8 @@ TensorNetwork::SlotCanonicalizationMetadata TensorNetwork::canonicalize_slots(
     using cord_set_t = container::set<ord_cord_it_t, detail::tuple_less<1>>;
 
     auto grand_index_list = ranges::views::concat(
-        edges_ | ranges::views::transform(edge2index), pure_proto_indices_);
+        edges_ | ranges::views::transform(edge2index<Edge>),
+        pure_proto_indices_);
 
     // for each named index type (as defined by named_index_compare) maps its
     // ptr in grand_index_list to its ordinal in grand_index_list + canonical

--- a/SeQuant/core/tensor_network.cpp
+++ b/SeQuant/core/tensor_network.cpp
@@ -34,6 +34,10 @@
 
 namespace sequant {
 
+auto edge2index(const TensorNetwork::Edge &e) -> const Index & {
+  return e.idx();
+};
+
 ExprPtr TensorNetwork::canonicalize(
     const container::vector<std::wstring> &cardinal_tensor_labels, bool fast,
     const named_indices_t *named_indices_ptr) {
@@ -248,15 +252,15 @@ ExprPtr TensorNetwork::canonicalize(
           // order
           std::size_t ord = 0;
           for (auto &&[idx_ord, idx_ord_can] : idx_can) {
-            const auto &idx = *(grand_index_list_.begin() + idx_ord);
+            const auto &idx = (edges_.begin() + idx_ord)->idx();
             const auto new_idx = idxfac.make(idx);
             if (idx != new_idx) idxrepl.emplace(idx, std::move(new_idx));
             ++ord;
           }
         } else if (sz == 1) {  // no need for resorting of colors with 1 index
                                // only, but still need to replace the index
-          const auto it = grand_index_list_.begin() + std::get<0>(beg->second);
-          const auto &idx = *it;
+          const auto it = edges_.begin() + std::get<0>(beg->second);
+          const auto &idx = it->idx();
           const auto new_idx = idxfac.make(idx);
           if (idx != new_idx) idxrepl.emplace(idx, std::move(new_idx));
         }
@@ -473,7 +477,7 @@ TensorNetwork::make_bliss_graph(const named_indices_t *named_indices_ptr,
       nidx;  // where spbundle vertices will start
 
   // iterates over edges_, then pure_proto_indices_, this is equivalent to
-  // iteration over grand_index_list_
+  // iteration over grand_index_list
   ranges::for_each(edges_, [&](const Edge &edge) {
     const Index &idx = edge.idx();
     ++nv;  // each index is a vertex
@@ -818,9 +822,6 @@ void TensorNetwork::init_edges() const {
   ext_indices_.reserve(ext_indices_.size() + pure_proto_indices_.size());
   ext_indices_.insert(pure_proto_indices_.begin(), pure_proto_indices_.end());
 
-  grand_index_list_ = ranges::views::concat(
-      edges_ | ranges::views::transform(edge2index_), pure_proto_indices_);
-
   have_edges_ = true;
 }
 
@@ -903,16 +904,19 @@ TensorNetwork::SlotCanonicalizationMetadata TensorNetwork::canonicalize_slots(
         std::tuple<size_t, size_t, named_indices_t::const_iterator>;
     using cord_set_t = container::set<ord_cord_it_t, detail::tuple_less<1>>;
 
+    auto grand_index_list = ranges::views::concat(
+        edges_ | ranges::views::transform(edge2index), pure_proto_indices_);
+
     // for each named index type (as defined by named_index_compare) maps its
-    // ptr in grand_index_list_ to its ordinal in grand_index_list_ + canonical
+    // ptr in grand_index_list to its ordinal in grand_index_list + canonical
     // ordinal + its iterator in metadata.named_indices
     container::map<std::pair<const Index *, IndexSlotType>, cord_set_t,
                    decltype(named_index_compare)>
         idx2cord(named_index_compare);
     // collect named indices and sort on the fly
     size_t idx_ord = 0;
-    auto grand_index_list_end = grand_index_list_.end();
-    for (auto git = grand_index_list_.begin(); git != grand_index_list_end;
+    auto grand_index_list_end = grand_index_list.end();
+    for (auto git = grand_index_list.begin(); git != grand_index_list_end;
          ++git) {
       const auto &idx = *git;
       if (is_named_index(idx)) {

--- a/SeQuant/core/tensor_network.hpp
+++ b/SeQuant/core/tensor_network.hpp
@@ -201,10 +201,6 @@ class TensorNetwork {
     static inline Terminal null_terminal_ = {};
   };
 
-  static inline auto edge2index_ = [](const Edge &e) -> const Index & {
-    return e.idx();
-  };
-
  public:
   /// @throw std::logic_error if exprptr_range contains a non-tensor
   /// @note uses RTTI
@@ -356,12 +352,6 @@ class TensorNetwork {
   /// @note these will need to be processed separately from the rest
   /// to appear as vertices on the graph
   mutable named_indices_t pure_proto_indices_;
-  /// grand list of all indices is view of concatenated ranges of indices in
-  /// edges_ and pure_proto_indices_
-  mutable ranges::concat_view<
-      ranges::transform_view<ranges::ref_view<edges_t>, decltype(edge2index_)>,
-      ranges::ref_view<named_indices_t>>
-      grand_index_list_;
 
   // replacements of anonymous indices produced by the last call to
   // canonicalize()

--- a/SeQuant/core/tensor_network_v2.cpp
+++ b/SeQuant/core/tensor_network_v2.cpp
@@ -39,10 +39,6 @@
 
 namespace sequant {
 
-auto edge2index(const TensorNetworkV2::Edge &e) -> const Index & {
-  return e.idx();
-};
-
 struct FullLabelIndexLocator {
   std::wstring_view label;
   FullLabelIndexLocator(std::wstring_view label) : label(std::move(label)) {}
@@ -756,7 +752,8 @@ TensorNetworkV2::canonicalize_slots(
     using cord_set_t = container::set<ord_cord_it_t, detail::tuple_less<1>>;
 
     auto grand_index_list = ranges::views::concat(
-        edges_ | ranges::views::transform(edge2index), pure_proto_indices_);
+        edges_ | ranges::views::transform(edge2index<Edge>),
+        pure_proto_indices_);
 
     // for each named index type (as defined by named_index_compare) maps its
     // ptr in grand_index_list to its ordinal in grand_index_list + canonical

--- a/SeQuant/core/tensor_network_v2.cpp
+++ b/SeQuant/core/tensor_network_v2.cpp
@@ -39,6 +39,10 @@
 
 namespace sequant {
 
+auto edge2index(const TensorNetworkV2::Edge &e) -> const Index & {
+  return e.idx();
+};
+
 struct FullLabelIndexLocator {
   std::wstring_view label;
   FullLabelIndexLocator(std::wstring_view label) : label(std::move(label)) {}
@@ -751,8 +755,11 @@ TensorNetworkV2::canonicalize_slots(
         std::tuple<size_t, size_t, NamedIndexSet::const_iterator>;
     using cord_set_t = container::set<ord_cord_it_t, detail::tuple_less<1>>;
 
+    auto grand_index_list = ranges::views::concat(
+        edges_ | ranges::views::transform(edge2index), pure_proto_indices_);
+
     // for each named index type (as defined by named_index_compare) maps its
-    // ptr in grand_index_list_ to its ordinal in grand_index_list_ + canonical
+    // ptr in grand_index_list to its ordinal in grand_index_list + canonical
     // ordinal + its iterator in metadata.named_indices
     container::map<std::pair<const Index *, IndexSlotType>, cord_set_t,
                    decltype(named_index_compare)>
@@ -760,8 +767,8 @@ TensorNetworkV2::canonicalize_slots(
 
     // collect named indices and sort them on the fly
     size_t idx_ord = 0;
-    auto grand_index_list_end = grand_index_list_.end();
-    for (auto git = grand_index_list_.begin(); git != grand_index_list_end;
+    auto grand_index_list_end = grand_index_list.end();
+    for (auto git = grand_index_list.begin(); git != grand_index_list_end;
          ++git) {
       const auto &idx = *git;
 
@@ -781,8 +788,10 @@ TensorNetworkV2::canonicalize_slots(
             slot_type = IndexSlotType::TensorAux;
           else if (edge_it->first_vertex().getOrigin() == Origin::Bra)
             slot_type = IndexSlotType::TensorBra;
-          else  // edge_it->first_vertex().getOrigin() == Origin::Ket
+          else {
+            assert(edge_it->first_vertex().getOrigin() == Origin::Ket);
             slot_type = IndexSlotType::TensorKet;
+          }
         } else
           slot_type = IndexSlotType::SPBundle;
         const auto idxptr_slottype = std::make_pair(&idx, slot_type);
@@ -1197,9 +1206,6 @@ void TensorNetworkV2::init_edges() {
   // ... and add pure protoindices to the external indices
   ext_indices_.reserve(ext_indices_.size() + pure_proto_indices_.size());
   ext_indices_.insert(pure_proto_indices_.begin(), pure_proto_indices_.end());
-
-  grand_index_list_ = ranges::views::concat(
-      edges_ | ranges::views::transform(edge2index_), pure_proto_indices_);
 
   have_edges_ = true;
 }

--- a/SeQuant/core/tensor_network_v2.hpp
+++ b/SeQuant/core/tensor_network_v2.hpp
@@ -416,6 +416,11 @@ std::basic_ostream<CharT, Traits> &operator<<(
   return stream;
 }
 
+template <typename Edge>
+auto edge2index(const Edge &e) -> const Index & {
+  return e.idx();
+}
+
 }  // namespace sequant
 
 #endif  // SEQUANT_TENSOR_NETWORK_H

--- a/SeQuant/core/tensor_network_v2.hpp
+++ b/SeQuant/core/tensor_network_v2.hpp
@@ -171,10 +171,6 @@ class TensorNetworkV2 {
     Index index;
   };
 
-  static inline auto edge2index_ = [](const Edge &e) -> const Index & {
-    return e.idx();
-  };
-
   struct Graph {
     /// The type used to encode the color of a vertex. The restriction of this
     /// being as 32-bit integer comes from how BLISS is trying to convert these
@@ -366,13 +362,6 @@ class TensorNetworkV2 {
   /// @note these will need to be processed separately from the rest
   /// to appear as vertices on the graph
   NamedIndexSet pure_proto_indices_;
-  /// grand list of all indices is view of concatenated ranges of indices in
-  /// edges_ and pure_proto_indices_
-  ranges::concat_view<
-      ranges::transform_view<ranges::ref_view<container::vector<Edge>>,
-                             decltype(edge2index_)>,
-      ranges::ref_view<NamedIndexSet>>
-      grand_index_list_;
 
   /// initializes edges_, ext_indices_, and pure_proto_indices_
   void init_edges();


### PR DESCRIPTION
The type of this member variable being the type that it was caused compiler warnings. Also, it turns out that there is no need for this index collection to be a member variable in the first place. It is only ever used very locally in the code. Hence, it has now been converted into a local variable instead. As a bonus, this gets rid of the compiler warning as the member variable it referred to no longer exists.

Note that not caching the index list should be fine as the functions it is being used in are almost never called repeatedly on the same TensorNetwork instance. Therefore, the caching benefit that the member variable provided is nullified.

Fixes #250