### PR TITLE
Refactor deprecated use of shared_ptr atomic access API

### DIFF
--- a/SeQuant/core/math.hpp
+++ b/SeQuant/core/math.hpp
@@ -55,19 +55,34 @@ inline sequant::intmax_t factorial(std::size_t n) {
     return values[n];
   else {
     // this memoizes values for n>n_max_precomputed
-    static std::atomic<std::shared_ptr<std::vector<sequant::intmax_t>>> memvals;
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
+    using ValHolder =
+        std::atomic<std::shared_ptr<std::vector<sequant::intmax_t>>>;
+    auto load = [](auto &&holder) { return holder.load(); };
+    auto store = [](auto &&holder, ValHolder::value_type arg) {
+      holder.store(std::move(arg));
+    };
+#else
+    using ValHolder = std::shared_ptr<std::vector<sequant::intmax_t>>;
+    auto load = [](auto &&holder) { return std::atomic_load(&holder); };
+    auto store = [](auto &&holder, ValHolder arg) {
+      std::atomic_store(&holder, std::move(arg));
+    };
+#endif
+    static ValHolder memvals;
     // used to serialize access to memvals
     static std::mutex memvals_mutex;
 
     const std::size_t n_in_memvals = n - n_max_precomputed - 1;
-    const auto memvals_handle = memvals.load();
+    const auto memvals_handle = load(memvals);
     if (memvals_handle && memvals_handle->size() > n_in_memvals) {
       return (*memvals_handle)[n_in_memvals];
     } else {
       std::lock_guard<std::mutex> lock(memvals_mutex);
       // memvals might have been updated while we were waiting for the lock
       // hence reload the state
-      const auto memvals_handle = memvals.load();
+      const auto memvals_handle = load(memvals);
       if (memvals_handle && memvals_handle->size() > n_in_memvals) {
         return (*memvals_handle)[n_in_memvals];
       } else {
@@ -80,7 +95,7 @@ inline sequant::intmax_t factorial(std::size_t n) {
           new_memvals->emplace_back(
               (i == 0 ? values[n_max_precomputed] : new_memvals->back()) *
               (i + n_max_precomputed + 1));
-        memvals.store(new_memvals);
+        store(memvals, new_memvals);
         return (*new_memvals)[n_in_memvals];
       }
     }

--- a/SeQuant/core/math.hpp
+++ b/SeQuant/core/math.hpp
@@ -5,8 +5,9 @@
 #ifndef SEQUANT_CORE_MATH_HPP
 #define SEQUANT_CORE_MATH_HPP
 
-#include <assert.h>
 #include <SeQuant/core/rational.hpp>
+
+#include <cassert>
 #include <cstddef>
 
 namespace sequant {

--- a/SeQuant/core/math.hpp
+++ b/SeQuant/core/math.hpp
@@ -7,6 +7,7 @@
 
 #include <SeQuant/core/rational.hpp>
 
+#include <atomic>
 #include <cassert>
 #include <cstddef>
 
@@ -54,34 +55,32 @@ inline sequant::intmax_t factorial(std::size_t n) {
     return values[n];
   else {
     // this memoizes values for n>n_max_precomputed
-    static std::shared_ptr<std::vector<sequant::intmax_t>> memvals;
+    static std::atomic<std::shared_ptr<std::vector<sequant::intmax_t>>> memvals;
     // used to serialize access to memvals
     static std::mutex memvals_mutex;
 
     const std::size_t n_in_memvals = n - n_max_precomputed - 1;
-    const auto memvals_handle = std::atomic_load(&memvals);
+    const auto memvals_handle = memvals.load();
     if (memvals_handle && memvals_handle->size() > n_in_memvals) {
       return (*memvals_handle)[n_in_memvals];
     } else {
       std::lock_guard<std::mutex> lock(memvals_mutex);
       // memvals might have been updated while we were waiting for the lock
       // hence reload the state
-      const auto memvals_handle =
-          memvals;  // nonatomic read OK since I'm the only writer
+      const auto memvals_handle = memvals.load();
       if (memvals_handle && memvals_handle->size() > n_in_memvals) {
         return (*memvals_handle)[n_in_memvals];
       } else {
-        decltype(memvals) new_memvals =
-            std::make_shared<std::vector<sequant::intmax_t>>(
-                memvals_handle
-                    ? *memvals_handle
-                    : std::vector<sequant::intmax_t>{});  // copy old memvals
+        auto new_memvals = std::make_shared<std::vector<sequant::intmax_t>>(
+            memvals_handle
+                ? *memvals_handle
+                : std::vector<sequant::intmax_t>{});  // copy old memvals
         new_memvals->reserve(n_in_memvals + 1);
         for (auto i = new_memvals->size(); i <= n_in_memvals; ++i)
           new_memvals->emplace_back(
               (i == 0 ? values[n_max_precomputed] : new_memvals->back()) *
               (i + n_max_precomputed + 1));
-        std::atomic_store(&memvals, new_memvals);
+        memvals.store(new_memvals);
         return (*new_memvals)[n_in_memvals];
       }
     }


### PR DESCRIPTION
Using a plain std::shared_ptr together with std::atomic_{load,store} has
been deprecated in C++20 and the API is removed in C++26. See P2869
(and/or https://github.com/cplusplus/papers/issues/1525) for details.

This commit removes the use of this depracted API in the way suggested
by P2869 (that is, wrap in a std::atomic type and use that directly
rather than via std::atomic_{load,store}).