### PR TITLE
Disable cloning of ranges-v3 docs repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ check_cxx_execution_header(SEQUANT)
 
 # Ranges-V3
 include(FindOrFetchRangeV3)
+set(RANGE_V3_DOCS OFF) # Disable cloning of range-v3 docs repo
 
 # Boost will be added after defining SeQuant
 include(external/boost.cmake)


### PR DESCRIPTION
By default Range-V3 docs are also cloned as a submodule
```
[1/9] Creating directories for 'rangev3-populate'
[1/9] Performing download step (git clone) for 'rangev3-populate'
Cloning into 'rangev3-src'...
HEAD is now at a81477931 release 0.12.0
Submodule 'doc/gh-pages' (https://github.com/ericniebler/range-v3.git) registered for path 'doc/gh-pages'
Cloning into '/Users/ajay/Code/mpqc4/cmake-build-debug/_deps/rangev3-src/doc/gh-pages'...
Submodule path 'doc/gh-pages': checked out '2dae74bb693e42d850fb0adcc9045c5b71fbdeae'
```