### PR TITLE
Drop `find_package` from FindOrFetchGoogleBenchmark

### DIFF
--- a/cmake/modules/FindOrFetchGoogleBenchmark.cmake
+++ b/cmake/modules/FindOrFetchGoogleBenchmark.cmake
@@ -1,5 +1,3 @@
-find_package(benchmark)
-
 if (NOT TARGET benchmark::benchmark)
     include(${vg_cmake_kit_SOURCE_DIR}/modules/VRGFindOrFetchPackage.cmake)
 


### PR DESCRIPTION
As discussed in #312, `find_package` is not needed here, can directly use `VRGFindOrFetchPackage` module. 