### PR TITLE
MR support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,8 @@ set(SeQuant_src
         SeQuant/core/parse.hpp
         SeQuant/core/ranges.hpp
         SeQuant/core/rational.hpp
+        SeQuant/core/result_expr.cpp
+        SeQuant/core/result_expr.hpp
         SeQuant/core/runtime.cpp
         SeQuant/core/runtime.hpp
         SeQuant/core/space.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -633,6 +633,10 @@ if (SEQUANT_BUILD_DOCS)
     add_subdirectory(doc)
 endif ()
 
+####### External interface ########
+
+add_subdirectory(external-interface)
+
 
 ##########################
 # export SeQuant

--- a/SeQuant/core/export/itf.cpp
+++ b/SeQuant/core/export/itf.cpp
@@ -250,7 +250,6 @@ void one_electron_integral_remapper(ExprPtr &expr,
 
   auto braIndices = tensor.bra();
   auto ketIndices = tensor.ket();
-  assert(tensor.aux().empty());
 
   // Use the bra-ket (hermitian) symmetry of the integrals to exchange creators
   // and annihilators such that the larger index space is on the left (in the
@@ -264,7 +263,7 @@ void one_electron_integral_remapper(ExprPtr &expr,
   }
 
   expr = ex<Tensor>(tensor.label(), bra(std::move(braIndices)),
-                    ket(std::move(ketIndices)), tensor.aux());
+                    ket(std::move(ketIndices)), aux(tensor.aux()));
 }
 
 template <typename BraContainer, typename KetContainer>
