### PR TITLE
Add ext index consistency check to spintrace()

### DIFF
--- a/SeQuant/core/utility/indices.hpp
+++ b/SeQuant/core/utility/indices.hpp
@@ -335,8 +335,8 @@ Container external_indices(const Expr& expr) {
   std::optional<Tensor> symmetrizer;
   expr.visit(
       [&](const ExprPtr& expr) {
-        if (expr.is<Tensor>() && expr.as<Tensor>().label() == L"S" ||
-            expr.as<Tensor>().label() == L"A") {
+        if (expr.is<Tensor>() && (expr.as<Tensor>().label() == L"S" ||
+                                  expr.as<Tensor>().label() == L"A")) {
           assert(!symmetrizer.has_value() ||
                  symmetrizer.value() == expr.as<Tensor>());
           symmetrizer = expr.as<Tensor>();

--- a/SeQuant/domain/mbpt/spin.cpp
+++ b/SeQuant/domain/mbpt/spin.cpp
@@ -1562,6 +1562,22 @@ ExprPtr spintrace(
     return expression;
   }
 
+#ifndef NDEBUG
+  // Verify that the amount of external indices matches the amount of indices in
+  // ext_index_groups
+  auto count_indices = [](const auto& range) {
+    auto sizes = range | ranges::views::transform(
+                             [](const auto& list) { return list.size(); });
+    return std::accumulate(sizes.begin(), sizes.end(), 0);
+  };
+  auto determined_externals =
+      external_indices<container::svector<container::svector<Index>>>(
+          expression);
+
+  assert(count_indices(ext_index_groups) ==
+         count_indices(determined_externals));
+#endif
+
   // This function must be used for tensors with spin-specific indices only. If
   // the spin-symmetry is conserved: the tensor is expanded; else: zero is
   // returned.

--- a/tests/unit/test_spin.cpp
+++ b/tests/unit/test_spin.cpp
@@ -278,7 +278,7 @@ TEST_CASE("spin", "[spin]") {
   SECTION("Product") {
     const auto expr = ex<Tensor>(L"f", bra{L"i_1"}, ket{L"a_1"}) *
                       ex<Tensor>(L"t", bra{L"a_1"}, ket{L"i_1"});
-    auto result = spintrace(expr, {{L"i_1", L"a_1"}});
+    auto result = spintrace(expr);
     canonicalize(result);
     REQUIRE_THAT(result, EquivalentTo("2 f{i1;a1} t{a1;i1}"));
   }
@@ -291,7 +291,7 @@ TEST_CASE("spin", "[spin]") {
                                    ket{L"a_1", L"a_2"}, Symmetry::antisymm) *
                         ex<Tensor>(L"t", bra{L"a_1"}, ket{L"i_1"}) *
                         ex<Tensor>(L"t", bra{L"a_2"}, ket{L"i_2"});
-      auto result = spintrace(expr, {{L"i_1", L"a_1"}});
+      auto result = spintrace(expr);
       canonicalize(result);
       REQUIRE_THAT(result,
                    EquivalentTo("- g{i1,i2;a1,a2} t{a1;i2} t{a2;i1} "
@@ -301,7 +301,7 @@ TEST_CASE("spin", "[spin]") {
 
   SECTION("Scaled Product with variable") {
     ExprPtr expr = parse_expr(L"1/2 Var g{i1,i2;a1,a2}:A t{a1;i1} t{a2;i2}");
-    auto result = spintrace(expr, {{L"i_1", L"a_1"}});
+    auto result = spintrace(expr);
     canonicalize(result);
     REQUIRE_THAT(
         result,


### PR DESCRIPTION
However, the question is: is it a desired feature for `spintrace` to be given a (seemingly) inconsistent set of external indices? 'cause there are some test cases that do this. I'm just not sure whether this is on purpose or not...

EDIT: This has been discussed and it's indeed the test cases that are faulty. Hence we'll keep the consistency check in place and fix the test cases.