### PR TITLE
Roll back to `TensorNetworkV1`.

### DIFF
--- a/SeQuant/core/eval_expr.cpp
+++ b/SeQuant/core/eval_expr.cpp
@@ -9,7 +9,7 @@
 #include <SeQuant/core/index.hpp>
 #include <SeQuant/core/tensor.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
-#include <SeQuant/core/tensor_network_v2.hpp>
+#include <SeQuant/core/tensor_network.hpp>
 #include <SeQuant/core/utility/indices.hpp>
 #include <SeQuant/core/wstring.hpp>
 #include <SeQuant/external/bliss/graph.hh>
@@ -84,7 +84,7 @@ EvalExpr::EvalExpr(Tensor const& tnsr)
       expr_{tnsr.clone()} {
   if (is_tot(tnsr)) {
     ExprPtrList tlist{expr_};
-    auto tn = TensorNetworkV2(tlist);
+    auto tn = TensorNetwork(tlist);
     auto md =
         tn.canonicalize_slots(TensorCanonicalizer::cardinal_tensor_labels());
     hash_value_ = md.hash_value();
@@ -527,7 +527,7 @@ EvalExprNode binarize(Product const& prod) {
       collect_tensor_factors(left, subfacs);
       collect_tensor_factors(right, subfacs);
       auto ts = subfacs | transform([](auto&& t) { return t.expr; });
-      auto tn = TensorNetworkV2(ts);
+      auto tn = TensorNetwork(ts);
       auto canon =
           tn.canonicalize_slots(TensorCanonicalizer::cardinal_tensor_labels());
       hash::combine(h, canon.hash_value());

--- a/tests/unit/test_tensor_network.cpp
+++ b/tests/unit/test_tensor_network.cpp
@@ -1075,4 +1075,22 @@ TEST_CASE("tensor_network_v2", "[elements]") {
       // std::wcout << oss.str() << std::endl;
     }
   }
+
+  SECTION("debug") {
+    auto const prod1 =
+        parse_expr(L"g{i_2,i_3;a_2,a_3}:A-C-S * t{a_2;i_2}:A-C-S")
+            ->as<Product>();
+    auto const prod2 =
+        parse_expr(L"g{i_2,i_3;a_2,a_3}:A-C-S * t{a_2;i_3}:A-C-S")
+            ->as<Product>();
+
+    auto tn1 = TensorNetworkV2(prod1.factors());
+    auto tn2 = TensorNetworkV2(prod2.factors());
+    auto const canon1 =
+        tn1.canonicalize_slots(TensorCanonicalizer::cardinal_tensor_labels());
+    auto const canon2 =
+        tn2.canonicalize_slots(TensorCanonicalizer::cardinal_tensor_labels());
+    REQUIRE(canon1.hash_value() == canon2.hash_value());
+    CHECK_FALSE(canon1.phase == canon2.phase);
+  }
 }


### PR DESCRIPTION
`TensorNetworkV2` needs more testing. Using it produces incorrect result for spin-orbital CC calculations in `mpqc4` when cache management is involved. This suggests the phase computation (?) in `TensorNetworkV2::canonicalize_slots` is not correct. `TensorNetworkV2::canonicalize` seems OK as it is also used heavily in closed-shell CC tests and those pass.