### PR TITLE
Compute intermediate hashes strictly.

### DIFF
--- a/SeQuant/core/eval_expr.cpp
+++ b/SeQuant/core/eval_expr.cpp
@@ -324,10 +324,10 @@ EvalExprNode binarize(Product const& prod) {
                  | ranges::to_vector;
 
   auto hvals = factors | transform([](auto&& n) { return n->hash_value(); });
+  auto const hs = imed_hashes(hvals) | ranges::to_vector;
 
-  auto make_prod = [i = 0, hs = imed_hashes(hvals)](
-                       EvalExprNode const& left,
-                       EvalExprNode const& right) mutable -> EvalExpr {
+  auto make_prod = [i = 0, &hs](EvalExprNode const& left,
+                                EvalExprNode const& right) mutable -> EvalExpr {
     auto h = ranges::at(hs, ++i);
     if (left->is_scalar() && right->is_scalar()) {
       // scalar * scalar

--- a/tests/unit/test_eval_expr.cpp
+++ b/tests/unit/test_eval_expr.cpp
@@ -200,6 +200,10 @@ TEST_CASE("eval_expr", "[EvalExpr]") {
 
     REQUIRE_FALSE(x1.hash_value() == x3.hash_value());
     REQUIRE_FALSE(x12.hash_value() == x3.hash_value());
+    auto tree1 = binarize(parse_expr(L"A C"));
+    auto tree2 = binarize(parse_expr(L"A t{a1;i1}"));
+
+    REQUIRE(tree1->hash_value() != tree2->hash_value());
   }
 
   SECTION("Symmetry of product") {


### PR DESCRIPTION
This is required instead of lazily computing them during binarization to avoid surprises. See the test cases.