### PR TITLE
Run `/doc/examples/`

### DIFF
--- a/doc/examples/CMakeLists.txt
+++ b/doc/examples/CMakeLists.txt
@@ -8,6 +8,9 @@ endif()
 
 file(GLOB_RECURSE EXAMPLE_CODES LIST_DIRECTORIES false CONFIGURE_DEPENDS "*.cpp")
 
+# Create a list to track runnable examples
+set(RUNNABLE_DOC_EXAMPLES "")
+
 set(counter 1)
 foreach(current IN LISTS EXAMPLE_CODES)
     file(READ "${current}" contents)
@@ -16,6 +19,11 @@ foreach(current IN LISTS EXAMPLE_CODES)
 
     if ("${contents}" MATCHES " main\\(")
         add_executable(${current_name} ${current})
+
+        # check if running is disabled, we do not want to run very expensive examples
+        if (NOT "${contents}" MATCHES "// SEQUANT_DOC_EXAMPLE: DO NOT RUN")
+            list(APPEND RUNNABLE_DOC_EXAMPLES ${current_name})
+        endif ()
     else()
         add_library(${current_name} ${current})
     endif()
@@ -32,3 +40,15 @@ foreach(current IN LISTS EXAMPLE_CODES)
 
     math(EXPR counter "${counter} + 1")
 endforeach()
+
+# Testing runnable examples
+if (SEQUANT_TESTS AND RUNNABLE_DOC_EXAMPLES)
+    foreach (example IN LISTS RUNNABLE_DOC_EXAMPLES)
+        # these tests should fail if any runtime issue is encountered
+        add_test(
+                NAME "sequant/doc-examples/${example}"
+                COMMAND ${example}
+                WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        )
+    endforeach ()
+endif ()

--- a/doc/examples/user/cc.cpp
+++ b/doc/examples/user/cc.cpp
@@ -8,6 +8,8 @@
 #include <SeQuant/domain/mbpt/models/cc.hpp>
 #include <SeQuant/domain/mbpt/spin.hpp>
 
+// SEQUANT_DOC_EXAMPLE: DO NOT RUN
+
 int main() {
   // start-snippet-0
   using namespace sequant;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,5 +23,5 @@ add_subdirectory(integration)
 
 # target for running ALL tests
 add_custom_target_subproject(sequant check
-    USES_TERMINAL COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -R "^sequant")
-
+    USES_TERMINAL COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -R "^sequant"
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
Address issue #316 

Examples files in `doc/examples` can now be tested as part of the test suite. 

We already separate examples into executables and libraries based on the presence of `main()` function. Now, the executables are added to the test suite, and `ctest` will discover them as part of `check_sequant` target. 

Time consuming tests can be disabled by using adding `// SEQUANT_DOC_EXAMPLE: DO NOT RUN` comment in the source file (see `doc/examples/cc.cpp`)