@@ -397,17 +396,21 @@ void two_electron_integral_remapper(ExprPtr &expr,
 
 void integral_remapper(ExprPtr &expr, const Context &ctx,
                        std::wstring_view oneElectronIntegralName,
-                       std::wstring_view twoElectronIntegralName) {
+                       std::wstring_view twoElectronIntegralName,
+                       std::wstring_view dfTensorName) {
   two_electron_integral_remapper(expr, twoElectronIntegralName, ctx);
   one_electron_integral_remapper(expr, oneElectronIntegralName, ctx);
+  // We can reuse the same logic for the DF tensors
+  one_electron_integral_remapper(expr, dfTensorName, ctx);
 }
 
 void remap_integrals(ExprPtr &expr, const Context &ctx,
                      std::wstring_view oneElectronIntegralName,
-                     std::wstring_view twoElectronIntegralName) {
+                     std::wstring_view twoElectronIntegralName,
+                     std::wstring_view dfTensorName) {
   auto remapper = [&](ExprPtr &expr) {
     return integral_remapper(expr, ctx, oneElectronIntegralName,
-                             twoElectronIntegralName);
+                             twoElectronIntegralName, dfTensorName);
   };
 
   const bool visitedRoot = expr->visit(remapper, true);

--- a/SeQuant/core/export/itf.cpp
+++ b/SeQuant/core/export/itf.cpp
@@ -179,7 +179,9 @@ std::vector<Contraction> to_contractions(const ExprPtr &expression,
   std::wstring itfCode;
 
   if (expression.is<Constant>()) {
-    throw std::invalid_argument("Can't transform constants into contractions");
+    // Make use of special One[] tensor to represent adding constants
+    return {Contraction{expression.as<Constant>().value().real(), resultTensor,
+                        Tensor(L"One", {}, {}, {})}};
   } else if (expression.is<Tensor>()) {
     return {Contraction{1, resultTensor, expression.as<Tensor>(), {}}};
   } else if (expression.is<Product>()) {

--- a/SeQuant/core/export/itf.cpp
+++ b/SeQuant/core/export/itf.cpp
@@ -600,8 +600,19 @@ std::wstring ITFGenerator::generate() const {
          currentSection.contractionBlocks) {
       for (const Contraction &currentContraction : currentBlock) {
         if (currentContraction.factor == 0) {
+          if (currentContraction.lhs.label() == L"One" &&
+              !currentContraction.rhs.has_value()) {
+            // This is likely the only contraction belonging to the given result
+            // meaning that we simply want to explicitly set it to zero
+            itf +=
+                L"alloc " + to_itf(currentContraction.result, *m_ctx) + L"\n";
+            itf +=
+                L"store " + to_itf(currentContraction.result, *m_ctx) + L"\n";
+          }
+
           continue;
         }
+
         // For now we'll do a really silly contribution-by-contribution
         // load-process-store strategy
         if (allocatedTensors.find(currentContraction.result) ==

--- a/SeQuant/core/export/itf.cpp
+++ b/SeQuant/core/export/itf.cpp
@@ -559,7 +559,12 @@ std::wstring ITFGenerator::generate() const {
   }
   itf += L"\n";
   for (const Tensor &current : m_createdTensors) {
-    itf += L"tensor: " + to_itf(current, *m_ctx) + L", !Create{type:disk}\n";
+    itf += L"tensor: " + to_itf(current, *m_ctx);
+    if (current.indices().size() > 0) {
+      itf += +L", !Create{type:disk}\n";
+    } else {
+      itf += +L", !Create{type:scalar}\n";
+    }
   }
   itf += L"\n\n";
 

--- a/SeQuant/core/export/itf.cpp
+++ b/SeQuant/core/export/itf.cpp
@@ -109,12 +109,13 @@ std::vector<Contraction> to_contractions(const Product &product,
       IndexGroups intermediateIndexGroups = get_unique_indices(factor);
 
       // Collect all intermediate indices and sort them such that the order of
-      // index spaces is the canonical one within ITF (largest space leftmost).
+      // index spaces is the canonical one within ITF
       // This is possible, because the index ordering of intermediates is
       // arbitrary
       std::vector<Index> intermediateIndices;
       intermediateIndices.reserve(intermediateIndexGroups.bra.size() +
-                                  intermediateIndexGroups.ket.size());
+                                  intermediateIndexGroups.ket.size() +
+                                  intermediateIndexGroups.aux.size());
       intermediateIndices.insert(intermediateIndices.end(),
                                  intermediateIndexGroups.bra.begin(),
                                  intermediateIndexGroups.bra.end());
@@ -497,7 +498,10 @@ std::wstring to_itf(const Tensor &tensor, const Context &ctx,
   std::wstring tags;
   std::wstring indices;
 
-  for (const Index &current : tensor.braket()) {
+  // Note that it is important to iterate over the auxiliary indices first as
+  // ITF expects those the be listed first
+  for (const Index &current :
+       ranges::views::concat(tensor.aux(), tensor.bra(), tensor.ket())) {
     IndexComponents components = decomposeIndex(current);
 
     assert(components.id <= 7);

--- a/SeQuant/core/export/itf.cpp
+++ b/SeQuant/core/export/itf.cpp
@@ -607,9 +607,9 @@ std::wstring ITFGenerator::generate() const {
 
       itf += L"\n";
     }
-
-    itf += L"\n---- end\n";
   }
+
+  itf += L"\n---- end\n";
 
   return itf;
 }

--- a/SeQuant/core/export/itf.hpp
+++ b/SeQuant/core/export/itf.hpp
@@ -8,6 +8,7 @@
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/tensor.hpp>
 
+#include <functional>
 #include <optional>
 #include <set>
 #include <string>
@@ -45,6 +46,16 @@ struct CodeBlock {
   CodeBlock(std::wstring blockName, std::vector<Result> results);
 };
 
+class Context {
+ public:
+  virtual ~Context();
+
+  virtual int compare(const Index &lhs, const Index &rhs) const = 0;
+  virtual std::wstring get_base_label(const IndexSpace &space) const = 0;
+  virtual std::wstring get_tag(const IndexSpace &space) const = 0;
+  virtual std::wstring get_name(const IndexSpace &space) const = 0;
+};
+
 namespace detail {
 
 /// Comparator that identifies Tensors only by their "block", which is defined
@@ -57,7 +68,7 @@ struct TensorBlockCompare {
 
 /// Replaces one- and two-electron integrals in the given expression with
 /// versions that use the index ordering and tensor naming as expected in ITF
-void remap_integrals(ExprPtr &expr,
+void remap_integrals(ExprPtr &expr, const Context &ctx,
                      std::wstring_view oneElectronIntegralName = L"f",
                      std::wstring_view twoElectronIntegralName = L"g");
 
@@ -85,7 +96,7 @@ struct CodeSection {
 /// generating capabilities
 class ITFGenerator {
  public:
-  ITFGenerator() = default;
+  ITFGenerator(const itf::Context &ctx);
 
   void addBlock(const itf::CodeBlock &block);
 
@@ -96,6 +107,7 @@ class ITFGenerator {
   std::set<Tensor, TensorBlockCompare> m_importedTensors;
   std::set<Tensor, TensorBlockCompare> m_createdTensors;
   std::vector<CodeSection> m_codes;
+  const Context *m_ctx;
 };
 
 }  // namespace detail
@@ -103,7 +115,7 @@ class ITFGenerator {
 }  // namespace itf
 
 /// Translates the given ITF CodeBlock to executable ITF code
-std::wstring to_itf(const itf::CodeBlock &block);
+std::wstring to_itf(const itf::CodeBlock &block, const itf::Context &ctx);
 
 /// Translates the given collection/range of ITF CodeBlocks or Results to
 /// executable ITF code
@@ -111,12 +123,12 @@ template <typename Container,
           typename = std::enable_if_t<!std::is_same_v<
               std::remove_const_t<std::remove_reference_t<Container>>,
               itf::CodeBlock>>>
-std::wstring to_itf(Container &&container) {
+std::wstring to_itf(Container &&container, const itf::Context &ctx) {
   using ContainerType = std::remove_const_t<std::remove_reference_t<Container>>;
   static_assert(
       std::is_same_v<typename ContainerType::value_type, itf::CodeBlock> ||
       std::is_same_v<typename ContainerType::value_type, ExprPtr>);
-  itf::detail::ITFGenerator generator;
+  itf::detail::ITFGenerator generator(ctx);
 
   if constexpr (std::is_same_v<typename ContainerType::value_type,
                                itf::CodeBlock>) {

--- a/SeQuant/core/export/itf.hpp
+++ b/SeQuant/core/export/itf.hpp
@@ -70,7 +70,8 @@ struct TensorBlockCompare {
 /// versions that use the index ordering and tensor naming as expected in ITF
 void remap_integrals(ExprPtr &expr, const Context &ctx,
                      std::wstring_view oneElectronIntegralName = L"f",
-                     std::wstring_view twoElectronIntegralName = L"g");
+                     std::wstring_view twoElectronIntegralName = L"g",
+					 std::wstring_view dfTensorName = L"DF");
 
 /// Represents a single contraction where the contraction of lhs with rhs,
 /// multiplied by the given factor contributes to the given result. If rhs is

--- a/SeQuant/core/export/itf.hpp
+++ b/SeQuant/core/export/itf.hpp
@@ -112,20 +112,20 @@ template <typename Container,
               std::remove_const_t<std::remove_reference_t<Container>>,
               itf::CodeBlock>>>
 std::wstring to_itf(Container &&container) {
+  using ContainerType = std::remove_const_t<std::remove_reference_t<Container>>;
   static_assert(
-      std::is_same_v<typename Container::value_type, itf::CodeBlock> ||
-      std::is_same_v<std::remove_const_t<typename Container::value_type>,
-                     ExprPtr>);
+      std::is_same_v<typename ContainerType::value_type, itf::CodeBlock> ||
+      std::is_same_v<typename ContainerType::value_type, ExprPtr>);
   itf::detail::ITFGenerator generator;
 
-  if constexpr (std::is_same_v<typename Container::value_type,
+  if constexpr (std::is_same_v<typename ContainerType::value_type,
                                itf::CodeBlock>) {
     for (const itf::CodeBlock &current : container) {
       generator.addBlock(current);
     }
   } else {
     static_assert(
-        std::is_same_v<typename Container::value_type, itf::Result>,
+        std::is_same_v<typename ContainerType::value_type, itf::Result>,
         "Container::value_type must either be itf::CodeBlock or itf::Result");
 
     itf::CodeBlock block(L"Generate_Results",

--- a/SeQuant/core/export/itf.hpp
+++ b/SeQuant/core/export/itf.hpp
@@ -71,7 +71,7 @@ struct TensorBlockCompare {
 void remap_integrals(ExprPtr &expr, const Context &ctx,
                      std::wstring_view oneElectronIntegralName = L"f",
                      std::wstring_view twoElectronIntegralName = L"g",
-					 std::wstring_view dfTensorName = L"DF");
+                     std::wstring_view dfTensorName = L"DF");
 
 /// Represents a single contraction where the contraction of lhs with rhs,
 /// multiplied by the given factor contributes to the given result. If rhs is

--- a/SeQuant/core/parse.hpp
+++ b/SeQuant/core/parse.hpp
@@ -5,8 +5,10 @@
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>
 #include <SeQuant/core/op.hpp>
+#include <SeQuant/core/result_expr.hpp>
 #include <SeQuant/core/tensor.hpp>
 
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -73,9 +75,14 @@ struct ParseError : std::runtime_error {
 /// \return SeQuant expression.
 // clang-format on
 ExprPtr parse_expr(std::wstring_view raw,
-                   Symmetry perm_symm = Symmetry::nonsymm,
-                   BraKetSymmetry braket_symm = BraKetSymmetry::nonsymm,
-                   ParticleSymmetry particle_symm = ParticleSymmetry::symm);
+                   std::optional<Symmetry> perm_symm = {},
+                   std::optional<BraKetSymmetry> braket_symm = {},
+                   std::optional<ParticleSymmetry> particle_symm = {});
+
+ResultExpr parse_result_expr(
+    std::wstring_view raw, std::optional<Symmetry> perm_symm = {},
+    std::optional<BraKetSymmetry> braket_symm = {},
+    std::optional<ParticleSymmetry> particle_symm = {});
 
 ///
 /// Get a parsable string from an expression.
@@ -92,6 +99,7 @@ ExprPtr parse_expr(std::wstring_view raw,
 /// \param annot_sym Whether to add sequant::Symmetry annotation
 ///                  to each Tensor string.
 /// \return wstring of the expression.
+std::wstring deparse(const ResultExpr &expr, bool annot_sym = true);
 std::wstring deparse(const ExprPtr &expr, bool annot_sym = true);
 std::wstring deparse(const Expr &expr, bool annot_sym = true);
 std::wstring deparse(const Product &product, bool annot_sym);

--- a/SeQuant/core/parse/ast.hpp
+++ b/SeQuant/core/parse/ast.hpp
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <string>
+#include <variant>
 #include <vector>
 
 namespace sequant::parse::ast {
@@ -125,6 +126,17 @@ Product::Product(std::vector<NullaryValue> factors)
 
 Sum::Sum(std::vector<Product> summands) : summands(std::move(summands)) {}
 
+struct ResultExpr : boost::spirit::x3::position_tagged {
+  std::variant<Tensor, Variable> lhs;
+  Sum rhs;
+
+  ResultExpr(Variable variable = {}, Sum expr = {})
+      : lhs(std::move(variable)), rhs(std::move(expr)) {}
+
+  ResultExpr(Tensor tensor, Sum expr)
+      : lhs(std::move(tensor)), rhs(std::move(expr)) {}
+};
+
 }  // namespace sequant::parse::ast
 
 BOOST_FUSION_ADAPT_STRUCT(sequant::parse::ast::IndexLabel, label, id);
@@ -139,5 +151,6 @@ BOOST_FUSION_ADAPT_STRUCT(sequant::parse::ast::Tensor, name, indices, symmetry);
 
 BOOST_FUSION_ADAPT_STRUCT(sequant::parse::ast::Product, factors);
 BOOST_FUSION_ADAPT_STRUCT(sequant::parse::ast::Sum, summands);
+BOOST_FUSION_ADAPT_STRUCT(sequant::parse::ast::ResultExpr, lhs, rhs);
 
 #endif  // SEQUANT_CORE_PARSE_AST_HPP

--- a/SeQuant/core/parse/deparse.cpp
+++ b/SeQuant/core/parse/deparse.cpp
@@ -5,6 +5,7 @@
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>
 #include <SeQuant/core/op.hpp>
+#include <SeQuant/core/result_expr.hpp>
 #include <SeQuant/core/tensor.hpp>
 
 #include <range/v3/all.hpp>
@@ -165,6 +166,31 @@ std::wstring deparse(const Expr& expr, bool annot_sym) {
     return deparse(expr.as<Variable>());
   else
     throw std::runtime_error("Unsupported expr type for deparse!");
+}
+
+std::wstring deparse(const ResultExpr& result, bool annot_sym) {
+  std::wstring deparsed;
+  if (result.has_label()) {
+    deparsed += result.label();
+  } else {
+    deparsed += L"?";
+  }
+
+  if (!result.bra().empty() || !result.ket().empty()) {
+    deparsed += L"{";
+    deparsed += details::deparse_indices(result.bra());
+    deparsed += L";";
+    deparsed += details::deparse_indices(result.ket());
+    deparsed += L"}";
+
+    if (annot_sym) {
+      deparsed += L":" + details::deparse_symm(result.symmetry()) + L"-" +
+                  details::deparse_symm(result.braket_symmetry()) + L"-" +
+                  details::deparse_symm(result.particle_symmetry());
+    }
+  }
+
+  return deparsed + L" = " + deparse(result.expression(), annot_sym);
 }
 
 std::wstring deparse(const Index& index) {

--- a/SeQuant/core/result_expr.cpp
+++ b/SeQuant/core/result_expr.cpp
@@ -1,0 +1,55 @@
+#include <SeQuant/core/result_expr.hpp>
+#include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/utility/indices.hpp>
+
+namespace sequant {
+
+ResultExpr::ResultExpr(const Tensor &tensor, ExprPtr expression)
+    : m_expr(std::move(expression)),
+      m_symm(tensor.symmetry()),
+      m_bksymm(tensor.braket_symmetry()),
+      m_psymm(tensor.particle_symmetry()),
+      m_braIndices(tensor.bra().begin(), tensor.bra().end()),
+      m_ketIndices(tensor.ket().begin(), tensor.ket().end()),
+      m_label(tensor.label()) {}
+
+ResultExpr::ResultExpr(const Variable &variable, ExprPtr expression)
+    : m_expr(std::move(expression)), m_label(variable.label()) {}
+
+ResultExpr &ResultExpr::operator=(ExprPtr expression) {
+  m_expr = std::move(expression);
+
+  return *this;
+}
+
+bool ResultExpr::has_label() const { return m_label.has_value(); }
+
+const std::wstring &ResultExpr::label() const { return m_label.value(); }
+
+Symmetry ResultExpr::symmetry() const { return m_symm; }
+
+void ResultExpr::set_symmetry(Symmetry symm) { m_symm = symm; }
+
+BraKetSymmetry ResultExpr::braket_symmetry() const { return m_bksymm; }
+
+void ResultExpr::set_braket_symmetry(BraKetSymmetry symm) { m_bksymm = symm; }
+
+ParticleSymmetry ResultExpr::particle_symmetry() const { return m_psymm; }
+
+void ResultExpr::set_particle_symmetry(ParticleSymmetry symm) {
+  m_psymm = symm;
+}
+
+const ResultExpr::IndexContainer &ResultExpr::bra() const {
+  return m_braIndices;
+}
+
+const ResultExpr::IndexContainer &ResultExpr::ket() const {
+  return m_ketIndices;
+}
+
+const ExprPtr &ResultExpr::expression() const { return m_expr; }
+
+ExprPtr &ResultExpr::expression() { return m_expr; }
+
+}  // namespace sequant

--- a/SeQuant/core/result_expr.cpp
+++ b/SeQuant/core/result_expr.cpp
@@ -16,6 +16,18 @@ ResultExpr::ResultExpr(const Tensor &tensor, ExprPtr expression)
 ResultExpr::ResultExpr(const Variable &variable, ExprPtr expression)
     : m_expr(std::move(expression)), m_label(variable.label()) {}
 
+ResultExpr::ResultExpr(IndexContainer bra, IndexContainer ket,
+                       IndexContainer aux, Symmetry symm,
+                       BraKetSymmetry braket_symm,
+                       ParticleSymmetry particle_symm, std::optional<std::wstring> label, ExprPtr expression)
+    : m_expr(std::move(expression)),
+      m_braIndices(std::move(bra)),
+      m_ketIndices(std::move(ket)),
+      m_auxIndices(std::move(aux)),
+      m_symm(symm),
+      m_bksymm(braket_symm),
+      m_psymm(particle_symm), m_label(std::move(label)) {}
+
 ResultExpr &ResultExpr::operator=(ExprPtr expression) {
   m_expr = std::move(expression);
 

--- a/SeQuant/core/result_expr.cpp
+++ b/SeQuant/core/result_expr.cpp
@@ -26,6 +26,8 @@ bool ResultExpr::has_label() const { return m_label.has_value(); }
 
 const std::wstring &ResultExpr::label() const { return m_label.value(); }
 
+void ResultExpr::set_label(std::wstring label) { m_label = std::move(label); }
+
 Symmetry ResultExpr::symmetry() const { return m_symm; }
 
 void ResultExpr::set_symmetry(Symmetry symm) { m_symm = symm; }
@@ -46,6 +48,10 @@ const ResultExpr::IndexContainer &ResultExpr::bra() const {
 
 const ResultExpr::IndexContainer &ResultExpr::ket() const {
   return m_ketIndices;
+}
+
+const ResultExpr::IndexContainer &ResultExpr::aux() const {
+  return m_auxIndices;
 }
 
 const ExprPtr &ResultExpr::expression() const { return m_expr; }

--- a/SeQuant/core/result_expr.hpp
+++ b/SeQuant/core/result_expr.hpp
@@ -23,6 +23,10 @@ class ResultExpr {
 
   ResultExpr(const Tensor &tensor, ExprPtr expression);
   ResultExpr(const Variable &variable, ExprPtr expression);
+  ResultExpr(IndexContainer bra, IndexContainer ket, IndexContainer aux,
+             Symmetry symm, BraKetSymmetry braket_symm,
+             ParticleSymmetry particle_symm, std::optional<std::wstring> label,
+             ExprPtr expression);
 
   ResultExpr(const ResultExpr &other) = default;
   ResultExpr(ResultExpr &&other) = default;

--- a/SeQuant/core/result_expr.hpp
+++ b/SeQuant/core/result_expr.hpp
@@ -1,0 +1,86 @@
+#ifndef SEQUANT_RESULT_EXPR_HPP
+#define SEQUANT_RESULT_EXPR_HPP
+
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
+
+#include <cassert>
+#include <initializer_list>
+#include <optional>
+#include <string>
+
+namespace sequant {
+
+class Tensor;
+class Variable;
+
+class ResultExpr {
+ public:
+  using IndexContainer = container::svector<Index>;
+
+  ResultExpr(const Tensor &tensor, ExprPtr expression);
+  ResultExpr(const Variable &variable, ExprPtr expression);
+
+  ResultExpr(const ResultExpr &other) = default;
+  ResultExpr(ResultExpr &&other) = default;
+
+  ResultExpr &operator=(const ResultExpr &other) = default;
+  ResultExpr &operator=(ResultExpr &&other) = default;
+
+  /// Assigns a new expression to this result
+  ResultExpr &operator=(ExprPtr expression);
+
+  bool has_label() const;
+  const std::wstring &label() const;
+
+  Symmetry symmetry() const;
+  void set_symmetry(Symmetry symm);
+
+  BraKetSymmetry braket_symmetry() const;
+  void set_braket_symmetry(BraKetSymmetry symm);
+
+  ParticleSymmetry particle_symmetry() const;
+  void set_particle_symmetry(ParticleSymmetry symm);
+
+  const IndexContainer &bra() const;
+  const IndexContainer &ket() const;
+
+  const ExprPtr &expression() const;
+  ExprPtr &expression();
+
+  template <typename Group>
+  container::svector<Group> index_particle_grouping() const {
+    container::svector<Group> groups;
+
+    assert(m_braIndices.size() == m_ketIndices.size() &&
+           "Not yet generalized to particle non-conserving results");
+
+    groups.reserve(m_braIndices.size());
+
+    // Note that the assumption is that indices are sorted
+    // based on the particle they belong to and that bra and
+    // ket indices are assigned to the same set of particles.
+    for (std::size_t i = 0; i < m_braIndices.size(); ++i) {
+      groups.emplace_back(
+          std::initializer_list<Index>{m_braIndices.at(i), m_ketIndices.at(i)});
+    }
+
+    return groups;
+  }
+
+ private:
+  ExprPtr m_expr;
+
+  Symmetry m_symm = Symmetry::nonsymm;
+  BraKetSymmetry m_bksymm = BraKetSymmetry::nonsymm;
+  ParticleSymmetry m_psymm = ParticleSymmetry::nonsymm;
+  IndexContainer m_braIndices;
+  IndexContainer m_ketIndices;
+  std::optional<std::wstring> m_label;
+};
+
+}  // namespace sequant
+
+#endif  // SEQUANT_RESULT_EXPR_HPP

--- a/SeQuant/core/utility/indices.hpp
+++ b/SeQuant/core/utility/indices.hpp
@@ -182,6 +182,7 @@ IndexGroups<Container> get_unique_indices(const Product& product) {
       } else {
         detail::remove_one(groups.bra, current);
         detail::remove_one(groups.ket, current);
+        detail::remove_one(groups.aux, current);
       }
     }
 
@@ -193,6 +194,7 @@ IndexGroups<Container> get_unique_indices(const Product& product) {
       } else {
         detail::remove_one(groups.bra, current);
         detail::remove_one(groups.ket, current);
+        detail::remove_one(groups.aux, current);
       }
     }
 

--- a/SeQuant/domain/mbpt/convention.cpp
+++ b/SeQuant/domain/mbpt/convention.cpp
@@ -42,9 +42,10 @@ void load(Convention conv) {
   set_default_context(sequant::Context(isr, Vacuum::SingleProduct));
 }
 
-void add_fermi_spin(std::shared_ptr<IndexSpaceRegistry>& isr) {
-  auto result = std::make_shared<IndexSpaceRegistry>();
-  for (auto&& space : *isr) {
+void add_fermi_spin(IndexSpaceRegistry& isr) {
+  IndexSpaceRegistry result;
+
+  for (auto&& space : isr) {
     if (space.base_key() != L"") {
       IndexSpace spin_any(space.base_key(), space.type(), Spin::any,
                           space.approximate_size());
@@ -52,17 +53,18 @@ void add_fermi_spin(std::shared_ptr<IndexSpaceRegistry>& isr) {
                          space.type(), Spin::alpha, space.approximate_size());
       IndexSpace spin_down(spinannotation_add(space.base_key(), Spin::beta),
                            space.type(), Spin::beta, space.approximate_size());
-      result->add(spin_any);
-      result->add(spin_up);
-      result->add(spin_down);
+      result.add(spin_any);
+      result.add(spin_up);
+      result.add(spin_down);
     }
   }
   const bool nulltype_ok = true;
-  result->reference_occupied_space(isr->reference_occupied_space(nulltype_ok));
-  result->vacuum_occupied_space(isr->vacuum_occupied_space(nulltype_ok));
-  result->particle_space(isr->particle_space(nulltype_ok));
-  result->hole_space(isr->hole_space(nulltype_ok));
-  result->complete_space(isr->complete_space(nulltype_ok));
+  result.reference_occupied_space(isr.reference_occupied_space(nulltype_ok));
+  result.vacuum_occupied_space(isr.vacuum_occupied_space(nulltype_ok));
+  result.particle_space(isr.particle_space(nulltype_ok));
+  result.hole_space(isr.hole_space(nulltype_ok));
+  result.complete_space(isr.complete_space(nulltype_ok));
+
   isr = std::move(result);
 }
 
@@ -72,7 +74,7 @@ std::shared_ptr<IndexSpaceRegistry> make_min_sr_spaces() {
   isr->add(L"i", 0b01, is_vacuum_occupied, is_reference_occupied, is_hole)
       .add(L"a", 0b10, is_particle)
       .add_union(L"p", {L"i", L"a"}, is_complete);
-  add_fermi_spin(isr);
+  add_fermi_spin(*isr);
 
   return isr;
 }
@@ -96,7 +98,7 @@ std::shared_ptr<IndexSpaceRegistry> make_mr_spaces() {
       .add_union(L"A", {L"u", L"a"}, is_particle)
       .add_union(L"p", {L"M", L"E"}, is_complete);
 
-  add_fermi_spin(isr);
+  add_fermi_spin(*isr);
 
   return isr;
 }
@@ -112,7 +114,7 @@ std::shared_ptr<IndexSpaceRegistry> make_sr_spaces() {
       .add_union(L"e", {L"a", L"g"})
       .add_union(L"x", {L"i", L"a"})
       .add_union(L"p", {L"m", L"e"}, is_complete);
-  add_fermi_spin(isr);
+  add_fermi_spin(*isr);
 
   return isr;
 }
@@ -134,7 +136,7 @@ std::shared_ptr<IndexSpaceRegistry> make_F12_sr_spaces() {
       .add_union(L"α", {L"e", L"α'"})
       .add_union(L"H", {L"i", L"α"})
       .add_union(L"κ", {L"p", L"α'"}, is_complete);
-  add_fermi_spin(isr);
+  add_fermi_spin(*isr);
 
   return isr;
 }
@@ -158,7 +160,7 @@ std::shared_ptr<IndexSpaceRegistry> make_legacy_spaces(bool ignore_spin) {
       .add_union(L"p", {L"m", L"x", L"e"})
       .add_union(L"κ", {L"p", L"α'"}, is_complete);
 
-  if (!ignore_spin) add_fermi_spin(isr);
+  if (!ignore_spin) add_fermi_spin(*isr);
 
   return isr;
 }
@@ -172,7 +174,7 @@ make_fermi_and_bose_spaces() {
       .add(L"a", 0b010)               // fermi unoccupied
       .add_union(L"p", {L"i", L"a"})  // fermi all
       ;
-  add_fermi_spin(isr);
+  add_fermi_spin(*isr);
   isr->add(L"β", 0b100);  // bose
 
   auto fermi_isr = std::make_shared<IndexSpaceRegistry>(isr->spaces());

--- a/SeQuant/domain/mbpt/convention.hpp
+++ b/SeQuant/domain/mbpt/convention.hpp
@@ -29,7 +29,7 @@ void load(Convention conv = Convention::Minimal);
 std::wstring decorate_label(std::wstring label, bool up);
 
 /// @brief add fermionic spin spaces to registry
-void add_fermi_spin(std::shared_ptr<IndexSpaceRegistry>& isr);
+void add_fermi_spin(IndexSpaceRegistry& isr);
 
 /// @name built-in definitions of IndexSpace
 /// @{

--- a/SeQuant/domain/mbpt/spin.cpp
+++ b/SeQuant/domain/mbpt/spin.cpp
@@ -376,7 +376,7 @@ bool has_tensor(const ExprPtr& expr, std::wstring label) {
 
   auto check_product = [&label](const Product& p) {
     return ranges::any_of(p.factors(), [&label](const auto& t) {
-      return (t->template as<Tensor>()).label() == label;
+      return t->template is<Tensor>() && (t->template as<Tensor>()).label() == label;
     });
   };
 

--- a/SeQuant/domain/mbpt/spin.cpp
+++ b/SeQuant/domain/mbpt/spin.cpp
@@ -1067,6 +1067,7 @@ container::svector<ResultExpr> closed_shell_spintrace(ResultExpr expr) {
         true);
 
     expression *= ex<Constant>(currentSign);
+    expression = simplify(expression);
 
     ResultExpr result = [&]() {
       assert(expr.has_label());

--- a/SeQuant/domain/mbpt/spin.cpp
+++ b/SeQuant/domain/mbpt/spin.cpp
@@ -6,6 +6,7 @@
 #include <SeQuant/core/expr_operator.hpp>
 #include <SeQuant/core/math.hpp>
 #include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/result_expr.hpp>
 #include <SeQuant/core/space.hpp>
 #include <SeQuant/core/tensor.hpp>
 
@@ -966,6 +967,16 @@ ExprPtr closed_shell_CC_spintrace(ExprPtr const& expr) {
   return st_expr;
 }
 
+ResultExpr closed_shell_spintrace(ResultExpr expr) {
+  expr.expression() = closed_shell_spintrace(
+      expr.expression(),
+      expr.index_particle_grouping<container::svector<Index>>());
+
+  expr.set_symmetry(Symmetry::nonsymm);
+
+  return expr;
+}
+
 ExprPtr closed_shell_CC_spintrace_rigorous(ExprPtr const& expr) {
   assert(expr->is<Sum>());
   using ranges::views::transform;
@@ -1628,6 +1639,17 @@ ExprPtr spintrace(
   result->visit(reset_idx_tags);
   return result;
 }  // ExprPtr spintrace
+
+ResultExpr spintrace(ResultExpr expr, bool spinfree_index_spaces) {
+  expr.expression() =
+      spintrace(expr.expression(),
+                expr.index_particle_grouping<container::svector<Index>>(),
+                spinfree_index_spaces);
+
+  expr.set_symmetry(Symmetry::nonsymm);
+
+  return expr;
+}
 
 ExprPtr factorize_S(const ExprPtr& expression,
                     std::initializer_list<IndexList> ext_index_groups,

--- a/SeQuant/domain/mbpt/spin.hpp
+++ b/SeQuant/domain/mbpt/spin.hpp
@@ -10,6 +10,7 @@
 #include <SeQuant/core/container.hpp>
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>
+#include <SeQuant/core/result_expr.hpp>
 #include <SeQuant/core/tensor.hpp>
 
 #include <cassert>
@@ -304,6 +305,8 @@ ExprPtr closed_shell_spintrace(
     const ExprPtr& expr,
     const container::svector<container::svector<Index>>& ext_index_groups = {});
 
+ResultExpr closed_shell_spintrace(ResultExpr expr);
+
 ///
 /// \brief Given a OpType::A or OpType::S tensor, generates a list of external
 ///        indices.
@@ -388,6 +391,8 @@ ExprPtr spintrace(
     const ExprPtr& expr,
     container::svector<container::svector<Index>> ext_index_groups = {},
     bool spinfree_index_spaces = true);
+
+ResultExpr spintrace(ResultExpr expr, bool spinfree_index_spaces = true);
 
 /// @brief Factorize S out of terms
 /// @details Given an expression, permute indices and check if a given product

--- a/SeQuant/domain/mbpt/spin.hpp
+++ b/SeQuant/domain/mbpt/spin.hpp
@@ -305,7 +305,7 @@ ExprPtr closed_shell_spintrace(
     const ExprPtr& expr,
     const container::svector<container::svector<Index>>& ext_index_groups = {});
 
-ResultExpr closed_shell_spintrace(ResultExpr expr);
+container::svector<ResultExpr> closed_shell_spintrace(ResultExpr expr);
 
 ///
 /// \brief Given a OpType::A or OpType::S tensor, generates a list of external

--- a/external-interface/.clang-format
+++ b/external-interface/.clang-format
@@ -1,0 +1,86 @@
+---
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+# Setting AlignConsecutiveDeclarations to true would be nice but it doesn't work right with PointerAlignment=Right
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakStringLiterals: true
+ColumnLimit:     120
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+    # Global.h must always be included last
+  - Regex: 'Global.h'
+    Priority: 10000
+    # Since a lot of windows-headers rely on windows.h, it has to be included first
+  - Regex: 'windows.h'
+    Priority: 1
+    # Assign a priority < INT_MAX to all other includes in order to be able to force headers
+    # to come after them
+  - Regex: '.*'
+    Priority: 10
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth:     4
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 3
+NamespaceIndentation: Inner
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  true
+SpacesInContainerLiterals: true
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          ForContinuationAndIndentation
+...
+

--- a/external-interface/CMakeLists.txt
+++ b/external-interface/CMakeLists.txt
@@ -7,11 +7,17 @@ FetchContent_Declare(
 	GIT_SHALLOW    ON
 )
 FetchContent_Declare(
+	spdlog
+	GIT_REPOSITORY https://github.com/gabime/spdlog.git
+	GIT_TAG        v1.13.0
+	GIT_SHALLOW    ON
+)
+FetchContent_Declare(
 	json
 	URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
 )
 
-FetchContent_MakeAvailable(cli11 json)
+FetchContent_MakeAvailable(cli11 json spdlog)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}")
 
@@ -27,4 +33,5 @@ target_link_libraries(external_interface
 		nlohmann_json::nlohmann_json
 		CLI11::CLI11
 		Boost::headers
+		spdlog::spdlog
 )

--- a/external-interface/CMakeLists.txt
+++ b/external-interface/CMakeLists.txt
@@ -1,0 +1,30 @@
+include(FetchContent)
+
+FetchContent_Declare(
+	cli11
+	GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
+	GIT_TAG        v2.4.1
+	GIT_SHALLOW    ON
+)
+FetchContent_Declare(
+	json
+	URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+)
+
+FetchContent_MakeAvailable(cli11 json)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}")
+
+add_executable(external_interface
+	external_interface.cpp
+	processing.cpp
+	utils.cpp
+)
+
+target_link_libraries(external_interface
+	PRIVATE
+		SeQuant::SeQuant
+		nlohmann_json::nlohmann_json
+		CLI11::CLI11
+		Boost::headers
+)

--- a/external-interface/CMakeLists.txt
+++ b/external-interface/CMakeLists.txt
@@ -9,13 +9,15 @@ FetchContent_Declare(
 FetchContent_Declare(
 	spdlog
 	GIT_REPOSITORY https://github.com/gabime/spdlog.git
-	GIT_TAG        v1.13.0
+	GIT_TAG        v1.15.1
 	GIT_SHALLOW    ON
 )
 FetchContent_Declare(
 	json
 	URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
 )
+
+set(SPDLOG_USE_STD_FORMAT OFF CACHE "" INTERNAL FORCE)
 
 FetchContent_MakeAvailable(cli11 json spdlog)
 

--- a/external-interface/external_interface.cpp
+++ b/external-interface/external_interface.cpp
@@ -1,0 +1,256 @@
+#include "processing.hpp"
+#include "utils.hpp"
+
+#include <SeQuant/core/context.hpp>
+#include <SeQuant/core/export/itf.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/parse.hpp>
+#include <SeQuant/core/runtime.hpp>
+#include <SeQuant/core/tensor_canonicalizer.hpp>
+#include <SeQuant/core/utility/indices.hpp>
+#include <SeQuant/core/utility/string.hpp>
+#include <SeQuant/domain/mbpt/convention.hpp>
+#include <SeQuant/domain/mbpt/op.hpp>
+#include <SeQuant/domain/mbpt/spin.hpp> // for remove_tensor
+
+#include <CLI/CLI.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <boost/algorithm/string.hpp>
+
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+using nlohmann::json;
+using namespace sequant;
+
+class ItfContext : public itf::Context {
+public:
+	ItfContext(const IndexSpaceMeta &meta) : m_meta(&meta) {}
+
+	int compare(const Index &lhs, const Index &rhs) const override {
+		const std::size_t lhsSize = m_meta->getSize(lhs);
+		const std::size_t rhsSize = m_meta->getSize(rhs);
+
+		// We compare indices based on the size of their associated index spaces
+		// (in descending order)
+		return static_cast< long >(rhsSize) - static_cast< long >(lhsSize);
+	}
+
+	std::wstring get_base_label(const IndexSpace &space) const override { return m_meta->getLabel(space); }
+
+	std::wstring get_tag(const IndexSpace &space) const override { return m_meta->getTag(space); }
+
+	std::wstring get_name(const IndexSpace &space) const override { return m_meta->getName(space); }
+
+private:
+	const IndexSpaceMeta *m_meta;
+};
+
+ProcessingOptions extractProcessingOptions(const json &details) {
+	ProcessingOptions options;
+
+	if (details.contains("density_fitting")) {
+		options.density_fitting = details.at("density_fitting").get< bool >();
+	}
+
+	if (details.contains("spintracing")) {
+		const std::string spintrace = details.at("spintracing").get< std::string >();
+
+		if (spintrace == "none") {
+			options.spintrace = SpinTracing::None;
+		} else if (spintrace == "closed_shell") {
+			options.spintrace = SpinTracing::ClosedShell;
+		} else if (spintrace == "rigorous") {
+			options.spintrace = SpinTracing::Rigorous;
+		} else {
+			throw std::runtime_error("Invalid spintracing option '" + spintrace + "'");
+		}
+	}
+
+	if (details.contains("projection")) {
+		const std::string projection = details.at("projection").get< std::string >();
+
+		if (projection == "primitive") {
+			options.transform = ProjectionTransformation::None;
+		} else if (projection == "biorthogonal") {
+			options.transform = ProjectionTransformation::Biorthogonal;
+		} else {
+			throw std::runtime_error("Invalid projection option '" + projection + "'");
+		}
+	}
+
+	if (details.contains("optimize")) {
+		options.factorize_to_binary = details.at("optimize").get< bool >();
+	}
+
+	return options;
+}
+
+itf::Result toItfResult(std::wstring_view resultName, const ExprPtr &expr, const ItfContext &ctx,
+						bool importResultTensor) {
+	IndexGroups externals = get_unique_indices(expr);
+
+	// TODO: Handle symmetry of result tensor
+	Tensor result(resultName, bra(externals.bra), ket(externals.ket), aux(externals.aux));
+
+	return itf::Result(expr, result, importResultTensor);
+}
+
+void generateITF(const json &blocks, std::string_view out_file, const IndexSpaceMeta &spaceMeta) {
+	std::vector< itf::CodeBlock > itfBlocks;
+	ItfContext context(spaceMeta);
+
+	for (const json &current_block : blocks) {
+		const std::string block_name = current_block.at("name");
+
+		std::vector< itf::Result > results;
+
+		for (const json &current_result : current_block.at("results")) {
+			const std::string result_name = current_result.at("name");
+			const std::string input_file  = current_result.at("equation_file");
+
+			if (!std::filesystem::exists(input_file)) {
+				throw std::runtime_error("Specified input file '" + input_file + "' does not exist");
+			}
+
+			// Read input file
+			std::ifstream in(input_file);
+			const std::string input(std::istreambuf_iterator< char >(in), {});
+
+			const std::wstring transcoded_input = toUtf16(input);
+			sequant::ExprPtr expression         = sequant::parse_expr(transcoded_input);
+
+			ProcessingOptions options = extractProcessingOptions(current_result);
+
+			expression = postProcess(expression, spaceMeta, options);
+
+			// std::wcout << to_latex_align(expression) << std::endl;
+
+			std::wstring resultName = toUtf16(current_result.at("name").get< std::string >());
+
+			if (needsSymmetrization(expression)) {
+				std::optional< ExprPtr > symmetrizer = popTensor(expression, L"S");
+				assert(symmetrizer.has_value());
+
+				IndexGroups externals = get_unique_indices(symmetrizer.value());
+				results.push_back(toItfResult(resultName + L"u", expression, context, false));
+
+				ExprPtr symmetrization = generateResultSymmetrization(resultName + L"u", externals);
+				results.push_back(
+					toItfResult(resultName, symmetrization, context, current_result.value("import", true)));
+			} else {
+				results.push_back(toItfResult(resultName, expression, context, current_result.value("import", true)));
+			}
+		}
+
+		itfBlocks.push_back(itf::CodeBlock(toUtf16(current_block.at("name").get< std::string >()), std::move(results)));
+	}
+
+	std::wstring itfCode = to_itf(std::move(itfBlocks), context);
+
+	std::wofstream output(out_file.data());
+	output << itfCode;
+}
+
+void generateCode(const json &details, const IndexSpaceMeta &spaceMeta) {
+	const std::string format   = details.at("output_format");
+	const std::string out_path = details.at("output_path");
+
+	if (boost::iequals(format, "itf")) {
+		generateITF(details.at("code_blocks"), out_path, spaceMeta);
+	} else {
+		throw std::runtime_error("Unknown code generation target format '" + std::string(format) + "'");
+	}
+}
+
+void registerIndexSpaces(const json &spaces, IndexSpaceMeta &meta) {
+	IndexSpaceRegistry &registry = *get_default_context().mutable_index_space_registry();
+
+	std::vector< std::pair<std::wstring, IndexSpaceMeta::Entry> > spaceList;
+	spaceList.reserve(spaces.size());
+
+	for (std::size_t i = 0; i < spaces.size(); ++i) {
+		const json &current = spaces.at(i);
+		const IndexSpace::Type type(1 << i);
+		const int size = current.at("size");
+
+		if (size <= 0) {
+			throw std::runtime_error("Index space sizes must be > 0");
+		}
+
+		IndexSpaceMeta::Entry entry;
+		entry.name = toUtf16(current.at("name").get< std::string >());
+		entry.tag  = toUtf16(current.at("tag").get< std::string >());
+
+		std::wstring label = toUtf16(current.at("label").get< std::string >());
+		registry.add(label, type, size);
+
+		spaceList.push_back(std::make_pair(std::move(label), std::move(entry) ));
+	}
+
+	mbpt::add_fermi_spin(registry);
+
+	for (auto &[label, entry] : spaceList) {
+		meta.registerSpace(Index(label + L"_1").space(), std::move(entry));
+	}
+}
+
+void process(const json &driver, IndexSpaceMeta &spaceMeta) {
+	if (!driver.contains("index_spaces")) {
+		throw std::runtime_error("Missing index_spaces definition");
+	}
+
+	registerIndexSpaces(driver.at("index_spaces"), spaceMeta);
+
+	if (driver.contains("code_generation")) {
+		const json &details = driver.at("code_generation");
+
+		generateCode(details, spaceMeta);
+	}
+}
+
+void generalSetup() {
+	TensorCanonicalizer::set_cardinal_tensor_labels(mbpt::cardinal_tensor_labels());
+}
+
+int main(int argc, char **argv) {
+	set_locale();
+	set_default_context(
+		Context(Vacuum::SingleProduct, IndexSpaceMetric::Unit, BraKetSymmetry::conjugate, SPBasis::spinorbital));
+	generalSetup();
+
+	CLI::App app("Interface for reading in equations generated outside of SeQuant");
+	argv = app.ensure_utf8(argv);
+
+	std::string driver;
+	app.add_option("--driver", driver, "Path to the JSON file used to drive the processing")->required();
+
+	CLI11_PARSE(app, argc, argv);
+
+	if (!std::filesystem::exists(driver)) {
+		throw std::runtime_error("Specified driver file '" + driver + "' does not exist");
+	}
+
+	IndexSpaceMeta spaceMeta;
+
+	try {
+		std::ifstream in(driver);
+		json driver_info;
+		in >> driver_info;
+
+		process(driver_info, spaceMeta);
+	} catch (const std::exception &e) {
+		std::wcout << "[ERROR]: " << e.what() << std::endl;
+		return 1;
+	}
+
+	return 0;
+}

--- a/external-interface/external_interface.cpp
+++ b/external-interface/external_interface.cpp
@@ -125,8 +125,7 @@ void generateITF(const json &blocks, std::string_view out_file, const IndexSpace
 			std::ifstream in(input_file);
 			const std::string input(std::istreambuf_iterator< char >(in), {});
 
-			const std::wstring transcoded_input = toUtf16(input);
-			sequant::ExprPtr expression         = sequant::parse_expr(transcoded_input);
+			sequant::ExprPtr expression = sequant::parse_expr(toUtf16(input), Symmetry::antisymm);
 
 			ProcessingOptions options = extractProcessingOptions(current_result);
 

--- a/external-interface/external_interface.cpp
+++ b/external-interface/external_interface.cpp
@@ -1,3 +1,4 @@
+#include "format_support.hpp"
 #include "processing.hpp"
 #include "utils.hpp"
 
@@ -133,13 +134,13 @@ void generateITF(const json &blocks, std::string_view out_file, const IndexSpace
 
 			sequant::ExprPtr expression = sequant::parse_expr(toUtf16(input), Symmetry::antisymm);
 
-			spdlog::debug("Initial equation is:\n{}", toUtf8(deparse(expression)));
+			spdlog::debug("Initial equation is:\n{}", expression);
 
 			ProcessingOptions options = extractProcessingOptions(current_result);
 
 			expression = postProcess(expression, spaceMeta, options);
 
-			spdlog::debug("Fully processed equation is:\n{}", toUtf8(deparse(expression)));
+			spdlog::debug("Fully processed equation is:\n{}", expression);
 
 			std::wstring resultName = toUtf16(current_result.at("name").get< std::string >());
 
@@ -147,14 +148,14 @@ void generateITF(const json &blocks, std::string_view out_file, const IndexSpace
 				std::optional< ExprPtr > symmetrizer = popTensor(expression, L"S");
 				assert(symmetrizer.has_value());
 
-				spdlog::debug("After popping S tensor:\n{}", toUtf8(deparse(expression)));
+				spdlog::debug("After popping S tensor:\n{}", expression);
 
 				IndexGroups externals = get_unique_indices(symmetrizer.value());
 				results.push_back(toItfResult(resultName + L"u", expression, context, false));
 
 				ExprPtr symmetrization = generateResultSymmetrization(resultName + L"u", externals);
 
-				spdlog::debug("Result symmetrization via {}", toUtf8(deparse(symmetrization)));
+				spdlog::debug("Result symmetrization via\n{}", symmetrization);
 
 				results.push_back(
 					toItfResult(resultName, std::move(symmetrization), context, current_result.value("import", true)));

--- a/external-interface/external_interface.cpp
+++ b/external-interface/external_interface.cpp
@@ -94,6 +94,10 @@ ProcessingOptions extractProcessingOptions(const json &details) {
 		options.factorize_to_binary = details.at("optimize").get< bool >();
 	}
 
+	if (details.contains("expand_symmetrizer")) {
+		options.expand_symmetrizer = details.at("expand_symmetrizer").get< bool >();
+	}
+
 	return options;
 }
 

--- a/external-interface/external_interface.cpp
+++ b/external-interface/external_interface.cpp
@@ -281,7 +281,7 @@ int main(int argc, char **argv) {
 	try {
 		std::ifstream in(driver);
 		json driver_info;
-		in >> driver_info;
+		driver_info = json::parse(in, /*callback*/ nullptr, /*allow_exceptions*/ true, /*skip_comments*/ true);
 
 		process(driver_info, spaceMeta);
 	} catch (const std::exception &e) {

--- a/external-interface/external_interface.cpp
+++ b/external-interface/external_interface.cpp
@@ -182,7 +182,7 @@ void generateITF(const json &blocks, std::string_view out_file, const IndexSpace
 				}
 
 				for (ResultExpr &current : postProcess(contribution, spaceMeta, options)) {
-					spdlog::debug("Fully processed equation is:\n{}", toUtf8(to_latex(current.expression())));
+					spdlog::debug("Fully processed equation is:\n{}", current);
 
 					if (needsSymmetrization(current.expression())) {
 						std::optional< ExprPtr > symmetrizer = popTensor(current.expression(), L"S");
@@ -194,7 +194,7 @@ void generateITF(const json &blocks, std::string_view out_file, const IndexSpace
 
 						current.set_label(current.label() + L"u");
 
-						spdlog::debug("After popping S tensor:\n{}", toUtf8(to_latex(current.expression())));
+						spdlog::debug("After popping S tensor:\n{}", current);
 
 						results.push_back(toItfResult(current, context, false));
 					} else {

--- a/external-interface/format_support.hpp
+++ b/external-interface/format_support.hpp
@@ -30,8 +30,8 @@ template<> struct fmt::formatter< sequant::Index > : fmt::formatter< std::string
 template<> struct fmt::formatter< sequant::Tensor > : fmt::formatter< std::string_view > {
 	template< typename FormatContext >
 	auto format(const sequant::Tensor &tensor, FormatContext &ctx) const -> decltype(ctx.out()) {
-		return fmt::format_to(ctx.out(), "{}[{};{}]", sequant::toUtf8(tensor.label()), fmt::join(tensor.bra(), ", "),
-						 fmt::join(tensor.ket(), ", "));
+		return fmt::format_to(ctx.out(), "{}[{};{};{}]", sequant::toUtf8(tensor.label()), fmt::join(tensor.bra(), ", "),
+						 fmt::join(tensor.ket(), ", "), fmt::join(tensor.aux(), ", "));
 	}
 };
 

--- a/external-interface/format_support.hpp
+++ b/external-interface/format_support.hpp
@@ -1,0 +1,130 @@
+#ifndef SEQUANT_EXTERNAL_FORMAT_SUPPORT_HPP
+#define SEQUANT_EXTERNAL_FORMAT_SUPPORT_HPP
+
+#include <spdlog/fmt/bundled/format.h>
+#include <spdlog/fmt/bundled/ranges.h>
+
+#include <SeQuant/core/complex.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/tensor.hpp>
+#include <SeQuant/core/utility/string.hpp>
+
+#include <string_view>
+
+// Index
+template<> struct fmt::formatter< sequant::Index > : fmt::formatter< std::string_view > {
+	template< typename FormatContext >
+	auto format(const sequant::Index &idx, FormatContext &ctx) const -> decltype(ctx.out()) {
+		if (idx.has_proto_indices()) {
+			return fmt::format_to(ctx.out(), "{}", sequant::toUtf8(idx.full_label()));
+		}
+
+		return fmt::format_to(ctx.out(), "{}", sequant::toUtf8(idx.label()));
+	}
+};
+
+// Tensor
+template<> struct fmt::formatter< sequant::Tensor > : fmt::formatter< std::string_view > {
+	template< typename FormatContext >
+	auto format(const sequant::Tensor &tensor, FormatContext &ctx) const -> decltype(ctx.out()) {
+		return fmt::format_to(ctx.out(), "{}[{};{}]", sequant::toUtf8(tensor.label()), fmt::join(tensor.bra(), ", "),
+						 fmt::join(tensor.ket(), ", "));
+	}
+};
+
+// Variable
+template<> struct fmt::formatter< sequant::Variable > : fmt::formatter< std::string_view > {
+	template< typename FormatContext >
+	auto format(const sequant::Variable &variable, FormatContext &ctx) const -> decltype(ctx.out()) {
+		return fmt::format_to(ctx.out(), "{}", sequant::toUtf8(variable.label()));
+	}
+};
+
+// rational
+template<> struct fmt::formatter< sequant::rational > : fmt::formatter< std::string_view > {
+	template< typename FormatContext >
+	auto format(const sequant::rational &number, FormatContext &ctx) const -> decltype(ctx.out()) {
+		std::stringstream sstream;
+		sstream << number;
+		return fmt::format_to(ctx.out(), "{}", sstream.str());
+	}
+};
+
+// Complex
+template<> struct fmt::formatter< sequant::Complex< sequant::rational > > : fmt::formatter< std::string_view > {
+	template< typename FormatContext >
+	auto format(const sequant::Complex< sequant::rational > &number, FormatContext &ctx) const -> decltype(ctx.out()) {
+		if (number.imag().is_zero()) {
+			return fmt::format_to(ctx.out(), "{}", number.real());
+		} else if (number.real().is_zero()) {
+			return fmt::format_to(ctx.out(), "{}i", number.imag());
+		} else if (number.imag() < 0) {
+			// We need this intermediate step to prevent any template-magic types from appearing
+			// due to the multiplication.
+			decltype(number.imag()) imag = -number.imag();
+			return fmt::format_to(ctx.out(), "({} - {}i)", number.real(), imag);
+		} else {
+			return fmt::format_to(ctx.out(), "({} + {}i)", number.real(), number.imag());
+		}
+	}
+};
+
+// Constant
+template<> struct fmt::formatter< sequant::Constant > : fmt::formatter< std::string_view > {
+	template< typename FormatContext >
+	auto format(const sequant::Constant &constant, FormatContext &ctx) const -> decltype(ctx.out()) {
+		return fmt::format_to(ctx.out(), "{}", constant.value());
+	}
+};
+
+// Product
+template<> struct fmt::formatter< sequant::Product > : fmt::formatter< std::string_view > {
+	template< typename FormatContext >
+	auto format(const sequant::Product &product, FormatContext &ctx) const -> decltype(ctx.out()) {
+		if (product.scalar().is_identity()) {
+			return fmt::format_to(ctx.out(), "{}", fmt::join(product.factors(), " "));
+		} else {
+			return fmt::format_to(ctx.out(), "{} {}", product.scalar(), fmt::join(product.factors(), " "));
+		}
+	}
+};
+
+// Sum
+template<> struct fmt::formatter< sequant::Sum > : fmt::formatter< std::string_view > {
+	template< typename FormatContext >
+	auto format(const sequant::Sum &sum, FormatContext &ctx) const -> decltype(ctx.out()) {
+		return fmt::format_to(ctx.out(), "{}", fmt::join(sum.summands(), "\n+ "));
+	}
+};
+
+// Expr
+template<> struct fmt::formatter< sequant::Expr > : fmt::formatter< std::string_view > {
+	template< typename FormatContext >
+	auto format(const sequant::Expr &expr, FormatContext &ctx) const -> decltype(ctx.out()) {
+		if (expr.is< sequant::Tensor >()) {
+			return format_to(ctx.out(), "{}", expr.as< sequant::Tensor >());
+		} else if (expr.is< sequant::Constant >()) {
+			return format_to(ctx.out(), "{}", expr.as< sequant::Constant >());
+		} else if (expr.is< sequant::Variable >()) {
+			return format_to(ctx.out(), "{}", expr.as< sequant::Variable >());
+		} else if (expr.is< sequant::Sum >()) {
+			return format_to(ctx.out(), "{}", expr.as< sequant::Sum >());
+		} else if (expr.is< sequant::Product >()) {
+			return format_to(ctx.out(), "{}", expr.as< sequant::Product >());
+		} else {
+			return format_to(ctx.out(), "<Unknown expression type>)");
+		}
+	}
+};
+
+// Expr
+template<> struct fmt::formatter< sequant::ExprPtr > : fmt::formatter< std::string_view > {
+	template< typename FormatContext >
+	auto format(const sequant::ExprPtr &expr, FormatContext &ctx) const -> decltype(ctx.out()) {
+		return format_to(ctx.out(), "{}", *expr);
+	}
+};
+
+#endif // SEQUANT_EXTERNAL_FORMAT_SUPPORT_HPP

--- a/external-interface/format_support.hpp
+++ b/external-interface/format_support.hpp
@@ -8,6 +8,7 @@
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>
 #include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/result_expr.hpp>
 #include <SeQuant/core/tensor.hpp>
 #include <SeQuant/core/utility/string.hpp>
 
@@ -104,26 +105,41 @@ template<> struct fmt::formatter< sequant::Expr > : fmt::formatter< std::string_
 	template< typename FormatContext >
 	auto format(const sequant::Expr &expr, FormatContext &ctx) const -> decltype(ctx.out()) {
 		if (expr.is< sequant::Tensor >()) {
-			return format_to(ctx.out(), "{}", expr.as< sequant::Tensor >());
+			return fmt::format_to(ctx.out(), "{}", expr.as< sequant::Tensor >());
 		} else if (expr.is< sequant::Constant >()) {
-			return format_to(ctx.out(), "{}", expr.as< sequant::Constant >());
+			return fmt::format_to(ctx.out(), "{}", expr.as< sequant::Constant >());
 		} else if (expr.is< sequant::Variable >()) {
-			return format_to(ctx.out(), "{}", expr.as< sequant::Variable >());
+			return fmt::format_to(ctx.out(), "{}", expr.as< sequant::Variable >());
 		} else if (expr.is< sequant::Sum >()) {
-			return format_to(ctx.out(), "{}", expr.as< sequant::Sum >());
+			return fmt::format_to(ctx.out(), "{}", expr.as< sequant::Sum >());
 		} else if (expr.is< sequant::Product >()) {
-			return format_to(ctx.out(), "{}", expr.as< sequant::Product >());
+			return fmt::format_to(ctx.out(), "{}", expr.as< sequant::Product >());
 		} else {
-			return format_to(ctx.out(), "<Unknown expression type>)");
+			return fmt::format_to(ctx.out(), "<Unknown expression type>)");
 		}
 	}
 };
 
-// Expr
+// ExprPtr
 template<> struct fmt::formatter< sequant::ExprPtr > : fmt::formatter< std::string_view > {
 	template< typename FormatContext >
 	auto format(const sequant::ExprPtr &expr, FormatContext &ctx) const -> decltype(ctx.out()) {
-		return format_to(ctx.out(), "{}", *expr);
+		return fmt::format_to(ctx.out(), "{}", *expr);
+	}
+};
+
+// ResultExpr
+template<> struct fmt::formatter< sequant::ResultExpr > : fmt::formatter< std::string_view > {
+	template< typename FormatContext >
+	auto format(const sequant::ResultExpr &result, FormatContext &ctx) const -> decltype(ctx.out()) {
+		std::string label = result.has_label() ? sequant::toUtf8(result.label()) : "?";
+
+		if (result.bra().empty() && result.ket().empty() && result.aux().empty()) {
+			return fmt::format_to(ctx.out(), "{} =\n{}", label, result.expression());
+		}
+
+		return fmt::format_to(ctx.out(), "{}[{};{};{}] =\n{}", label, fmt::join(result.bra(), ", "), fmt::join(result.ket(), ", "),
+						 fmt::join(result.aux(), ", "), result.expression());
 	}
 };
 

--- a/external-interface/processing.cpp
+++ b/external-interface/processing.cpp
@@ -41,6 +41,12 @@ ExprPtr postProcess(const ExprPtr &expression, const IndexSpaceMeta &spaceMeta, 
 
 	container::svector< container::svector< Index > > externals = getExternalIndexPairs(processed);
 
+	if (options.expand_symmetrizer) {
+		spdlog::debug("Fully expanding all antisymmetrizers before spintracing...");
+		processed = simplify(expand_A_op(processed));
+		spdlog::debug("Expanded expression:\n{}", processed);
+	}
+
 	switch (options.spintrace) {
 		case SpinTracing::None:
 			break;

--- a/external-interface/processing.cpp
+++ b/external-interface/processing.cpp
@@ -1,0 +1,76 @@
+#include "processing.hpp"
+#include "utils.hpp"
+
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/optimize.hpp>
+#include <SeQuant/core/tensor.hpp>
+
+#include <SeQuant/domain/mbpt/spin.hpp>
+
+using namespace sequant;
+
+ExprPtr postProcess(const ExprPtr &expression, const IndexSpaceMeta &spaceMeta, const ProcessingOptions &options) {
+	if (expression.is< Constant >() || expression.is< Variable >()) {
+		return expression;
+	}
+
+	ExprPtr processed;
+	if (options.density_fitting) {
+		throw std::runtime_error("DF insertion not yet implemented");
+	}
+
+	switch (options.spintrace) {
+		case SpinTracing::None:
+			processed = expression->clone();
+			break;
+		case SpinTracing::ClosedShell:
+		case SpinTracing::Rigorous:
+			// Spintracing expects to be fed a sum
+			if (!expression.is< Sum >()) {
+				processed = ex< Sum >(ExprPtrList{ expression->clone() });
+			} else {
+				processed = expression->clone();
+			}
+			break;
+	}
+
+	container::svector< container::svector< Index > > externals = getExternalIndexPairs(processed);
+
+	switch (options.spintrace) {
+		case SpinTracing::None:
+			break;
+		case SpinTracing::ClosedShell:
+			processed = closed_shell_spintrace(processed, externals);
+			break;
+		case SpinTracing::Rigorous:
+			processed = spintrace(processed, externals);
+			break;
+	}
+
+	processed = simplify(processed);
+
+	switch (options.transform) {
+		case ProjectionTransformation::None:
+			break;
+		case ProjectionTransformation::Biorthogonal:
+			processed = simplify(biorthogonal_transform(processed, externals));
+			break;
+	}
+
+	if (options.factorize_to_binary) {
+		std::optional< ExprPtr > symmetrizer = popTensor(processed, L"S");
+		if (!symmetrizer.has_value()) {
+			symmetrizer = popTensor(processed, L"A");
+		}
+
+		processed = optimize(processed);
+
+		if (symmetrizer.has_value()) {
+			processed = ex< Product >(1, ExprPtrList{ symmetrizer.value(), processed });
+		}
+	}
+
+	return processed;
+}

--- a/external-interface/processing.cpp
+++ b/external-interface/processing.cpp
@@ -1,11 +1,11 @@
 #include "processing.hpp"
+#include "format_support.hpp"
 #include "utils.hpp"
 
 #include <SeQuant/core/container.hpp>
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>
 #include <SeQuant/core/optimize.hpp>
-#include <SeQuant/core/parse.hpp>
 #include <SeQuant/core/tensor.hpp>
 
 #include <SeQuant/domain/mbpt/spin.hpp>
@@ -54,7 +54,7 @@ ExprPtr postProcess(const ExprPtr &expression, const IndexSpaceMeta &spaceMeta, 
 
 	processed = simplify(processed);
 	if (options.spintrace != SpinTracing::None) {
-		spdlog::debug("Expression after spintracing:\n{}", toUtf8(deparse(processed)));
+		spdlog::debug("Expression after spintracing:\n{}", processed);
 	}
 
 	switch (options.transform) {
@@ -68,7 +68,7 @@ ExprPtr postProcess(const ExprPtr &expression, const IndexSpaceMeta &spaceMeta, 
 				processed =
 					simplify(ex< Product >(ExprPtrList{ symmetrizer.value(), processed }, Product::Flatten::No));
 			}
-			spdlog::debug("Expression after biorthogonal transformation:\n{}", toUtf8(deparse(processed)));
+			spdlog::debug("Expression after biorthogonal transformation:\n{}", processed);
 			break;
 	}
 

--- a/external-interface/processing.cpp
+++ b/external-interface/processing.cpp
@@ -3,10 +3,10 @@
 #include "utils.hpp"
 
 #include <SeQuant/core/container.hpp>
-#include <SeQuant/core/rational.hpp>
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>
 #include <SeQuant/core/optimize.hpp>
+#include <SeQuant/core/rational.hpp>
 #include <SeQuant/core/result_expr.hpp>
 #include <SeQuant/core/tensor.hpp>
 
@@ -16,7 +16,7 @@
 
 using namespace sequant;
 
-ExprPtr custom_biorthogonalize(ExprPtr expr, const container::svector<container::svector<Index>> &externals) {
+ExprPtr custom_biorthogonalize(ExprPtr expr, const container::svector< container::svector< Index > > &externals) {
 	assert(externals.size() <= 2);
 
 	if (externals.size() < 2) {
@@ -35,33 +35,30 @@ ExprPtr custom_biorthogonalize(ExprPtr expr, const container::svector<container:
 		return expr;
 	}
 
-	container::map<Index, Index> permutation;
+	container::map< Index, Index > permutation;
 	if (braSpacesSame) {
-		permutation = {
-			{{externals[0][0], externals[1][0]}, {externals[1][0], externals[0][0]}}
-		};
+		permutation = { { { externals[0][0], externals[1][0] }, { externals[1][0], externals[0][0] } } };
 	} else {
 		assert(ketSpacesSame);
-		permutation = {
-			{{externals[0][1], externals[1][1]}, {externals[1][1], externals[0][1]}}
-		};
+		permutation = { { { externals[0][1], externals[1][1] }, { externals[1][1], externals[0][1] } } };
 	}
 
 	ExprPtr permuted = expr.clone();
-	permuted = transform_expr(permuted, permutation);
+	permuted         = transform_expr(permuted, permutation);
 
 	spdlog::warn("Adding additional factor of 1/2 to P1/S2 expression to remain consistent with GeCCo");
 
-	return ex<Constant>(ratio{1,2}) * ex<Constant>(ratio{1,3}) * ex<Sum>(ex<Constant>(2) * expr + permuted);
+	return ex< Constant >(ratio{ 1, 2 }) * ex< Constant >(ratio{ 1, 3 })
+		   * ex< Sum >(ex< Constant >(2) * expr + permuted);
 }
 
-ResultExpr postProcess(ResultExpr result, const IndexSpaceMeta &spaceMeta, const ProcessingOptions &options) {
+container::svector< ResultExpr > postProcess(ResultExpr result, const IndexSpaceMeta &spaceMeta,
+											 const ProcessingOptions &options) {
 	if (result.expression().is< Constant >() || result.expression().is< Variable >()) {
-		return result;
+		return { result };
 	}
 
-	ExprPtr processed;
-	const container::svector< container::svector< Index > > externals =
+	container::svector< container::svector< Index > > externals =
 		result.index_particle_grouping< container::svector< Index > >();
 
 
@@ -71,74 +68,77 @@ ResultExpr postProcess(ResultExpr result, const IndexSpaceMeta &spaceMeta, const
 
 	switch (options.spintrace) {
 		case SpinTracing::None:
-			processed = result.expression()->clone();
 			break;
 		case SpinTracing::ClosedShell:
 		case SpinTracing::Rigorous:
 			// Spintracing expects to be fed a sum
 			if (!result.expression().is< Sum >()) {
-				processed = ex< Sum >(ExprPtrList{ result.expression()->clone() });
+				result.expression() = ex< Sum >(ExprPtrList{ result.expression()->clone() });
 			} else {
-				processed = result.expression()->clone();
+				result.expression() = result.expression()->clone();
 			}
 			break;
 	}
 
-	assert(processed);
+	assert(result.expression());
 
 	if (options.expand_symmetrizer) {
 		spdlog::debug("Fully expanding all antisymmetrizers before spintracing...");
-		processed = simplify(expand_A_op(processed));
-		spdlog::debug("Expanded expression:\n{}", processed);
+		result.expression() = simplify(expand_A_op(result.expression()));
+		spdlog::debug("Expanded expression:\n{}", result);
 	}
+
+	container::svector< ResultExpr > processed;
 
 	switch (options.spintrace) {
 		case SpinTracing::None:
 			break;
 		case SpinTracing::ClosedShell:
-			processed = closed_shell_spintrace(processed, externals);
+			processed = closed_shell_spintrace(result);
 			break;
 		case SpinTracing::Rigorous:
-			processed = spintrace(processed, externals);
+			processed.push_back(spintrace(result));
 			break;
 	}
 
-	processed = simplify(processed);
-	if (options.spintrace != SpinTracing::None) {
-		spdlog::debug("Expression after spintracing:\n{}", processed);
-	}
+	for (ResultExpr &current : processed) {
+		externals = current.index_particle_grouping< container::svector< Index > >();
 
-	switch (options.transform) {
-		case ProjectionTransformation::None:
-			break;
-		case ProjectionTransformation::Biorthogonal:
-			// TODO: pop S tensor first?
-			std::optional< ExprPtr > symmetrizer = popTensor(processed, L"S");
-			processed                            = custom_biorthogonalize(processed, externals);
-			spdlog::debug("Biorthogonalized without simplification:\n{}", processed);
-			processed = simplify(processed);
-			if (symmetrizer) {
-				processed =
-					simplify(ex< Product >(ExprPtrList{ symmetrizer.value(), processed }, Product::Flatten::No));
+		current.expression() = simplify(current.expression());
+		if (options.spintrace != SpinTracing::None) {
+			spdlog::debug("Expression after spintracing:\n{}", current);
+		}
+
+		switch (options.transform) {
+			case ProjectionTransformation::None:
+				break;
+			case ProjectionTransformation::Biorthogonal:
+				// TODO: pop S tensor first?
+				std::optional< ExprPtr > symmetrizer = popTensor(current.expression(), L"S");
+				current.expression()                 = custom_biorthogonalize(current.expression(), externals);
+				spdlog::debug("Biorthogonalized without simplification:\n{}", current);
+				current.expression() = simplify(current.expression());
+				if (symmetrizer) {
+					current.expression() = simplify(
+						ex< Product >(ExprPtrList{ symmetrizer.value(), current.expression() }, Product::Flatten::No));
+				}
+				spdlog::debug("Expression after biorthogonal transformation:\n{}", current);
+				break;
+		}
+
+		if (options.factorize_to_binary) {
+			std::optional< ExprPtr > symmetrizer = popTensor(current.expression(), L"S");
+			if (!symmetrizer.has_value()) {
+				symmetrizer = popTensor(current.expression(), L"A");
 			}
-			spdlog::debug("Expression after biorthogonal transformation:\n{}", processed);
-			break;
-	}
 
-	if (options.factorize_to_binary) {
-		std::optional< ExprPtr > symmetrizer = popTensor(processed, L"S");
-		if (!symmetrizer.has_value()) {
-			symmetrizer = popTensor(processed, L"A");
-		}
+			current.expression() = optimize(current.expression());
 
-		processed = optimize(processed);
-
-		if (symmetrizer.has_value()) {
-			processed = ex< Product >(1, ExprPtrList{ symmetrizer.value(), processed });
+			if (symmetrizer.has_value()) {
+				current.expression() = ex< Product >(1, ExprPtrList{ symmetrizer.value(), current.expression() });
+			}
 		}
 	}
 
-	result.expression() = std::move(processed);
-
-	return result;
+	return processed;
 }

--- a/external-interface/processing.cpp
+++ b/external-interface/processing.cpp
@@ -65,7 +65,8 @@ ExprPtr postProcess(const ExprPtr &expression, const IndexSpaceMeta &spaceMeta, 
 			std::optional< ExprPtr > symmetrizer = popTensor(processed, L"S");
 			processed                            = simplify(biorthogonal_transform(processed, externals));
 			if (symmetrizer) {
-				processed = ex< Product >(ExprPtrList{ symmetrizer.value(), processed }, Product::Flatten::No);
+				processed =
+					simplify(ex< Product >(ExprPtrList{ symmetrizer.value(), processed }, Product::Flatten::No));
 			}
 			spdlog::debug("Expression after biorthogonal transformation:\n{}", toUtf8(deparse(processed)));
 			break;

--- a/external-interface/processing.cpp
+++ b/external-interface/processing.cpp
@@ -135,7 +135,8 @@ container::svector< ResultExpr > postProcess(ResultExpr result, const IndexSpace
 			current.expression() = optimize(current.expression());
 
 			if (symmetrizer.has_value()) {
-				current.expression() = ex< Product >(1, ExprPtrList{ symmetrizer.value(), current.expression() });
+				current.expression() =
+					ex< Product >(ExprPtrList{ symmetrizer.value(), current.expression() }, Product::Flatten::No);
 			}
 		}
 	}

--- a/external-interface/processing.cpp
+++ b/external-interface/processing.cpp
@@ -61,7 +61,12 @@ ExprPtr postProcess(const ExprPtr &expression, const IndexSpaceMeta &spaceMeta, 
 		case ProjectionTransformation::None:
 			break;
 		case ProjectionTransformation::Biorthogonal:
-			processed = simplify(biorthogonal_transform(processed, externals));
+			// TODO: pop S tensor first?
+			std::optional< ExprPtr > symmetrizer = popTensor(processed, L"S");
+			processed                            = simplify(biorthogonal_transform(processed, externals));
+			if (symmetrizer) {
+				processed = ex< Product >(ExprPtrList{ symmetrizer.value(), processed }, Product::Flatten::No);
+			}
 			spdlog::debug("Expression after biorthogonal transformation:\n{}", toUtf8(deparse(processed)));
 			break;
 	}

--- a/external-interface/processing.cpp
+++ b/external-interface/processing.cpp
@@ -5,9 +5,12 @@
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>
 #include <SeQuant/core/optimize.hpp>
+#include <SeQuant/core/parse.hpp>
 #include <SeQuant/core/tensor.hpp>
 
 #include <SeQuant/domain/mbpt/spin.hpp>
+
+#include <spdlog/spdlog.h>
 
 using namespace sequant;
 
@@ -50,12 +53,16 @@ ExprPtr postProcess(const ExprPtr &expression, const IndexSpaceMeta &spaceMeta, 
 	}
 
 	processed = simplify(processed);
+	if (options.spintrace != SpinTracing::None) {
+		spdlog::debug("Expression after spintracing:\n{}", toUtf8(deparse(processed)));
+	}
 
 	switch (options.transform) {
 		case ProjectionTransformation::None:
 			break;
 		case ProjectionTransformation::Biorthogonal:
 			processed = simplify(biorthogonal_transform(processed, externals));
+			spdlog::debug("Expression after biorthogonal transformation:\n{}", toUtf8(deparse(processed)));
 			break;
 	}
 

--- a/external-interface/processing.hpp
+++ b/external-interface/processing.hpp
@@ -1,0 +1,31 @@
+#ifndef SEQUANT_EXTERNAL_INTERFACE_PROCESSING_HPP
+#define SEQUANT_EXTERNAL_INTERFACE_PROCESSING_HPP
+
+#include "utils.hpp"
+
+#include <SeQuant/core/expr_fwd.hpp>
+
+enum class SpinTracing {
+	None,
+	ClosedShell,
+	Rigorous,
+};
+
+enum class ProjectionTransformation {
+	None,
+	Biorthogonal,
+};
+
+struct ProcessingOptions {
+	ProcessingOptions() = default;
+
+	bool density_fitting               = false;
+	SpinTracing spintrace              = SpinTracing::Rigorous;
+	ProjectionTransformation transform = ProjectionTransformation::None;
+	bool factorize_to_binary           = true;
+};
+
+sequant::ExprPtr postProcess(const sequant::ExprPtr &expression, const IndexSpaceMeta &space_meta,
+							 const ProcessingOptions &options = {});
+
+#endif

--- a/external-interface/processing.hpp
+++ b/external-interface/processing.hpp
@@ -23,6 +23,7 @@ struct ProcessingOptions {
 	SpinTracing spintrace              = SpinTracing::Rigorous;
 	ProjectionTransformation transform = ProjectionTransformation::None;
 	bool factorize_to_binary           = true;
+	bool expand_symmetrizer            = false;
 };
 
 sequant::ExprPtr postProcess(const sequant::ExprPtr &expression, const IndexSpaceMeta &space_meta,

--- a/external-interface/processing.hpp
+++ b/external-interface/processing.hpp
@@ -25,6 +25,7 @@ struct ProcessingOptions {
 	ProjectionTransformation transform = ProjectionTransformation::None;
 	bool factorize_to_binary           = true;
 	bool expand_symmetrizer            = false;
+	bool term_by_term                  = false;
 };
 
 sequant::container::svector< sequant::ResultExpr > postProcess(sequant::ResultExpr expression,

--- a/external-interface/processing.hpp
+++ b/external-interface/processing.hpp
@@ -3,7 +3,7 @@
 
 #include "utils.hpp"
 
-#include <SeQuant/core/expr_fwd.hpp>
+#include <SeQuant/core/result_expr.hpp>
 
 enum class SpinTracing {
 	None,
@@ -26,7 +26,7 @@ struct ProcessingOptions {
 	bool expand_symmetrizer            = false;
 };
 
-sequant::ExprPtr postProcess(const sequant::ExprPtr &expression, const IndexSpaceMeta &space_meta,
+sequant::ResultExpr postProcess(sequant::ResultExpr expression, const IndexSpaceMeta &space_meta,
 							 const ProcessingOptions &options = {});
 
 #endif

--- a/external-interface/processing.hpp
+++ b/external-interface/processing.hpp
@@ -3,6 +3,7 @@
 
 #include "utils.hpp"
 
+#include <SeQuant/core/container.hpp>
 #include <SeQuant/core/result_expr.hpp>
 
 enum class SpinTracing {
@@ -26,7 +27,8 @@ struct ProcessingOptions {
 	bool expand_symmetrizer            = false;
 };
 
-sequant::ResultExpr postProcess(sequant::ResultExpr expression, const IndexSpaceMeta &space_meta,
-							 const ProcessingOptions &options = {});
+sequant::container::svector< sequant::ResultExpr > postProcess(sequant::ResultExpr expression,
+															   const IndexSpaceMeta &space_meta,
+															   const ProcessingOptions &options = {});
 
 #endif

--- a/external-interface/utils.cpp
+++ b/external-interface/utils.cpp
@@ -219,6 +219,19 @@ sequant::ExprPtr generateResultSymmetrization(const ResultExpr &result, std::wst
 	return generateResultSymmetrization(precursorName, externals);
 }
 
+sequant::ExprPtr generateResultSymmetrization(const Tensor &result, std::wstring_view precursorName) {
+	assert(result.bra_rank() == result.ket_rank());
+
+	IndexGroups< std::vector< Index > > externals;
+
+	for (const auto [bra, ket] : ranges::views::zip(result.bra(), result.ket())) {
+		externals.bra.push_back(bra);
+		externals.ket.push_back(ket);
+	}
+
+	return generateResultSymmetrization(precursorName, externals);
+}
+
 sequant::ExprPtr generateResultSymmetrization(std::wstring_view precursorName,
 											  const sequant::IndexGroups< std::vector< sequant::Index > > &externals) {
 	assert(externals.bra.size() == externals.ket.size());

--- a/external-interface/utils.cpp
+++ b/external-interface/utils.cpp
@@ -1,0 +1,231 @@
+#include "utils.hpp"
+
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/space.hpp>
+#include <SeQuant/core/utility/indices.hpp>
+#include <SeQuant/core/utility/string.hpp>
+
+#include <algorithm>
+#include <bitset>
+#include <cassert>
+#include <functional>
+#include <sstream>
+
+#include <range/v3/view/zip.hpp>
+
+using namespace sequant;
+
+std::size_t IndexSpaceMeta::getSize(const IndexSpace &space) const {
+	return space.approximate_size();
+}
+
+std::size_t IndexSpaceMeta::getSize(const Index &index) const {
+	return getSize(index.space());
+}
+
+std::wstring IndexSpaceMeta::getLabel(const IndexSpace &space) const {
+	return space.base_key();
+}
+
+std::wstring IndexSpaceMeta::getName(const IndexSpace &space) const {
+	auto iter = m_entries.find(space);
+	if (iter == m_entries.end()) {
+		throw std::runtime_error("No known name for index space " + toUtf8(space.base_key()));
+	}
+
+	return iter->second.name;
+}
+
+std::wstring IndexSpaceMeta::getTag(const IndexSpace &space) const {
+	auto iter = m_entries.find(space);
+	if (iter == m_entries.end()) {
+		throw std::runtime_error("No known tag for index space " + toUtf8(space.base_key()));
+	}
+
+	return iter->second.tag;
+}
+
+void IndexSpaceMeta::registerSpace(IndexSpace space, Entry entry) {
+	m_entries.insert({ std::move(space), std::move(entry) });
+}
+
+container::svector< container::svector< Index > > getExternalIndexPairs(const Tensor &tensor) {
+	container::svector< container::svector< Index > > externalPairs;
+
+	auto zipped = ranges::views::zip(tensor.bra(), tensor.ket());
+
+	for (const auto &current : zipped) {
+		externalPairs.push_back({ current.first, current.second });
+	}
+
+	for (std::size_t i = zipped.size(); i < tensor.bra_rank(); ++i) {
+		externalPairs.push_back({ tensor.bra()[i] });
+	}
+
+	for (std::size_t i = zipped.size(); i < tensor.ket_rank(); ++i) {
+		externalPairs.push_back({ tensor.ket()[i] });
+	}
+
+	for (const Index &current : tensor.aux()) {
+		externalPairs.push_back({ current });
+	}
+
+	return externalPairs;
+}
+
+container::svector< container::svector< Index > > getExternalIndexPairs(const ExprPtr &expression) {
+	if (expression->is< Tensor >()) {
+		return getExternalIndexPairs(expression->as< Tensor >());
+	}
+
+	if (expression->is< Sum >()) {
+		// External indices are expected to be the same across summands
+		return getExternalIndexPairs(expression->as< Sum >().summand(0));
+	}
+
+	const Product &product = expression->as< Product >();
+
+	if (product.at(0)->is< Tensor >()
+		&& (product.at(0).as< Tensor >().label() == L"A" || product.at(0).as< Tensor >().label() == L"S")) {
+		// Special case in the presence of an (anti)symmetrizer operator
+		return getExternalIndexPairs(product.at(0).as< Tensor >());
+	}
+
+	IndexGroups groups = get_unique_indices(expression);
+	container::svector< container::svector< Index > > externalPairs;
+
+	auto visitor = [&groups, &externalPairs](const ExprPtr &expr) {
+		assert(expr.is< Tensor >());
+
+		const Tensor &tensor = expr.as< Tensor >();
+
+		for (std::size_t i = 0; i < std::min(tensor.bra_rank(), tensor.ket_rank()); ++i) {
+			const Index &braIdx = tensor.bra()[i];
+			const Index &ketIdx = tensor.ket()[i];
+
+			const bool braIsExternal = std::find(groups.bra.begin(), groups.bra.end(), braIdx) != groups.bra.end();
+			const bool ketIsExternal = std::find(groups.ket.begin(), groups.ket.end(), ketIdx) != groups.ket.end();
+
+			if (braIsExternal && ketIsExternal) {
+				// Bra and ket index are paired -> keep them paired in external index list
+				externalPairs.push_back({ braIdx, ketIdx });
+			} else if (braIsExternal) {
+				externalPairs.push_back({ braIdx });
+			} else if (ketIsExternal) {
+				externalPairs.push_back({ ketIdx });
+			}
+		}
+	};
+
+	expression->visit(visitor, true);
+
+
+	for (Index &current : groups.aux) {
+		externalPairs.push_back({ std::move(current) });
+	}
+
+	return externalPairs;
+}
+
+std::optional< ExprPtr > popTensor(ExprPtr &expression, std::wstring_view label) {
+	std::optional< ExprPtr > tensor;
+
+	if (expression->is< Sum >()) {
+		Sum result{};
+
+		for (ExprPtr &term : expression.as< Sum >()) {
+			std::optional< ExprPtr > popped = popTensor(term, label);
+			if (!tensor.has_value()) {
+				tensor = popped;
+			}
+			assert(tensor == popped);
+
+			result.append(std::move(term));
+		}
+
+		expression.as< Sum >() = std::move(result);
+
+		return tensor;
+	}
+
+	if (expression->is< Product >()) {
+		Product result;
+		result.scale(expression.as< Product >().scalar());
+
+		for (ExprPtr &factor : expression.as< Product >()) {
+			std::optional< ExprPtr > popped = popTensor(factor, label);
+			if (!tensor.has_value()) {
+				tensor = popped;
+			}
+			assert(!popped.has_value() || tensor == popped);
+
+			if (!factor.is< Constant >() || !factor.as< Constant >().is_zero()) {
+				result.append(1, std::move(factor));
+			}
+		}
+
+		if (result.size() > 1) {
+			expression.as< Product >() = std::move(result);
+		} else if (result.size() == 1) {
+			expression = std::move(result.factor(0));
+		} else {
+			expression = ex< Constant >(0);
+		}
+
+		return tensor;
+	}
+
+	if (expression->is< Tensor >()) {
+		if (expression.as< Tensor >().label() == label) {
+			tensor     = expression;
+			expression = ex< Constant >(0);
+		}
+
+		return tensor;
+	}
+
+	if (expression->is< Constant >() || expression->is< Variable >()) {
+		return tensor;
+	}
+
+	throw std::runtime_error("Unhandled expression type in popTensor");
+}
+
+bool needsSymmetrization(const sequant::ExprPtr &expression) {
+	bool containsSymmetrizer = false;
+	// Note: the assumption is that we never encounter cases where only part of the expression requires symmetrization
+	expression->visit(
+		[&containsSymmetrizer](const ExprPtr &expr) {
+			// Right now symmetrizer operators are represented as tensor objects with name "S"
+			if (expr.is< Tensor >() && expr.as< Tensor >().label() == L"S") {
+				containsSymmetrizer = true;
+			}
+		},
+		true);
+
+	return containsSymmetrizer;
+}
+
+sequant::ExprPtr generateResultSymmetrization(std::wstring_view precursorName,
+											  const sequant::IndexGroups< std::vector< sequant::Index > > &externals) {
+	assert(externals.bra.size() == externals.ket.size());
+
+	// Note: we're only symmetrizing over bra-ket, not over auxiliary indices
+	ExprPtr symmetrization = ex< Sum >(ExprPtrList{});
+	for (std::size_t i = 0; i < externals.bra.size(); ++i) {
+		std::vector< Index > symBra;
+		std::vector< Index > symKet;
+
+		for (std::size_t j = 0; j < externals.ket.size(); ++j) {
+			symBra.push_back(externals.bra[(i + j) % externals.bra.size()]);
+			symKet.push_back(externals.ket[(i + j) % externals.ket.size()]);
+		}
+
+		// TODO: indices are not yet in canonical order for the tensor
+		// Note: if sorting them, use stable sort to not undo the symmetrization permutations
+		symmetrization += ex< Tensor >(precursorName, bra(std::move(symBra)), ket(std::move(symKet)), aux(externals.aux));
+	}
+
+	return symmetrization;
+}

--- a/external-interface/utils.cpp
+++ b/external-interface/utils.cpp
@@ -165,7 +165,7 @@ std::optional< ExprPtr > popTensor(ExprPtr &expression, std::wstring_view label)
 			}
 		}
 
-		if (result.size() > 1) {
+		if (result.size() > 1 || (result.size() == 1 && result.scalar() != 1)) {
 			expression.as< Product >() = std::move(result);
 		} else if (result.size() == 1) {
 			expression = std::move(result.factor(0));

--- a/external-interface/utils.cpp
+++ b/external-interface/utils.cpp
@@ -2,6 +2,7 @@
 
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>
+#include <SeQuant/core/result_expr.hpp>
 #include <SeQuant/core/space.hpp>
 #include <SeQuant/core/utility/indices.hpp>
 #include <SeQuant/core/utility/string.hpp>
@@ -207,6 +208,17 @@ bool needsSymmetrization(const sequant::ExprPtr &expression) {
 	return containsSymmetrizer;
 }
 
+sequant::ExprPtr generateResultSymmetrization(const ResultExpr &result, std::wstring_view precursorName) {
+	IndexGroups< std::vector< Index > > externals;
+
+	for (const auto [bra, ket] : result.index_particle_grouping< std::pair< Index, Index > >()) {
+		externals.bra.push_back(bra);
+		externals.ket.push_back(ket);
+	}
+
+	return generateResultSymmetrization(precursorName, externals);
+}
+
 sequant::ExprPtr generateResultSymmetrization(std::wstring_view precursorName,
 											  const sequant::IndexGroups< std::vector< sequant::Index > > &externals) {
 	assert(externals.bra.size() == externals.ket.size());
@@ -222,8 +234,6 @@ sequant::ExprPtr generateResultSymmetrization(std::wstring_view precursorName,
 			symKet.push_back(externals.ket[(i + j) % externals.ket.size()]);
 		}
 
-		// TODO: indices are not yet in canonical order for the tensor
-		// Note: if sorting them, use stable sort to not undo the symmetrization permutations
 		symmetrization += ex< Tensor >(precursorName, bra(std::move(symBra)), ket(std::move(symKet)), aux(externals.aux));
 	}
 

--- a/external-interface/utils.cpp
+++ b/external-interface/utils.cpp
@@ -153,7 +153,7 @@ std::optional< ExprPtr > popTensor(ExprPtr &expression, std::wstring_view label)
 		Product result;
 		result.scale(expression.as< Product >().scalar());
 
-		for (ExprPtr &factor : expression.as< Product >()) {
+		for (ExprPtr &factor : expression.as< Product >().factors()) {
 			std::optional< ExprPtr > popped = popTensor(factor, label);
 			if (!tensor.has_value()) {
 				tensor = popped;
@@ -161,7 +161,7 @@ std::optional< ExprPtr > popTensor(ExprPtr &expression, std::wstring_view label)
 			assert(!popped.has_value() || tensor == popped);
 
 			if (!factor.is< Constant >() || !factor.as< Constant >().is_zero()) {
-				result.append(1, std::move(factor));
+				result.append(1, std::move(factor), Product::Flatten::No);
 			}
 		}
 

--- a/external-interface/utils.hpp
+++ b/external-interface/utils.hpp
@@ -46,6 +46,8 @@ bool needsSymmetrization(const sequant::ExprPtr &expression);
 
 sequant::ExprPtr generateResultSymmetrization(const sequant::ResultExpr &result, std::wstring_view precursorName);
 
+sequant::ExprPtr generateResultSymmetrization(const sequant::Tensor &result, std::wstring_view precursorName);
+
 sequant::ExprPtr generateResultSymmetrization(std::wstring_view precursorName,
 											  const sequant::IndexGroups< std::vector< sequant::Index > > &externals);
 

--- a/external-interface/utils.hpp
+++ b/external-interface/utils.hpp
@@ -1,0 +1,49 @@
+#ifndef SEQUANT_EXTERNAL_INTERFACE_UTILS_HPP
+#define SEQUANT_EXTERNAL_INTERFACE_UTILS_HPP
+
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/expr_fwd.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/space.hpp>
+#include <SeQuant/core/utility/indices.hpp>
+
+#include <map>
+#include <optional>
+#include <string>
+
+class IndexSpaceMeta {
+public:
+	struct Entry {
+		std::wstring tag;
+		std::wstring name;
+	};
+
+	IndexSpaceMeta() = default;
+
+	std::size_t getSize(const sequant::IndexSpace &space) const;
+
+	std::size_t getSize(const sequant::Index &index) const;
+
+	std::wstring getLabel(const sequant::IndexSpace &space) const;
+
+	std::wstring getName(const sequant::IndexSpace &space) const;
+
+	std::wstring getTag(const sequant::IndexSpace &space) const;
+
+	void registerSpace(sequant::IndexSpace space, Entry entry);
+
+private:
+	std::map< sequant::IndexSpace, Entry > m_entries;
+};
+
+sequant::container::svector< sequant::container::svector< sequant::Index > >
+	getExternalIndexPairs(const sequant::ExprPtr &expression);
+
+std::optional< sequant::ExprPtr > popTensor(sequant::ExprPtr &expression, std::wstring_view label);
+
+bool needsSymmetrization(const sequant::ExprPtr &expression);
+
+sequant::ExprPtr generateResultSymmetrization(std::wstring_view precursorName,
+											  const sequant::IndexGroups< std::vector< sequant::Index > > &externals);
+
+#endif

--- a/external-interface/utils.hpp
+++ b/external-interface/utils.hpp
@@ -4,6 +4,7 @@
 #include <SeQuant/core/container.hpp>
 #include <SeQuant/core/expr_fwd.hpp>
 #include <SeQuant/core/index.hpp>
+#include <SeQuant/core/result_expr.hpp>
 #include <SeQuant/core/space.hpp>
 #include <SeQuant/core/utility/indices.hpp>
 
@@ -42,6 +43,8 @@ sequant::container::svector< sequant::container::svector< sequant::Index > >
 std::optional< sequant::ExprPtr > popTensor(sequant::ExprPtr &expression, std::wstring_view label);
 
 bool needsSymmetrization(const sequant::ExprPtr &expression);
+
+sequant::ExprPtr generateResultSymmetrization(const sequant::ResultExpr &result, std::wstring_view precursorName);
 
 sequant::ExprPtr generateResultSymmetrization(std::wstring_view precursorName,
 											  const sequant::IndexGroups< std::vector< sequant::Index > > &externals);

--- a/tests/unit/test_export.cpp
+++ b/tests/unit/test_export.cpp
@@ -35,20 +35,38 @@ std::vector<std::vector<std::size_t>> twoElectronIntegralSymmetries() {
 #define CAPTURE_EXPR(expr) \
   INFO(#expr " := " << ::Catch::StringMaker<sequant::ExprPtr>::convert(expr))
 
+class ItfContext : public sequant::itf::Context {
+ public:
+  ItfContext() = default;
+
+  int compare(const sequant::Index &lhs, const sequant::Index &rhs) const {
+    return rhs.space().type().to_int32() - lhs.space().type().to_int32();
+  }
+
+  std::wstring get_base_label(const sequant::IndexSpace &space) const {
+    return L"a";
+  }
+  std::wstring get_tag(const sequant::IndexSpace &space) const { return L"b"; }
+  std::wstring get_name(const sequant::IndexSpace &space) const {
+    return L"tenshi";
+  }
+};
+
 TEST_CASE("Itf export", "[exports]") {
   using namespace sequant;
+  ItfContext ctx;
 
   SECTION("remap_integrals") {
     using namespace sequant::itf::detail;
     SECTION("Unchanged") {
       auto expr = parse_expr(L"t{i1;a1}");
       auto remapped = expr;
-      remap_integrals(expr);
+      remap_integrals(expr, ctx);
       REQUIRE(remapped == expr);
 
       expr = parse_expr(L"t{i1;a1} f{a1;i1} + first{a1;i1} second{i1;a1}");
       remapped = expr;
-      remap_integrals(expr);
+      remap_integrals(expr, ctx);
       REQUIRE(remapped == expr);
     }
 
@@ -67,7 +85,7 @@ TEST_CASE("Itf export", "[exports]") {
               ket{indices[indexPerm[2]], indices[indexPerm[3]]});
 
           auto transformed = integralExpr;
-          remap_integrals(transformed);
+          remap_integrals(transformed, ctx);
 
           CAPTURE(indexPerm);
           CAPTURE_EXPR(integralExpr);
@@ -92,7 +110,7 @@ TEST_CASE("Itf export", "[exports]") {
               ket{indices[indexPerm[2]], indices[indexPerm[3]]});
 
           auto transformed = integralExpr;
-          remap_integrals(transformed);
+          remap_integrals(transformed, ctx);
 
           CAPTURE(indexPerm);
           CAPTURE_EXPR(integralExpr);
@@ -117,7 +135,7 @@ TEST_CASE("Itf export", "[exports]") {
               ket{indices[indexPerm[2]], indices[indexPerm[3]]});
 
           auto transformed = integralExpr;
-          remap_integrals(transformed);
+          remap_integrals(transformed, ctx);
 
           CAPTURE(indexPerm);
           CAPTURE_EXPR(integralExpr);
@@ -144,7 +162,7 @@ TEST_CASE("Itf export", "[exports]") {
               ket{indices[indexPerm[2]], indices[indexPerm[3]]});
 
           auto transformed = integralExpr;
-          remap_integrals(transformed);
+          remap_integrals(transformed, ctx);
 
           CAPTURE(indexPerm);
           CAPTURE_EXPR(integralExpr);
@@ -169,7 +187,7 @@ TEST_CASE("Itf export", "[exports]") {
               ket{indices[indexPerm[2]], indices[indexPerm[3]]});
 
           auto transformed = integralExpr;
-          remap_integrals(transformed);
+          remap_integrals(transformed, ctx);
 
           CAPTURE(indexPerm);
           CAPTURE_EXPR(integralExpr);
@@ -186,7 +204,7 @@ TEST_CASE("Itf export", "[exports]") {
         ExprPtr expr = parse_expr(L"f{i2;i1} + f{a1;a2}");
         const ExprPtr expected = parse_expr(L"f{i1;i2} + f{a1;a2}");
 
-        remap_integrals(expr);
+        remap_integrals(expr, ctx);
 
         CAPTURE_EXPR(expr);
         CAPTURE_EXPR(expected);
@@ -197,7 +215,7 @@ TEST_CASE("Itf export", "[exports]") {
         ExprPtr expr = parse_expr(L"f{a1;i1} + f{i1;a1}");
         const ExprPtr expected = parse_expr(L"f{a1;i1} + f{a1;i1}");
 
-        remap_integrals(expr);
+        remap_integrals(expr, ctx);
 
         CAPTURE_EXPR(expr);
         CAPTURE_EXPR(expected);

--- a/tests/unit/test_parse.cpp
+++ b/tests/unit/test_parse.cpp
@@ -413,6 +413,50 @@ TEST_CASE("parse_expr", "[parse]") {
   }
 }
 
+TEST_CASE("parse_result", "[parse]") {
+  using namespace sequant;
+
+  SECTION("constant") {
+    ResultExpr result = parse_result_expr(L"A = 3");
+
+    REQUIRE(result.has_label());
+    REQUIRE(result.label() == L"A");
+    REQUIRE(result.bra().empty());
+    REQUIRE(result.ket().empty());
+    REQUIRE(result.symmetry() == Symmetry::nonsymm);
+    REQUIRE(result.braket_symmetry() == BraKetSymmetry::nonsymm);
+    REQUIRE(result.particle_symmetry() == ParticleSymmetry::nonsymm);
+
+    REQUIRE(result.expression().is<Constant>());
+    REQUIRE(result.expression().as<Constant>().value<int>() == 3);
+  }
+  SECTION("contraction") {
+    ResultExpr result =
+        parse_result_expr(L"R{i1,i2;e1,e2}:A = f{e2;e3} t{e1,e3;i1,i2}");
+
+    REQUIRE(result.has_label());
+    REQUIRE(result.label() == L"R");
+    REQUIRE(result.bra().size() == 2);
+    REQUIRE(result.bra()[0].full_label() == L"i_1");
+    REQUIRE(result.bra()[1].full_label() == L"i_2");
+    REQUIRE(result.ket().size() == 2);
+    REQUIRE(result.ket()[0].full_label() == L"e_1");
+    REQUIRE(result.ket()[1].full_label() == L"e_2");
+    REQUIRE(result.symmetry() == Symmetry::antisymm);
+    REQUIRE(result.braket_symmetry() ==
+            get_default_context().braket_symmetry());
+    REQUIRE(result.particle_symmetry() == ParticleSymmetry::symm);
+
+    REQUIRE(result.expression().is<Product>());
+    const Product& prod = result.expression().as<Product>();
+    REQUIRE(prod.size() == 2);
+    REQUIRE(prod.factor(0).is<Tensor>());
+    REQUIRE(prod.factor(0).as<Tensor>().label() == L"f");
+    REQUIRE(prod.factor(1).is<Tensor>());
+    REQUIRE(prod.factor(1).as<Tensor>().label() == L"t");
+  }
+}
+
 TEST_CASE("deparse", "[parse]") {
   using namespace sequant;
 
@@ -433,5 +477,20 @@ TEST_CASE("deparse", "[parse]") {
     ExprPtr expression = parse_expr(current);
 
     REQUIRE(deparse(expression, true) == current);
+  }
+  SECTION("result_expressions") {
+    std::vector<std::wstring> expressions = {
+        L"A = 5",
+        L"A = g{i_1,i_2;e_1,e_2}:S-N-S * t{e_1,e_2;i_1,i_2}:N-N-S",
+        L"R{i_1,i_2;e_1,e_2}:A-N-S = f{e_2;e_3}:A-N-S * "
+        L"t{e_1,e_3;i_1,i_2}:A-N-S + "
+        L"g{i_1,i_2;e_1,e_2}:A-N-S",
+    };
+
+    for (const std::wstring& current : expressions) {
+      ResultExpr result = parse_result_expr(current);
+
+      REQUIRE(deparse(result, true) == current);
+    }
   }
 }

--- a/tests/unit/test_spin.cpp
+++ b/tests/unit/test_spin.cpp
@@ -1360,4 +1360,36 @@ SECTION("Open-shell spin-tracing") {
     REQUIRE(result2[1]->size() == 24);
   }
 }
+
+SECTION("ResultExpr") {
+  SECTION("closed_shell") {
+    ResultExpr result = parse_result_expr(
+        L"R{i1,i2,i3;a1,a2,a3}:A = 1/12 * A{i1,i2,i3;a1,a2,a3}:A f{i4;i1} "
+        L"t{a1,a2,a3;i2,i3,i4}:A");
+
+    const ExprPtr expected = closed_shell_spintrace(
+        result.expression().clone(),
+        {{L"i_1", L"a_1"}, {L"i_2", L"a_2"}, {L"i_3", L"a_3"}});
+
+    ResultExpr traced = closed_shell_spintrace(result);
+
+    REQUIRE(traced.expression() == expected);
+    REQUIRE(traced.symmetry() == Symmetry::nonsymm);
+    REQUIRE(traced.particle_symmetry() == ParticleSymmetry::symm);
+  }
+  SECTION("rigorous") {
+    ResultExpr result = parse_result_expr(
+        L"R{i1,i2;e1,e2}:A = 1/4 A{i1,i2;e1,e2}:A g{i3,i4;e3,e4}:A "
+        L"t{e3,e4;i2,i3}:A t{e1,e2;i1,i4}:A");
+
+    const ExprPtr expected = spintrace(result.expression().clone(),
+                                       {{L"i_1", L"e_1"}, {L"i_2", L"e_2"}});
+
+    ResultExpr traced = spintrace(result);
+
+    REQUIRE(traced.expression() == expected);
+    REQUIRE(traced.symmetry() == Symmetry::nonsymm);
+    REQUIRE(traced.particle_symmetry() == ParticleSymmetry::symm);
+  }
+}
 }

--- a/tests/unit/test_spin.cpp
+++ b/tests/unit/test_spin.cpp
@@ -1371,11 +1371,12 @@ SECTION("ResultExpr") {
         result.expression().clone(),
         {{L"i_1", L"a_1"}, {L"i_2", L"a_2"}, {L"i_3", L"a_3"}});
 
-    ResultExpr traced = closed_shell_spintrace(result);
+	container::svector<ResultExpr> traced = closed_shell_spintrace(result);
 
-    REQUIRE(traced.expression() == expected);
-    REQUIRE(traced.symmetry() == Symmetry::nonsymm);
-    REQUIRE(traced.particle_symmetry() == ParticleSymmetry::symm);
+	REQUIRE(traced.size() == 1);
+    REQUIRE(traced[0].expression() == expected);
+    REQUIRE(traced[0].symmetry() == Symmetry::nonsymm);
+    REQUIRE(traced[0].particle_symmetry() == ParticleSymmetry::symm);
   }
   SECTION("rigorous") {
     ResultExpr result = parse_result_expr(

--- a/tests/unit/test_spin.cpp
+++ b/tests/unit/test_spin.cpp
@@ -243,6 +243,14 @@ TEST_CASE("Spin", "[spin]") {
     REQUIRE_THAT(result, EquivalentTo("1/4"));
     REQUIRE_THAT(swap_spin(exprPtr), EquivalentTo("1/4"));
   }
+  SECTION("Variable") {
+    auto exprPtr = ex<Variable>(L"Var");
+    auto result = spintrace(exprPtr);
+    REQUIRE(result->is<Variable>());
+    REQUIRE(result->is_atom());
+    REQUIRE(result->as<Variable>().label() == L"Var");
+    REQUIRE(to_latex(swap_spin(exprPtr->clone())) == to_latex(exprPtr));
+  }
 
   SECTION("Tensor") {
     const auto expr = ex<Constant>(rational{1, 4}) *
@@ -277,6 +285,28 @@ TEST_CASE("Spin", "[spin]") {
                    EquivalentTo("- g{i1,i2;a1,a2} t{a1;i2} t{a2;i1} "
                                 "+ 2 g{i1,i2;a1,a2} t{a1;i1} t{a2;i2}"));
     }
+  }
+
+  SECTION("Scaled Product with variable") {
+    ExprPtr expr = parse_expr(L"1/2 Var g{i1,i2;a1,a2}:A t{a1;i1} t{a2;i2}");
+    auto result = spintrace(expr, {{L"i_1", L"a_1"}});
+    canonicalize(result);
+    REQUIRE_THAT(
+        result,
+        EquivalentTo(
+            L"2 Var * g{i_1,i_2;a_1,a_2}:N * t{a_1;i_1}:N * t{a_2;i_2}:N"
+            " - 1 Var * g{i_1,i_2;a_1,a_2}:N * t{a_1;i_2}:N * t{a_2;i_1}:N"));
+  }
+
+  SECTION("Tensor times variable") {
+    ResultExpr expr = parse_result_expr(
+        L"R2{a1,a2;i1,i2}:A = 1/4 A{i1,i2;a1,a2}:A INTkx{a1,a2;i1,i2}:A H");
+    auto results = closed_shell_spintrace(expr);
+    REQUIRE_THAT(
+        results.at(0),
+        EquivalentTo(L"R2{a_1,a_2;i_1,i_2}:N = -1 H * S{i_1,i_2;a_1,a_2}:N "
+                     L"* INTkx{a_1,a_2;i_2,i_1}:N + 2 H * "
+                     L"S{i_1,i_2;a_1,a_2}:N * INTkx{a_1,a_2;i_1,i_2}:N"));
   }
 
   SECTION("Sum") {
@@ -1371,9 +1401,9 @@ SECTION("ResultExpr") {
         result.expression().clone(),
         {{L"i_1", L"a_1"}, {L"i_2", L"a_2"}, {L"i_3", L"a_3"}});
 
-	container::svector<ResultExpr> traced = closed_shell_spintrace(result);
+    container::svector<ResultExpr> traced = closed_shell_spintrace(result);
 
-	REQUIRE(traced.size() == 1);
+    REQUIRE(traced.size() == 1);
     REQUIRE(traced[0].expression() == expected);
     REQUIRE(traced[0].symmetry() == Symmetry::nonsymm);
     REQUIRE(traced[0].particle_symmetry() == ParticleSymmetry::symm);


### PR DESCRIPTION
This PR makes SeQuant post-processing ready for being able to deal with multireference theories. In particular, an implicit representation of the result (via e.g. a symmetrization operator) becomes impossible due to the existence of results (residuals) that have indices of different index space in the bra and/or ket group, which must not be symmetrized. The same issue is then also relevant for spintracing, which has to be able to deal with this situation - especially the fact that spintracing a single expression can now lead to producing multiple (independent!) results.

Additionally, this PR introduce what I have called "external interface" which allows to define input equations in SeQuant-parseable form along with a JSON file detailing how the inputs shall be processed. At the moment, this interface is specifically geared towards generating ITF code in the end, but generalizations should be possible.

----

TODO
- [ ] Support spintracing of `ResultExpr` objects for other spintracing variants as well
- [ ] Move MR biorthogonalization logic into SeQuant (instead of living as custom code in the interface)
- [ ] Add MR test cases