### PR TITLE
Scaled leaf tensor intermediate does not have leaf tensor's label.

### DIFF
--- a/SeQuant/core/eval_expr.cpp
+++ b/SeQuant/core/eval_expr.cpp
@@ -559,9 +559,18 @@ EvalExprNode binarize(Product const& prod) {
 
     auto h = left->hash_value();
     hash::combine(h, right->hash_value());
+
+    ExprPtr result_expr = left->expr();
+    if (left->result_type() == ResultType::Tensor &&
+        left->op_type() == EvalOp::Id) {
+      auto const& t = left->as_tensor();
+      result_expr =
+          dummy::make_tensor(bra(t.bra()), ket(t.ket()), aux(t.aux()));
+    }
+
     auto result = EvalExpr{EvalOp::Prod,           //
                            left->result_type(),    //
-                           left->expr(),           //
+                           result_expr,            //
                            left->canon_indices(),  //
                            1,                      //
                            h};

--- a/tests/unit/test_eval_expr.cpp
+++ b/tests/unit/test_eval_expr.cpp
@@ -289,5 +289,11 @@ TEST_CASE("eval_expr", "[EvalExpr]") {
                      ->as<Tensor>()};
 
     REQUIRE_NOTHROW(result_expr(t1, t2, EvalOp::Prod));
+
+    auto const node = binarize(parse_expr(L"42 t{a1;i1}"));
+    REQUIRE(node->op_type() == EvalOp::Prod);
+    REQUIRE(node->is_tensor());
+    REQUIRE(!node.leaf());
+    REQUIRE(node->as_tensor().label() != L"t");
   }
 }


### PR DESCRIPTION
eg.
before: `(42 * t{a1;i1}) -> t{a1;i1}`
after: `(42 * t{a1;i1}) -> I{a1;i1}`

nb. `I` is a dummy label.