### PR TITLE
`TN::canonicalize_slots` produces phase associated with reordering antisymmetric bra/ket slots bundles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,7 @@ set(SeQuant_src
         SeQuant/core/utility/string.hpp
         SeQuant/core/utility/string.cpp
         SeQuant/core/utility/tuple.hpp
+        SeQuant/core/utility/swap.hpp
         SeQuant/core/wick.hpp
         SeQuant/core/wick.impl.hpp
         SeQuant/core/wolfram.hpp
@@ -415,7 +416,7 @@ if (SEQUANT_IWYU)
 endif()
 
 if (SEQUANT_BENCHMARKS)
-	add_subdirectory(benchmarks)
+    add_subdirectory(benchmarks)
 endif()
 
 ### unit tests

--- a/SeQuant/core/algorithm.hpp
+++ b/SeQuant/core/algorithm.hpp
@@ -22,8 +22,9 @@ using suitable_call_operator =
     decltype(std::declval<Callable>()(std::declval<Args>()...));
 
 /// @brief bubble sort that uses swap exclusively
-template <typename ForwardIter, typename Sentinel, typename Compare>
-void bubble_sort(ForwardIter begin, Sentinel end, Compare comp) {
+template <typename ForwardIter, typename Sentinel,
+          typename Compare = std::less<>>
+void bubble_sort(ForwardIter begin, Sentinel end, Compare comp = {}) {
   if (begin == end) return;  // no-op for empty range
   bool swapped;
   do {

--- a/SeQuant/core/eval_expr.cpp
+++ b/SeQuant/core/eval_expr.cpp
@@ -265,9 +265,9 @@ size_t hash_imed(EvalExpr const& left, EvalExpr const& right,
   return h;
 }
 
-std::pair<container::svector<Index>,  // bra
-          container::svector<Index>   // ket
-          >
+[[maybe_unused]] std::pair<container::svector<Index>,  // bra
+                           container::svector<Index>   // ket
+                           >
 target_braket(Tensor const& t1, Tensor const& t2) noexcept {
   using ranges::contains;
   using ranges::views::concat;

--- a/SeQuant/core/index.hpp
+++ b/SeQuant/core/index.hpp
@@ -6,14 +6,11 @@
 #define SEQUANT_INDEX_H
 
 #include <SeQuant/core/container.hpp>
-#include <SeQuant/core/hash.hpp>
-#include <iostream>
-// #include <SeQuant/core/space.hpp>
 #include <SeQuant/core/context.hpp>
+#include <SeQuant/core/hash.hpp>
 #include <SeQuant/core/tag.hpp>
 #include <SeQuant/core/utility/string.hpp>
-// Only needed due to a (likely) compiler bug in Apple Clang
-// #include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/utility/swap.hpp>
 
 #include <algorithm>
 #include <atomic>
@@ -23,6 +20,7 @@
 #include <cwchar>
 #include <functional>
 #include <initializer_list>
+#include <iostream>
 #include <iterator>
 #include <map>
 #include <mutex>
@@ -868,28 +866,10 @@ void Index::canonicalize_proto_indices() {
     std::stable_sort(begin(proto_indices_), end(proto_indices_));
 }
 
-class IndexSwapper {
- public:
-  IndexSwapper() : even_num_of_swaps_(true) {}
-  static IndexSwapper &thread_instance() {
-    static thread_local IndexSwapper instance_{};
-    return instance_;
-  }
-
-  bool even_num_of_swaps() const { return even_num_of_swaps_; }
-  void reset() { even_num_of_swaps_ = true; }
-
- private:
-  std::atomic<bool> even_num_of_swaps_;
-  void toggle() { even_num_of_swaps_ = !even_num_of_swaps_; }
-
-  friend inline void swap(Index &, Index &);
-};
-
 /// swap operator helps tracking # of swaps
 inline void swap(Index &first, Index &second) {
   std::swap(first, second);
-  IndexSwapper::thread_instance().toggle();
+  detail::count_swap<Index>();
 }
 
 /// Generates temporary indices

--- a/SeQuant/core/tensor_canonicalizer.hpp
+++ b/SeQuant/core/tensor_canonicalizer.hpp
@@ -184,14 +184,13 @@ class DefaultTensorCanonicalizer : public TensorCanonicalizer {
         auto _bra = bra_range(t);
         auto _ket = ket_range(t);
         //      std::wcout << "canonicalizing " << to_latex(t);
-        IndexSwapper::thread_instance().reset();
+        reset_ts_swap_counter<Index>();
         // std::{stable_}sort does not necessarily use swap! so must implement
         // sort outselves .. thankfully ranks will be low so can stick with
         // bubble
         bubble_sort(begin(_bra), end(_bra), idxcmp);
         bubble_sort(begin(_ket), end(_ket), idxcmp);
-        if (is_antisymm)
-          even = IndexSwapper::thread_instance().even_num_of_swaps();
+        if (is_antisymm) even = ts_swap_counter_is_even<Index>();
         //      std::wcout << " is " << (even ? "even" : "odd") << " and
         //      produces " << to_latex(t) << std::endl;
       } break;

--- a/SeQuant/core/tensor_network.cpp
+++ b/SeQuant/core/tensor_network.cpp
@@ -14,6 +14,7 @@
 #include <SeQuant/core/latex.hpp>
 #include <SeQuant/core/logger.hpp>
 #include <SeQuant/core/tag.hpp>
+#include <SeQuant/core/tensor.hpp>
 #include <SeQuant/core/tensor_network.hpp>
 #include <SeQuant/core/tensor_network/vertex_painter.hpp>
 #include <SeQuant/core/tensor_network_v2.hpp>
@@ -964,6 +965,115 @@ TensorNetwork::SlotCanonicalizationMetadata TensorNetwork::canonicalize_slots(
     metadata.named_index_compare = std::move(named_index_compare);
 
   }  // named indices resort to canonical order
+
+  // compute the phase associated with *slot* canonicalization ...
+  // - choose an index-independent order of slots: loop over bra then ket then
+  // aux slots of each tensor ... record each Index in the order of its
+  // appearance when iterating over slots. This is the input ordinal of this
+  // Index. NB We can't just use Index::full_label() to look up Index in edges_
+  // since this would produce label-dependent ordinals
+  // - canonicalization reorders slots according to the topology-based order of
+  // indices.
+  // - for each antisymmetric bra/ket bundle determine its parity according to
+  // the input ordinals and canonical ordinals, the product is the phase due to
+  // slot canonicalization
+  {
+    metadata.phase = 1;
+
+    // iterate over tensor bra/ket/aux index slots in the canonical input order,
+    // for each antisymmetric bra/ket compute phase
+    container::map<Index, std::size_t, FullLabelCompare>
+        idx_inord;  // Index -> input ordinal; helps with computing the ordinals
+                    // during the traversal
+    for (auto &_t : tensors_) {
+      assert(std::dynamic_pointer_cast<Tensor>(_t));
+      auto t = std::static_pointer_cast<Tensor>(_t);
+
+      // returns an iterator to {Index,inord} pair
+      auto index_inord_it = [&](const Index &idx) {
+        auto it = idx_inord.find(idx.full_label());
+        if (it == idx_inord.end()) {
+          const auto inord = idx_inord.size();
+          bool inserted;
+          std::tie(it, inserted) = idx_inord.emplace(idx, inord);
+          assert(inserted);
+        }
+        return it;
+      };
+
+      // computes parity of a bra/ket bundle due to the reordering of its slots
+      // involved in the TN canonicalization
+      auto input_to_canonical_parity = [&](const auto &idx_rng) {
+        using ranges::size;
+        const auto sz = size(idx_rng);
+        if (sz < 2) {  // no phase for 1-index bundles, but still process the
+                       // indices to ensure ordinals are correct
+          using ranges::begin;
+          index_inord_it(*begin(idx_rng));
+          return 1;
+        }
+
+        auto parity = [&](auto &rng) {
+          reset_ts_swap_counter<std::size_t>();
+          using ranges::begin;
+          using ranges::end;
+          bubble_sort(begin(rng), end(rng));
+          return ts_swap_counter_is_even<std::size_t>() ? +1 : -1;
+        };
+
+        container::vector<SwapCountable<std::size_t>> ordinals_input;
+        container::vector<SwapCountable<std::size_t>> ordinals_canonical;
+        ordinals_input.reserve(sz);
+        ordinals_canonical.reserve(sz);
+        for (const auto &idx : idx_rng) {
+          // input ordinal
+          std::size_t inord;
+          std::tie(std::ignore, inord) = *index_inord_it(idx);
+          ordinals_input.emplace_back(inord);
+
+          // use canonical ordinal of the index vertex as the canonical index
+          // ordinal to find it need the ordinal of the corresponding vertex in
+          // the input graph
+          auto input_vertex_it = this->edges_.find(idx.full_label());
+          assert(input_vertex_it != this->edges_.end());
+          const auto inord_vertex = input_vertex_it - this->edges_.begin();
+          const auto canord_vertex = cl[inord_vertex];
+
+          // to which edge did this get mapped?
+          //          std::wcout << "vlabels[ord_original=" << inord_vertex
+          //                     << "]=" << vlabels[inord_vertex]
+          //                     << " -> ord_canonical=" << canord_vertex <<
+          //                     std::endl;
+          ordinals_canonical.emplace_back(canord_vertex);
+        }
+
+        // parity = parity(original range) * parity(canonical range)
+        const auto parity_original = parity(ordinals_input);
+        const auto parity_canonical = parity(ordinals_canonical);
+        return parity_original * parity_canonical;
+      };
+
+      // canonical order of slots: bra, then ket, then aux. We only care about
+      // indices in tensor slots here, so no need to worry about protoindex
+      // slots
+      if (t->symmetry() == Symmetry::antisymm) {
+        // bra first, then ket
+        metadata.phase *= input_to_canonical_parity(t->bra());
+        metadata.phase *= input_to_canonical_parity(t->ket());
+      } else {  // although we don't need to worry about phases, we still need
+                // to process all indices so that the input ordinals are correct
+        for (auto &&idx : t->bra()) {
+          index_inord_it(idx);
+        }
+        for (auto &&idx : t->ket()) {
+          index_inord_it(idx);
+        }
+      }
+      for (auto &&idx : t->aux()) {
+        index_inord_it(idx);
+      }
+    }
+  }
 
   return metadata;
 }

--- a/SeQuant/core/tensor_network.cpp
+++ b/SeQuant/core/tensor_network.cpp
@@ -872,7 +872,10 @@ TensorNetwork::SlotCanonicalizationMetadata TensorNetwork::canonicalize_slots(
   // distinct_named_indices = false
   auto [graph, vlabels, vcolors, vtypes] =
       make_bliss_graph(&named_indices, /* distinct_named_indices = */ false);
-  //    graph->write_dot(std::wcout, vlabels);
+  if (Logger::instance().canonicalize_dot) {
+    std::wcout << "Input graph for canonicalization:\n";
+    graph->write_dot(std::wcout, vlabels);
+  }
 
   // canonize the graph
   bliss::Stats stats;
@@ -890,6 +893,7 @@ TensorNetwork::SlotCanonicalizationMetadata TensorNetwork::canonicalize_slots(
       return pvector;
     };
 
+    std::wcout << "Canonicalized graph:\n";
     auto cvlabels = permute(vlabels, cl);
     metadata.graph->write_dot(std::wcout, cvlabels);
   }

--- a/SeQuant/core/tensor_network.cpp
+++ b/SeQuant/core/tensor_network.cpp
@@ -213,7 +213,7 @@ ExprPtr TensorNetwork::canonicalize(
       container::multimap<size_t, std::pair<size_t, size_t>> color2idx;
       // collect colors and anonymous indices sorted by colors
       size_t idx_ord = 0;
-      for (auto &&ttpair : edges_) {
+      for ([[maybe_unused]] auto &&ttpair : edges_) {
         if (is_anonymous_index_ord(idx_ord)) {
           auto color = vcolors[idx_ord];
           if (colors.find(color) == colors.end()) colors.insert(color);
@@ -512,7 +512,7 @@ TensorNetwork::make_bliss_graph(const named_indices_t *named_indices_ptr,
     assert(!bundle.empty());
     ++nv;  // each symmetric protoindex bundle is a vertex
     std::wstring spbundle_label = L"<";
-    std::size_t pi_count = 0;
+    [[maybe_unused]] std::size_t pi_count = 0;
     const auto end = bundle.end();
     auto it = bundle.begin();
     spbundle_label += it->full_label();
@@ -622,7 +622,7 @@ TensorNetwork::make_bliss_graph(const named_indices_t *named_indices_ptr,
   index_cnt = 0;
   ranges::for_each(edges_, [&](const Edge &edge) {
     assert(edge.size() > 0);
-    const auto edge_connected = edge.size() == 2;
+    [[maybe_unused]] const auto edge_connected = edge.size() == 2;
     for (int t = 0; t != edge.size(); ++t) {
       const auto &terminal = edge[t];
       const auto tensor_ord = terminal.tensor_ord;

--- a/SeQuant/core/tensor_network.hpp
+++ b/SeQuant/core/tensor_network.hpp
@@ -216,8 +216,7 @@ class TensorNetwork {
         } else {
           throw std::logic_error(
               "TensorNetwork::TensorNetwork: non-tensors in the given "
-              "expression "
-              "range");
+              "expression range");
         }
       }
       return;

--- a/SeQuant/core/tensor_network.hpp
+++ b/SeQuant/core/tensor_network.hpp
@@ -284,6 +284,11 @@ class TensorNetwork {
     /// canonicalized colored graph, use graph->cmp to compare against another
     /// to detect equivalence
     std::shared_ptr<bliss::Graph> graph;
+
+    /// if tensor network contains tensors with antisymmetric bra/ket this
+    /// reports the phase change due to permutation of slots relative to their
+    /// input order
+    std::int8_t phase = +1;  // +1 or -1
   };
 
   /// Like canonicalize(), but only use graph-based canonicalization to
@@ -335,6 +340,15 @@ class TensorNetwork {
     }
     bool operator()(const std::wstring_view &first, const Edge &second) const {
       return first < second.idx().full_label();
+    }
+    bool operator()(const Index &first, const Index &second) const {
+      return first.full_label() < second.full_label();
+    }
+    bool operator()(const Index &first, const std::wstring_view &second) const {
+      return first.full_label() < second;
+    }
+    bool operator()(const std::wstring_view &first, const Index &second) const {
+      return first < second.full_label();
     }
   };
   // Index -> Edge, sorted by full label

--- a/SeQuant/core/tensor_network_v2.hpp
+++ b/SeQuant/core/tensor_network_v2.hpp
@@ -264,6 +264,11 @@ class TensorNetworkV2 {
     /// canonicalized colored graph, use graph->cmp to compare against another
     /// to detect equivalence
     std::shared_ptr<bliss::Graph> graph;
+
+    /// if tensor network contains tensors with antisymmetric bra/ket this
+    /// reports the phase change due to permutation of slots relative to their
+    /// input order
+    std::int8_t phase = +1;  // +1 or -1
   };
 
   /// Like canonicalize(), but only use graph-based canonicalization to

--- a/SeQuant/core/utility/swap.hpp
+++ b/SeQuant/core/utility/swap.hpp
@@ -1,0 +1,125 @@
+//
+// Created by Eduard Valeyev on 2/14/25.
+//
+
+#ifndef SEQUANT_CORE_UTILITY_SWAPPABLE_HPP
+#define SEQUANT_CORE_UTILITY_SWAPPABLE_HPP
+
+#include <atomic>
+
+namespace sequant {
+
+/// use this as a swap-countable deep wrapper for types whose swaps are not
+/// counted
+template <typename T>
+class SwapCountable;
+
+/// use this as a swap-countable shallow wrapper for types whose swaps are not
+/// counted
+template <typename T>
+class SwapCountableRef;
+
+/// counted swap for types whose default swap is not counted
+template <typename T>
+inline void counted_swap(T& a, T& b);
+
+namespace detail {
+
+/// use this for implementing custom swap that counts swaps by default
+template <typename T>
+inline void count_swap();
+
+/// atomic counter, used by swap overloads for SwapCountable and
+/// SwapCountableRef
+template <typename T>
+struct SwapCounter {
+  SwapCounter() : even_num_of_swaps_(true) {}
+  static SwapCounter& thread_instance() {
+    static thread_local SwapCounter instance_{};
+    return instance_;
+  }
+
+  bool even_num_of_swaps() const { return even_num_of_swaps_; }
+  void reset() { even_num_of_swaps_ = true; }
+
+ private:
+  std::atomic<bool> even_num_of_swaps_;
+  void toggle() { even_num_of_swaps_ = !even_num_of_swaps_; }
+
+  friend class SwapCountable<T>;
+  friend class SwapCountableRef<T>;
+  friend inline void counted_swap<T>(T& a, T& b);
+  friend inline void count_swap<T>();
+};
+
+template <typename T>
+inline void count_swap() {
+  detail::SwapCounter<T>::thread_instance().toggle();
+}
+
+}  // namespace detail
+
+/// Wraps `T` to make its swap countable
+template <typename T>
+class SwapCountable {
+ public:
+  template <typename U>
+  explicit SwapCountable(U&& v) : value_(std::forward<U>(v)) {}
+
+ private:
+  T value_;
+
+  friend inline void swap(SwapCountable& a, SwapCountable& b) {
+    using std::swap;
+    swap(a.value_, b.value_);
+    detail::SwapCounter<T>::thread_instance().toggle();
+  }
+
+  friend inline bool operator<(const SwapCountable& a, const SwapCountable& b) {
+    return a.value_ < b.value_;
+  }
+};
+
+/// Wraps `T&` to make its swap countable
+template <typename T>
+class SwapCountableRef {
+ public:
+  explicit SwapCountableRef(T& ref) : ref_(ref) {}
+
+ private:
+  T& ref_;
+
+  // NB swapping const wrappers swaps the payload
+  friend inline void swap(const SwapCountableRef& a,
+                          const SwapCountableRef& b) {
+    using std::swap;
+    swap(a.ref_, b.ref_);
+    detail::SwapCounter<T>::thread_instance().toggle();
+  }
+
+  friend inline bool operator<(const SwapCountableRef& a,
+                               const SwapCountableRef& b) {
+    return a.ref_ < b.ref_;
+  }
+};
+
+template <typename T>
+void reset_ts_swap_counter() {
+  detail::SwapCounter<T>::thread_instance().reset();
+}
+
+template <typename T>
+bool ts_swap_counter_is_even() {
+  return detail::SwapCounter<T>::thread_instance().even_num_of_swaps();
+}
+
+template <typename T>
+inline void counted_swap(T& a, T& b) {
+  using std::swap;
+  swap(a, b);
+  detail::SwapCounter<T>::thread_instance().toggle();
+}
+
+}  // namespace sequant
+
+#endif  // SEQUANT_CORE_UTILITY_SWAPPABLE_HPP

--- a/SeQuant/core/utility/swap.hpp
+++ b/SeQuant/core/utility/swap.hpp
@@ -21,13 +21,13 @@ class SwapCountableRef;
 
 /// counted swap for types whose default swap is not counted
 template <typename T>
-inline void counted_swap(T& a, T& b);
+void counted_swap(T& a, T& b);
 
 namespace detail {
 
 /// use this for implementing custom swap that counts swaps by default
 template <typename T>
-inline void count_swap();
+void count_swap();
 
 /// atomic counter, used by swap overloads for SwapCountable and
 /// SwapCountableRef
@@ -48,12 +48,12 @@ struct SwapCounter {
 
   friend class SwapCountable<T>;
   friend class SwapCountableRef<T>;
-  friend inline void counted_swap<T>(T& a, T& b);
-  friend inline void count_swap<T>();
+  friend void counted_swap<T>(T& a, T& b);
+  friend void count_swap<T>();
 };
 
 template <typename T>
-inline void count_swap() {
+void count_swap() {
   detail::SwapCounter<T>::thread_instance().toggle();
 }
 
@@ -69,13 +69,13 @@ class SwapCountable {
  private:
   T value_;
 
-  friend inline void swap(SwapCountable& a, SwapCountable& b) {
+  friend void swap(SwapCountable& a, SwapCountable& b) {
     using std::swap;
     swap(a.value_, b.value_);
     detail::SwapCounter<T>::thread_instance().toggle();
   }
 
-  friend inline bool operator<(const SwapCountable& a, const SwapCountable& b) {
+  friend bool operator<(const SwapCountable& a, const SwapCountable& b) {
     return a.value_ < b.value_;
   }
 };
@@ -90,15 +90,13 @@ class SwapCountableRef {
   T& ref_;
 
   // NB swapping const wrappers swaps the payload
-  friend inline void swap(const SwapCountableRef& a,
-                          const SwapCountableRef& b) {
+  friend void swap(const SwapCountableRef& a, const SwapCountableRef& b) {
     using std::swap;
     swap(a.ref_, b.ref_);
     detail::SwapCounter<T>::thread_instance().toggle();
   }
 
-  friend inline bool operator<(const SwapCountableRef& a,
-                               const SwapCountableRef& b) {
+  friend bool operator<(const SwapCountableRef& a, const SwapCountableRef& b) {
     return a.ref_ < b.ref_;
   }
 };
@@ -114,7 +112,7 @@ bool ts_swap_counter_is_even() {
 }
 
 template <typename T>
-inline void counted_swap(T& a, T& b) {
+void counted_swap(T& a, T& b) {
   using std::swap;
   swap(a, b);
   detail::SwapCounter<T>::thread_instance().toggle();

--- a/SeQuant/domain/mbpt/spin.cpp
+++ b/SeQuant/domain/mbpt/spin.cpp
@@ -304,10 +304,10 @@ ExprPtr expand_antisymm(const Tensor& tensor, bool skip_spinsymm) {
   auto get_phase = [](const Tensor& t) {
     container::svector<Index> bra(t.bra().begin(), t.bra().end());
     container::svector<Index> ket(t.ket().begin(), t.ket().end());
-    IndexSwapper::thread_instance().reset();
-    bubble_sort(std::begin(bra), std::end(bra), std::less<Index>{});
-    bubble_sort(std::begin(ket), std::end(ket), std::less<Index>{});
-    return IndexSwapper::thread_instance().even_num_of_swaps() ? 1 : -1;
+    reset_ts_swap_counter<Index>();
+    bubble_sort(std::begin(bra), std::end(bra));
+    bubble_sort(std::begin(ket), std::end(ket));
+    return ts_swap_counter_is_even<Index>() ? 1 : -1;
   };
 
   // Generate a sum of asymmetric tensors if the input tensor is antisymmetric
@@ -476,10 +476,9 @@ ExprPtr expand_A_op(const Product& product) {
       container::svector<Index> transformed_list;
       for (const auto& [key, val] : map) transformed_list.push_back(val);
 
-      IndexSwapper::thread_instance().reset();
-      bubble_sort(std::begin(transformed_list), std::end(transformed_list),
-                  std::less<Index>{});
-      phase = IndexSwapper::thread_instance().even_num_of_swaps() ? 1 : -1;
+      reset_ts_swap_counter<Index>();
+      bubble_sort(std::begin(transformed_list), std::end(transformed_list));
+      phase = ts_swap_counter_is_even<Index>() ? 1 : -1;
     }
 
     Product new_product{};
@@ -564,9 +563,9 @@ ExprPtr symmetrize_expr(const Product& product) {
   auto get_phase = [](const container::map<Index, Index>& map) {
     container::svector<Index> idx_list;
     for (const auto& [key, val] : map) idx_list.push_back(val);
-    IndexSwapper::thread_instance().reset();
-    bubble_sort(std::begin(idx_list), std::end(idx_list), std::less<Index>{});
-    return IndexSwapper::thread_instance().even_num_of_swaps() ? 1 : -1;
+    reset_ts_swap_counter<Index>();
+    bubble_sort(std::begin(idx_list), std::end(idx_list));
+    return ts_swap_counter_is_even<Index>() ? 1 : -1;
   };
 
   container::svector<container::map<Index, Index>> maps;

--- a/cmake/modules/FindOrFetchGoogleBenchmark.cmake
+++ b/cmake/modules/FindOrFetchGoogleBenchmark.cmake
@@ -14,4 +14,4 @@ endif()
 # postcond check
 if (NOT TARGET benchmark::benchmark)
 	message(FATAL_ERROR "FindOrFetchGoogleBenchmark could not make TARGET benchmark::benchmark available")
-endif(NOT TARGET libperm)
+endif()

--- a/tests/unit/test_canonicalize.cpp
+++ b/tests/unit/test_canonicalize.cpp
@@ -435,6 +435,19 @@ TEST_CASE("Canonicalizer", "[algorithms]") {
                // these differ by a sign ...
                std::make_tuple(L"g{i1,i4;a1,a4}:A * t{a4;i4}:A",
                                L"g{i3,i2;a2,a4}:A * t{a4;i3}:A", true, true),
+               // more spin-orbital CC cases suggested by Bimal
+               // 1
+               std::make_tuple(L"g{i_2,i_3;a_2,a_3}:A * t{a_2;i_1}:A",
+                               L"g{i_3,i_4;a_3,a_4}:A * t{a_3;i_1}:A", true,
+                               false),
+               std::make_tuple(L"g{i_2,i_3;a_2,a_3}:A * t{a_2;i_1}:A",
+                               L"g{i_3,i_4;a_3,a_4}:A * t{a_4;i_1}:A", true,
+                               true),
+               // 2
+               std::make_tuple(
+                   L"g{i_3,i_4;a_3,a_4}:A * t{a_3;i_1}:A * t{a_4;i_2}:A",
+                   L"g{i_3,i_4;a_3,a_4}:A * t{a_4;i_1}:A * t{a_3;i_2}:A", true,
+                   true),
            }) {
         std::wcout << "============== " << input1
                    << " ===============" << std::endl;

--- a/tests/unit/test_canonicalize.cpp
+++ b/tests/unit/test_canonicalize.cpp
@@ -431,6 +431,14 @@ TEST_CASE("Canonicalizer", "[algorithms]") {
                    L"g{a3;a4;x1,x2} * C{a3<i1,i4>;a3} * C{a4;a4<i1>}",
                    L"g{a3;a4;x2,x1} * C{a3<i1,i2>;a3} * C{a4;a4<i2>}", true,
                    false),
+               //////////////// TNs w antisymmetric tensors
+               // unlike the nonsymmetric/symmetric cases we need to check for
+               // the phase
+               // also the change in the order of named indices produced by
+               // canonicalize_slots may absorb the phase ... so these tests are
+               // not robust due to relying on specific canonical order (which
+               // will change by changing bliss heuristics, colors, etc.)
+               //
                // spin-orbital CC cases suggested by Bimal testing
                // these differ by a sign ...
                std::make_tuple(L"g{i1,i4;a1,a4}:A * t{a4;i4}:A",
@@ -443,11 +451,18 @@ TEST_CASE("Canonicalizer", "[algorithms]") {
                std::make_tuple(L"g{i_2,i_3;a_2,a_3}:A * t{a_2;i_1}:A",
                                L"g{i_3,i_4;a_3,a_4}:A * t{a_4;i_1}:A", true,
                                true),
-               // 2
+               // 2a
                std::make_tuple(
                    L"g{i_3,i_4;a_3,a_4}:A * t{a_3;i_1}:A * t{a_4;i_2}:A",
                    L"g{i_3,i_4;a_3,a_4}:A * t{a_4;i_1}:A * t{a_3;i_2}:A", true,
                    true),
+               // 2b: unlike its equivalent counterpart 2a the order of named
+               // indices is different for the 2 TNs, which cancels out the
+               // phase change
+               std::make_tuple(
+                   L"g{i_3,i_4;a_3,a_4}:A * t{a_3;i_1}:A * t{a_4;i_2}:A",
+                   L"g{i_3,i_4;a_3,a_4}:A * t{a_3;i_2}:A * t{a_4;i_1}:A", true,
+                   false),
            }) {
         std::wcout << "============== " << input1
                    << " ===============" << std::endl;


### PR DESCRIPTION
example: `g{i1,i4;a1,a4}:A * t{a4;i4}` and `g{i3,i2;a2,a4}:A * t{a4;i3}` are equivalent up to a sign.