### PR TITLE
use `boost::container::small_vector` for `bliss::{Graph,Digraph}::Vertex::edges*`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,13 @@ add_library(SeQuant-bliss
         SeQuant/external/bliss/bliss_C.cc
         SeQuant/external/bliss/bliss_C.h
         )
-target_link_libraries(SeQuant-bliss PUBLIC range-v3::range-v3)
+target_link_libraries(SeQuant-bliss PUBLIC range-v3::range-v3 Boost::headers)
+# modularized Boost has finer grained targets than just Boost::headers
+if (Boost_IS_MODULARIZED)
+    target_link_libraries(SeQuant-bliss PUBLIC
+            Boost::container
+    )
+endif()
 
 set(SeQuant_src
         ${PROJECT_BINARY_DIR}/SeQuant/version.hpp

--- a/SeQuant/external/bliss/graph.cc
+++ b/SeQuant/external/bliss/graph.cc
@@ -14,9 +14,9 @@
 /*
   Copyright (c) 2003-2015 Tommi Junttila
   Released under the GNU Lesser General Public License version 3.
-  
+
   This file is part of bliss.
-  
+
   bliss is free software: you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as published by
   the Free Software Foundation, version 3 of the License.
@@ -84,7 +84,7 @@ AbstractGraph::~AbstractGraph()
     free(first_path_automorphism); first_path_automorphism = 0; }
   if(best_path_automorphism) {
     free(best_path_automorphism); best_path_automorphism = 0; }
- 
+
   report_hook = 0;
   report_user_param = 0;
 }
@@ -602,7 +602,7 @@ public:
   bool needs_long_prune;
   unsigned int long_prune_begin;
   std::set<unsigned int, std::less<unsigned int> > long_prune_redundant;
-  
+
   UintSeqHash eqref_hash;
   unsigned int subcertificate_length;
 };
@@ -666,7 +666,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
   /* ... and the component recursion data structures in the partition */
   if(opt_use_comprec)
     p.cr_init();
-  
+
   neighbour_heap.init(N);
 
   in_search = false;
@@ -688,7 +688,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 	      timer1.get_duration());
       fflush(verbstr);
     }
-  
+
 
 
   /*
@@ -783,7 +783,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
   cr_level = 0;
   if(opt_use_comprec and
      nucr_find_first_component(cr_level) == true and
-     p.nof_discrete_cells() + cr_component_elements < 
+     p.nof_discrete_cells() + cr_component_elements <
      cr_cep_stack[cr_cep_index].discrete_cell_limit)
     {
       cr_level = p.cr_split_level(0, cr_component);
@@ -837,7 +837,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
   /*
    * The actual backtracking search
    */
-  while(!search_stack.empty()) 
+  while(!search_stack.empty())
     {
       TreeNode&          current_node  = search_stack.back();
       const unsigned int current_level = (unsigned int)search_stack.size()-1;
@@ -867,7 +867,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 	  if(current_node.fp_extendable == TreeNode::YES)
 	    {
 	      search_stack.pop_back();
-	      continue;	      
+	      continue;
 	    }
 	  if(current_node.split_element == TreeNode::SPLIT_END)
 	    {
@@ -907,7 +907,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
       /* Fetch split cell information */
       Partition::Cell * const cell =
 	p.get_cell(p.elements[current_node.split_cell_first]);
-  
+
       /* Restore component recursion information */
       cr_level = current_node.cr_level;
       cr_cep_stack.resize(current_node.cr_cep_stack_size);
@@ -1049,7 +1049,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 	      }
 	    continue;
 	  }
-	
+
 	/* Split on smallest */
 	current_node.split_element = next_split_element;
       }
@@ -1094,7 +1094,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
        */
       if(cell->is_unit())
 	refine_to_equitable(cell, new_cell);
-      else 
+      else
 	refine_to_equitable(new_cell);
 
 
@@ -1108,7 +1108,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
       if(!first_path_info.empty())
 	{
 	  /* We are no longer on the first path */
-	  const unsigned int subcertificate_length = 
+	  const unsigned int subcertificate_length =
 	    certificate_current_path.size() - certificate_index;
 	  if(refine_equal_to_first)
 	    {
@@ -1179,7 +1179,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 		}
 	    }
 
-	  
+
 	  /* Check if no longer equal to the first path and,
 	   * if canonical labeling is desired, also worse than the
 	   * current best path */
@@ -1305,14 +1305,14 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 
 	  if(opt_use_failure_recording)
 	    failure_recording_hashes.resize(base_size);
-	  
+
 	  /*
 	  for(unsigned int j = 0; j < search_stack.size(); j++)
 	    fprintf(stderr, "%u ", search_stack[j].split_element);
 	  fprintf(stderr, "\n");
 	  p.print(stderr); fprintf(stderr, "\n");
 	  */
-	  
+
 	  /*
 	   * Backtrack to the previous level
 	   */
@@ -1562,7 +1562,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 	  continue;
 	}
 
-      
+
     handle_best_path_automorphism:
       /*
        *
@@ -1596,13 +1596,13 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 		  best_path_automorphism[p.elements[i]] = p.elements[i];
 	    }
 	  }
-	
+
 #if defined(BLISS_VERIFY_AUTOMORPHISMS)
 	/* Verify that it really is an automorphism */
 	if(!is_automorphism(best_path_automorphism))
 	  fatal_error("Best path automorhism validation check failed");
 #endif
-	
+
 	unsigned int gca_level_with_first = 0;
 	for(unsigned int i = search_stack.size(); i > 0; i--) {
 	  if((int)first_path_info[gca_level_with_first].splitting_element !=
@@ -1624,7 +1624,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 	    /* Record automorphism */
 	    long_prune_add_automorphism(best_path_automorphism);
 	  }
-	    
+
 	/*
 	 * Update orbit information
 	 */
@@ -1646,7 +1646,7 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 	    /* Update statistics */
 	    stats.nof_generators++;
 	  }
-	  
+
 	/*
 	 * Compute backjumping level
 	 */
@@ -1668,14 +1668,14 @@ AbstractGraph::search(const bool canonical, Stats& stats)
 
       _INTERNAL_ERROR();
 
-      
+
     handle_first_path_automorphism:
       /*
        *
        * A first-path automorphism: aut[i] = elements[first_path_labeling[i]]
        *
        */
-      
+
 
       if(p.is_discrete())
 	{
@@ -1705,17 +1705,17 @@ AbstractGraph::search(const bool canonical, Stats& stats)
       if(!is_automorphism(first_path_automorphism))
 	fatal_error("First path automorphism validation check failed");
 #endif
-      
+
       if(opt_use_long_prune)
 	{
 	  long_prune_add_automorphism(first_path_automorphism);
 	}
-      
+
       /*
        * Update orbit information
        */
       update_orbit_information(first_path_orbits, first_path_automorphism);
-      
+
       /*
        * Compute backjumping level
        */
@@ -1838,7 +1838,7 @@ Digraph::Vertex::remove_duplicate_edges(std::vector<bool>& tmp)
   /* Pre-conditions  */
   for(unsigned int i = 0; i < tmp.size(); i++) assert(tmp[i] == false);
 #endif
-  for(std::vector<unsigned int>::iterator iter = edges_out.begin();
+  for(auto iter = edges_out.begin();
       iter != edges_out.end(); )
     {
       const unsigned int dest_vertex = *iter;
@@ -1856,14 +1856,14 @@ Digraph::Vertex::remove_duplicate_edges(std::vector<bool>& tmp)
     }
 
   /* Clear tmp */
-  for(std::vector<unsigned int>::iterator iter = edges_out.begin();
+  for(auto iter = edges_out.begin();
       iter != edges_out.end();
       iter++)
     {
       tmp[*iter] = false;
     }
 
-  for(std::vector<unsigned int>::iterator iter = edges_in.begin();
+  for(auto iter = edges_in.begin();
       iter != edges_in.end(); )
     {
       const unsigned int dest_vertex = *iter;
@@ -1881,7 +1881,7 @@ Digraph::Vertex::remove_duplicate_edges(std::vector<bool>& tmp)
     }
 
   /* Clear tmp */
-  for(std::vector<unsigned int>::iterator iter = edges_in.begin();
+  for(auto iter = edges_in.begin();
       iter != edges_in.end();
       iter++)
     {
@@ -2004,8 +2004,8 @@ Digraph::cmp(Digraph& other)
       Vertex& v2 = other.vertices[i];
       v1.sort_edges();
       v2.sort_edges();
-      std::vector<unsigned int>::const_iterator ei1 = v1.edges_in.begin();
-      std::vector<unsigned int>::const_iterator ei2 = v2.edges_in.begin();
+      auto ei1 = v1.edges_in.begin();
+      auto ei2 = v2.edges_in.begin();
       while(ei1 != v1.edges_in.end())
 	{
 	  if(*ei1 < *ei2)
@@ -2041,7 +2041,7 @@ Digraph::permute(const std::vector<unsigned int>& perm) const
     {
       const Vertex& v = vertices[i];
       g->change_color(perm[i], v.color);
-      for(std::vector<unsigned int>::const_iterator ei = v.edges_out.begin();
+      for(auto ei = v.edges_out.begin();
 	  ei != v.edges_out.end();
 	  ei++)
 	{
@@ -2061,7 +2061,7 @@ Digraph::permute(const unsigned int* const perm) const
     {
       const Vertex &v = vertices[i];
       g->change_color(perm[i], v.color);
-      for(std::vector<unsigned int>::const_iterator ei = v.edges_out.begin();
+      for(auto ei = v.edges_out.begin();
 	  ei != v.edges_out.end();
 	  ei++)
 	{
@@ -2109,7 +2109,7 @@ Digraph::write_dot(FILE* const fp)
     {
       const Vertex& v = *vi;
       fprintf(fp, "v%u [label=\"%u:%u\"];\n", vnum, vnum, v.color);
-      for(std::vector<unsigned int>::const_iterator ei = v.edges_out.begin();
+      for(auto ei = v.edges_out.begin();
 	  ei != v.edges_out.end();
 	  ei++)
 	{
@@ -2167,7 +2167,7 @@ Digraph::get_hash()
   for(unsigned int i = 0; i < get_nof_vertices(); i++)
     {
       Vertex &v = vertices[i];
-      for(std::vector<unsigned int>::const_iterator ei = v.edges_out.begin();
+      for(auto ei = v.edges_out.begin();
 	  ei != v.edges_out.end();
 	  ei++)
 	{
@@ -2198,7 +2198,7 @@ Digraph::read_dimacs(FILE* const fp, FILE* const errstr)
 
   const bool verbose = false;
   FILE* const verbstr = stdout;
-  
+
   /* Read comments and the problem definition line */
   while(1)
     {
@@ -2235,7 +2235,7 @@ Digraph::read_dimacs(FILE* const fp, FILE* const errstr)
 	fprintf(errstr, "error in line %u: not in DIMACS format\n", line_num);
       goto error_exit;
     }
-  
+
   if(nof_vertices <= 0)
     {
       if(errstr)
@@ -2336,7 +2336,7 @@ Digraph::read_dimacs(FILE* const fp, FILE* const errstr)
       fprintf(verbstr, "Done\n");
       fflush(verbstr);
     }
-  
+
   return g;
 
  error_exit:
@@ -2382,7 +2382,7 @@ Digraph::write_dimacs(FILE* const fp)
   for(unsigned int i = 0; i < get_nof_vertices(); i++)
     {
       Vertex& v = vertices[i];
-      for(std::vector<unsigned int>::const_iterator ei = v.edges_out.begin();
+      for(auto ei = v.edges_out.begin();
 	  ei != v.edges_out.end();
 	  ei++)
 	{
@@ -2427,7 +2427,7 @@ Digraph::selfloop_invariant(const Digraph* const g, const unsigned int vnum)
 {
   /* Quite inefficient but luckily not in the critical path */
   const Vertex& v = g->vertices[vnum];
-  for(std::vector<unsigned int>::const_iterator ei = v.edges_out.begin();
+  for(auto ei = v.edges_out.begin();
       ei != v.edges_out.end();
       ei++)
     {
@@ -2455,7 +2455,7 @@ Digraph::refine_according_to_invariant(unsigned int (*inv)(const Digraph* const 
 
   for(Partition::Cell* cell = p.first_nonsingleton_cell; cell; )
     {
-      
+
       Partition::Cell* const next_cell = cell->next_nonsingleton;
       const unsigned int* ep = p.elements + cell->first;
       for(unsigned int i = cell->length; i > 0; i--, ep++)
@@ -2491,7 +2491,7 @@ Digraph::refine_according_to_invariant(unsigned int (*inv)(const Digraph* const 
 bool
 Digraph::split_neighbourhood_of_cell(Partition::Cell* const cell)
 {
-  
+
 
   const bool was_equal_to_first = refine_equal_to_first;
 
@@ -2505,8 +2505,8 @@ Digraph::split_neighbourhood_of_cell(Partition::Cell* const cell)
   for(unsigned int i = cell->length; i > 0; i--)
     {
       const Vertex& v = vertices[*ep++];
-      
-      std::vector<unsigned int>::const_iterator ei = v.edges_out.begin();
+
+      auto ei = v.edges_out.begin();
       for(unsigned int j = v.nof_edges_out(); j != 0; j--)
 	{
 	  const unsigned int dest_vertex = *ei++;
@@ -2530,7 +2530,7 @@ Digraph::split_neighbourhood_of_cell(Partition::Cell* const cell)
     {
       const unsigned int start = neighbour_heap.remove();
       Partition::Cell* const neighbour_cell = p.get_cell(p.elements[start]);
-      
+
       if(compute_eqref_hash)
 	{
 	  eqref_hash.update(neighbour_cell->first);
@@ -2578,7 +2578,7 @@ Digraph::split_neighbourhood_of_cell(Partition::Cell* const cell)
     {
       const Vertex& v = vertices[*ep++];
 
-      std::vector<unsigned int>::const_iterator ei = v.edges_in.begin();
+      auto ei = v.edges_in.begin();
       for(unsigned int j = v.nof_edges_in(); j > 0; j--)
 	{
 	  const unsigned int dest_vertex = *ei++;
@@ -2646,7 +2646,7 @@ Digraph::split_neighbourhood_of_cell(Partition::Cell* const cell)
     return true;
 
   return false;
-  
+
  worse_exit:
   /* Clear neighbour heap */
   UintSeqHash rest;
@@ -2702,12 +2702,12 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
    * Phase 1
    * Refine neighbours according to the edges that leave the vertex v
    */
-  std::vector<unsigned int>::const_iterator ei = v.edges_out.begin();
+  auto ei = v.edges_out.begin();
   for(unsigned int j = v.nof_edges_out(); j > 0; j--)
     {
       const unsigned int dest_vertex = *ei++;
       Partition::Cell* const neighbour_cell = p.get_cell(dest_vertex);
-   
+
       if(neighbour_cell->is_unit()) {
 	if(in_search) {
 	  /* Remember neighbour in order to generate certificate */
@@ -2720,7 +2720,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	  neighbour_heap.insert(neighbour_cell->first);
 	}
       neighbour_cell->max_ival_count++;
-      
+
       unsigned int* const swap_position =
 	p.elements + neighbour_cell->first + neighbour_cell->length -
 	neighbour_cell->max_ival_count;
@@ -2755,7 +2755,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
       if(neighbour_cell->length > 1 and
 	 neighbour_cell->max_ival_count != neighbour_cell->length)
 	{
-	  
+
 	  Partition::Cell* const new_cell =
 	    p.aux_split_in_two(neighbour_cell,
 			       neighbour_cell->length -
@@ -2769,7 +2769,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	    }
 	  neighbour_cell->max_ival_count = 0;
 
-	  
+
 	  if(compute_eqref_hash)
 	    {
 	      /* Update hash */
@@ -2780,7 +2780,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	      eqref_hash.update(new_cell->length);
 	      eqref_hash.update(1);
 	    }
-	  
+
 	  /* Add cells in splitting_queue */
 	  if(neighbour_cell->is_in_splitting_queue()) {
 	    /* Both cells must be included in splitting_queue in order
@@ -2809,7 +2809,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	{
 	  neighbour_cell->max_ival_count = 0;
 	}
-      
+
       /*
        * Build certificate if required
        */
@@ -2840,7 +2840,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
     {
       const unsigned int dest_vertex = *ei++;
       Partition::Cell* const neighbour_cell = p.get_cell(dest_vertex);
-      
+
       if(neighbour_cell->is_unit()) {
 	if(in_search) {
 	  neighbour_heap.insert(neighbour_cell->first);
@@ -2898,8 +2898,8 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	    ep++;
 	  }
 	  neighbour_cell->max_ival_count = 0;
-	  
-	  
+
+
 	  if(compute_eqref_hash)
 	    {
 	      eqref_hash.update(neighbour_cell->first);
@@ -2938,7 +2938,7 @@ Digraph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	{
 	  neighbour_cell->max_ival_count = 0;
 	}
-      
+
       /*
        * Build certificate if required
        */
@@ -3023,7 +3023,7 @@ Digraph::is_equitable() const
       const Vertex& first_vertex = vertices[*ep++];
 
       /* Count outgoing edges of the first vertex for cells */
-      for(std::vector<unsigned int>::const_iterator ei =
+      for(auto ei =
 	    first_vertex.edges_out.begin();
 	  ei != first_vertex.edges_out.end();
 	  ei++)
@@ -3035,7 +3035,7 @@ Digraph::is_equitable() const
       for(unsigned int i = cell->length; i > 1; i--)
 	{
 	  const Vertex &vertex = vertices[*ep++];
-	  for(std::vector<unsigned int>::const_iterator ei =
+	  for(auto ei =
 		vertex.edges_out.begin();
 	      ei != vertex.edges_out.end();
 	      ei++)
@@ -3072,7 +3072,7 @@ Digraph::is_equitable() const
       const Vertex& first_vertex = vertices[*ep++];
 
       /* Count incoming edges of the first vertex for cells */
-      for(std::vector<unsigned int>::const_iterator ei =
+      for(auto ei =
 	    first_vertex.edges_in.begin();
 	  ei != first_vertex.edges_in.end();
 	  ei++)
@@ -3084,7 +3084,7 @@ Digraph::is_equitable() const
       for(unsigned int i = cell->length; i > 1; i--)
 	{
 	  const Vertex &vertex = vertices[*ep++];
-	  for(std::vector<unsigned int>::const_iterator ei =
+	  for(auto ei =
 		vertex.edges_in.begin();
 	      ei != vertex.edges_in.end();
 	      ei++)
@@ -3262,8 +3262,7 @@ Digraph::sh_first_max_neighbours()
 	continue;
       int value = 0;
       const Vertex &v = vertices[p.elements[cell->first]];
-      std::vector<unsigned int>::const_iterator ei;
-      ei = v.edges_in.begin();
+      auto ei = v.edges_in.begin();
       for(unsigned int j = v.nof_edges_in(); j > 0; j--)
 	{
 	  Partition::Cell * const neighbour_cell = p.get_cell(*ei++);
@@ -3298,7 +3297,7 @@ Digraph::sh_first_max_neighbours()
 	    value++;
 	  neighbour_cell->max_ival = 0;
 	}
-      
+
       if(value > best_value)
 	{
 	  best_value = value;
@@ -3327,15 +3326,13 @@ Digraph::sh_first_smallest_max_neighbours()
       cell;
       cell = cell->next_nonsingleton)
     {
-	
+
       if(opt_use_comprec and p.cr_get_level(cell->first) != cr_level)
 	continue;
-	
+
       int value = 0;
       const Vertex& v = vertices[p.elements[cell->first]];
-      std::vector<unsigned int>::const_iterator ei;
-
-      ei = v.edges_in.begin();
+      auto ei = v.edges_in.begin();
       for(unsigned int j = v.nof_edges_in(); j > 0; j--)
 	{
 	  Partition::Cell * const neighbour_cell = p.get_cell(*ei++);
@@ -3407,9 +3404,7 @@ Digraph::sh_first_largest_max_neighbours()
 
       int value = 0;
       const Vertex &v = vertices[p.elements[cell->first]];
-      std::vector<unsigned int>::const_iterator ei;
-
-      ei = v.edges_in.begin();
+      auto ei = v.edges_in.begin();
       for(unsigned int j = v.nof_edges_in(); j > 0; j--)
 	{
 	  Partition::Cell* const neighbour_cell = p.get_cell(*ei++);
@@ -3499,12 +3494,12 @@ Digraph::is_automorphism(unsigned int* const perm)
       Vertex& v2 = vertices[perm[i]];
 
       edges1.clear();
-      for(std::vector<unsigned int>::iterator ei = v1.edges_in.begin();
+      for(auto ei = v1.edges_in.begin();
 	  ei != v1.edges_in.end();
 	  ei++)
 	edges1.insert(perm[*ei]);
       edges2.clear();
-      for(std::vector<unsigned int>::iterator ei = v2.edges_in.begin();
+      for(auto ei = v2.edges_in.begin();
 	  ei != v2.edges_in.end();
 	  ei++)
 	edges2.insert(*ei);
@@ -3512,12 +3507,12 @@ Digraph::is_automorphism(unsigned int* const perm)
 	return false;
 
       edges1.clear();
-      for(std::vector<unsigned int>::iterator ei = v1.edges_out.begin();
+      for(auto ei = v1.edges_out.begin();
 	  ei != v1.edges_out.end();
 	  ei++)
 	edges1.insert(perm[*ei]);
       edges2.clear();
-      for(std::vector<unsigned int>::iterator ei = v2.edges_out.begin();
+      for(auto ei = v2.edges_out.begin();
 	  ei != v2.edges_out.end();
 	  ei++)
 	edges2.insert(*ei);
@@ -3544,12 +3539,12 @@ Digraph::is_automorphism(const std::vector<unsigned int>& perm) const
       const Vertex& v2 = vertices[perm[i]];
 
       edges1.clear();
-      for(std::vector<unsigned int>::const_iterator ei = v1.edges_in.begin();
+      for(auto ei = v1.edges_in.begin();
 	  ei != v1.edges_in.end();
 	  ei++)
 	edges1.insert(perm[*ei]);
       edges2.clear();
-      for(std::vector<unsigned int>::const_iterator ei = v2.edges_in.begin();
+      for(auto ei = v2.edges_in.begin();
 	  ei != v2.edges_in.end();
 	  ei++)
 	edges2.insert(*ei);
@@ -3557,12 +3552,12 @@ Digraph::is_automorphism(const std::vector<unsigned int>& perm) const
 	return false;
 
       edges1.clear();
-      for(std::vector<unsigned int>::const_iterator ei = v1.edges_out.begin();
+      for(auto ei = v1.edges_out.begin();
 	  ei != v1.edges_out.end();
 	  ei++)
 	edges1.insert(perm[*ei]);
       edges2.clear();
-      for(std::vector<unsigned int>::const_iterator ei = v2.edges_out.begin();
+      for(auto ei = v2.edges_out.begin();
 	  ei != v2.edges_out.end();
 	  ei++)
 	edges2.insert(*ei);
@@ -3595,7 +3590,7 @@ Digraph::nucr_find_first_component(const unsigned int level)
   /* The component is discrete, return false */
   if(!first_cell)
     return false;
-	
+
   std::vector<Partition::Cell*> component;
   first_cell->max_ival = 1;
   component.push_back(first_cell);
@@ -3603,11 +3598,9 @@ Digraph::nucr_find_first_component(const unsigned int level)
   for(unsigned int i = 0; i < component.size(); i++)
     {
       Partition::Cell* const cell = component[i];
-	  
-      const Vertex& v = vertices[p.elements[cell->first]];
-      std::vector<unsigned int>::const_iterator ei;
 
-      ei = v.edges_out.begin();
+      const Vertex& v = vertices[p.elements[cell->first]];
+      auto ei = v.edges_out.begin();
       for(unsigned int j = v.nof_edges_out(); j > 0; j--)
 	{
 	  const unsigned int neighbour = *ei++;
@@ -3632,13 +3625,13 @@ Digraph::nucr_find_first_component(const unsigned int level)
 	  const unsigned int start = neighbour_heap.remove();
 	  Partition::Cell* const neighbour_cell =
 	    p.get_cell(p.elements[start]);
-	  
+
 	  /* Skip saturated neighbour cells */
 	  if(neighbour_cell->max_ival_count == neighbour_cell->length)
 	    {
 	      neighbour_cell->max_ival_count = 0;
 	      continue;
-	    } 
+	    }
 	  neighbour_cell->max_ival_count = 0;
 	  neighbour_cell->max_ival = 1;
 	  component.push_back(neighbour_cell);
@@ -3648,7 +3641,7 @@ Digraph::nucr_find_first_component(const unsigned int level)
       for(unsigned int j = v.nof_edges_in(); j > 0; j--)
 	{
 	  const unsigned int neighbour = *ei++;
-	  
+
 	  Partition::Cell* const neighbour_cell = p.get_cell(neighbour);
 
 	  /* Skip unit neighbours */
@@ -3670,13 +3663,13 @@ Digraph::nucr_find_first_component(const unsigned int level)
 	  const unsigned int start = neighbour_heap.remove();
 	  Partition::Cell* const neighbour_cell =
 	    p.get_cell(p.elements[start]);
-	  
+
 	  /* Skip saturated neighbour cells */
 	  if(neighbour_cell->max_ival_count == neighbour_cell->length)
 	    {
 	      neighbour_cell->max_ival_count = 0;
 	      continue;
-	    } 
+	    }
 	  neighbour_cell->max_ival_count = 0;
 	  neighbour_cell->max_ival = 1;
 	  component.push_back(neighbour_cell);
@@ -3732,7 +3725,7 @@ Digraph::nucr_find_first_component(const unsigned int level,
       /* The component is discrete, return false */
       return false;
     }
-	
+
   std::vector<Partition::Cell*> comp;
   KStack<Partition::Cell*> neighbours;
   neighbours.init(get_nof_vertices());
@@ -3747,14 +3740,13 @@ Digraph::nucr_find_first_component(const unsigned int level,
       unsigned int nuconn = 1;
 
       const Vertex& v = vertices[p.elements[cell->first]];
-      std::vector<unsigned int>::const_iterator ei;
 
       /*| Phase 1: outgoing edges */
-      ei = v.edges_out.begin();
+      auto ei = v.edges_out.begin();
       for(unsigned int j = v.nof_edges_out(); j > 0; j--)
 	{
 	  const unsigned int neighbour = *ei++;
-	  
+
 	  Partition::Cell* const neighbour_cell = p.get_cell(neighbour);
 
 	  /* Skip unit neighbours */
@@ -3936,7 +3928,7 @@ Graph::Vertex::remove_duplicate_edges(std::vector<bool>& tmp)
   /* Pre-conditions  */
   for(unsigned int i = 0; i < tmp.size(); i++) assert(tmp[i] == false);
 #endif
-  for(std::vector<unsigned int>::iterator iter = edges.begin();
+  for(auto iter = edges.begin();
       iter != edges.end(); )
     {
       const unsigned int dest_vertex = *iter;
@@ -3954,7 +3946,7 @@ Graph::Vertex::remove_duplicate_edges(std::vector<bool>& tmp)
     }
 
   /* Clear tmp */
-  for(std::vector<unsigned int>::iterator iter = edges.begin();
+  for(auto iter = edges.begin();
       iter != edges.end();
       iter++)
     {
@@ -4048,7 +4040,7 @@ Graph::read_dimacs(FILE* const fp, FILE* const errstr)
 
   const bool verbose = false;
   FILE* const verbstr = stdout;
-  
+
   /* Read comments and the problem definition line */
   while(1)
     {
@@ -4087,7 +4079,7 @@ Graph::read_dimacs(FILE* const fp, FILE* const errstr)
 	fprintf(errstr, "error in line %u: not in DIMACS format\n", line_num);
       goto error_exit;
     }
-  
+
   if(nof_vertices <= 0)
     {
       if(errstr)
@@ -4210,7 +4202,7 @@ Graph::write_dimacs(FILE* const fp)
   for(unsigned int i = 0; i < get_nof_vertices(); i++)
     {
       Vertex &v = vertices[i];
-      for(std::vector<unsigned int>::const_iterator ei = v.edges.begin();
+      for(auto ei = v.edges.begin();
 	  ei != v.edges.end();
 	  ei++)
 	{
@@ -4241,7 +4233,7 @@ Graph::write_dimacs(FILE* const fp)
   for(unsigned int i = 0; i < get_nof_vertices(); i++)
     {
       Vertex &v = vertices[i];
-      for(std::vector<unsigned int>::const_iterator ei = v.edges.begin();
+      for(auto ei = v.edges.begin();
 	  ei != v.edges.end();
 	  ei++)
 	{
@@ -4296,8 +4288,8 @@ Graph::cmp(Graph& other)
       Vertex &v2 = other.vertices[i];
       v1.sort_edges();
       v2.sort_edges();
-      std::vector<unsigned int>::const_iterator ei1 = v1.edges.begin();
-      std::vector<unsigned int>::const_iterator ei2 = v2.edges.begin();
+      auto ei1 = v1.edges.begin();
+      auto ei2 = v2.edges.begin();
       while(ei1 != v1.edges.end())
 	{
 	  if(*ei1 < *ei2)
@@ -4324,7 +4316,7 @@ Graph::permute(const std::vector<unsigned int>& perm) const
       const Vertex& v = vertices[i];
       Vertex& permuted_v = g->vertices[perm[i]];
       permuted_v.color = v.color;
-      for(std::vector<unsigned int>::const_iterator ei = v.edges.begin();
+      for(auto ei = v.edges.begin();
 	  ei != v.edges.end();
 	  ei++)
 	{
@@ -4350,7 +4342,7 @@ Graph::permute(const unsigned int* perm) const
       const Vertex& v = vertices[i];
       Vertex& permuted_v = g->vertices[perm[i]];
       permuted_v.color = v.color;
-      for(std::vector<unsigned int>::const_iterator ei = v.edges.begin();
+      for(auto ei = v.edges.begin();
 	  ei != v.edges.end();
 	  ei++)
 	{
@@ -4398,7 +4390,7 @@ Graph::write_dot(FILE* const fp)
     {
       Vertex& v = *vi;
       fprintf(fp, "v%u [label=\"%u:%u\"];\n", vnum, vnum, v.color);
-      for(std::vector<unsigned int>::const_iterator ei = v.edges.begin();
+      for(auto ei = v.edges.begin();
 	  ei != v.edges.end();
 	  ei++)
 	{
@@ -4444,7 +4436,7 @@ Graph::get_hash()
   for(unsigned int i = 0; i < get_nof_vertices(); i++)
     {
       Vertex &v = vertices[i];
-      for(std::vector<unsigned int>::const_iterator ei = v.edges.begin();
+      for(auto ei = v.edges.begin();
 	  ei != v.edges.end();
 	  ei++)
 	{
@@ -4517,7 +4509,7 @@ unsigned int
 Graph::selfloop_invariant(const Graph* const g, const unsigned int v)
 {
   const Vertex& vertex = g->vertices[v];
-  for(std::vector<unsigned int>::const_iterator ei = vertex.edges.begin();
+  for(auto ei = vertex.edges.begin();
       ei != vertex.edges.end();
       ei++)
     {
@@ -4606,8 +4598,8 @@ Graph::split_neighbourhood_of_cell(Partition::Cell* const cell)
   for(unsigned int i = cell->length; i > 0; i--)
     {
       const Vertex& v = vertices[*ep++];
-      
-      std::vector<unsigned int>::const_iterator ei = v.edges.begin();
+
+      auto ei = v.edges.begin();
       for(unsigned int j = v.nof_edges(); j != 0; j--)
 	{
 	  const unsigned int dest_vertex = *ei++;
@@ -4628,12 +4620,12 @@ Graph::split_neighbourhood_of_cell(Partition::Cell* const cell)
 	  }
 	}
     }
-  
+
   while(!neighbour_heap.is_empty())
     {
       const unsigned int start = neighbour_heap.remove();
       Partition::Cell * const neighbour_cell = p.get_cell(p.elements[start]);
-      
+
       if(compute_eqref_hash)
 	{
 	  eqref_hash.update(neighbour_cell->first);
@@ -4707,7 +4699,7 @@ Graph::split_neighbourhood_of_cell(Partition::Cell* const cell)
       rest.update(failure_recording_fp_deviation);
       failure_recording_fp_deviation = rest.get_value();
     }
- 
+
   return true;
 }
 
@@ -4729,12 +4721,12 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 
   const Vertex& v = vertices[p.elements[unit_cell->first]];
 
-  std::vector<unsigned int>::const_iterator ei = v.edges.begin();
+  auto ei = v.edges.begin();
   for(unsigned int j = v.nof_edges(); j > 0; j--)
     {
       const unsigned int dest_vertex = *ei++;
       Partition::Cell * const neighbour_cell = p.get_cell(dest_vertex);
-      
+
       if(neighbour_cell->is_unit()) {
 	if(in_search) {
 	  /* Remember neighbour in order to generate certificate */
@@ -4756,7 +4748,7 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
       *swap_position = dest_vertex;
       p.in_pos[dest_vertex] = swap_position;
     }
-  
+
   while(!neighbour_heap.is_empty())
     {
       const unsigned int start = neighbour_heap.remove();
@@ -4790,8 +4782,8 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	      ep++;
 	    }
 	  neighbour_cell->max_ival_count = 0;
-	  
-	  
+
+
 	  if(compute_eqref_hash)
 	    {
 	      /* Update hash */
@@ -4802,7 +4794,7 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	      eqref_hash.update(new_cell->length);
 	      eqref_hash.update(1);
 	    }
-	  
+
 	  /* Add cells in splitting_queue */
 	  if(neighbour_cell->is_in_splitting_queue()) {
 	    /* Both cells must be included in splitting_queue in order
@@ -4833,7 +4825,7 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	     neighbour_cell->max_ival_count == neighbour_cell->length */
 	  neighbour_cell->max_ival_count = 0;
 	}
-      
+
       /*
        * Build certificate if required
        */
@@ -4854,7 +4846,7 @@ Graph::split_neighbourhood_of_unit_cell(Partition::Cell* const unit_cell)
 	    }
 	} /* if(in_search) */
     } /* while(!neighbour_heap.is_empty()) */
-  
+
   if(refine_compare_certificate and
      (refine_equal_to_first == false) and
      (refine_cmp_to_best < 0))
@@ -4913,13 +4905,13 @@ bool Graph::is_equitable() const
     {
       if(cell->is_unit())
 	continue;
-      
+
       unsigned int *ep = p.elements + cell->first;
       const Vertex &first_vertex = vertices[*ep++];
 
       /* Count how many edges lead from the first vertex to
        * the neighbouring cells */
-      for(std::vector<unsigned int>::const_iterator ei =
+      for(auto ei =
 	    first_vertex.edges.begin();
 	  ei != first_vertex.edges.end();
 	  ei++)
@@ -4931,7 +4923,7 @@ bool Graph::is_equitable() const
       for(unsigned int i = cell->length; i > 1; i--)
 	{
 	  const Vertex &vertex = vertices[*ep++];
-	  for(std::vector<unsigned int>::const_iterator ei =
+	  for(auto ei =
 		vertex.edges.begin();
 	      ei != vertex.edges.end();
 	      ei++)
@@ -5104,7 +5096,7 @@ Graph::sh_first_max_neighbours()
       if(opt_use_comprec and p.cr_get_level(cell->first) != cr_level)
 	continue;
       const Vertex& v = vertices[p.elements[cell->first]];
-      std::vector<unsigned int>::const_iterator ei = v.edges.begin();
+      auto ei = v.edges.begin();
       for(unsigned int j = v.nof_edges(); j > 0; j--)
 	{
 	  Partition::Cell * const neighbour_cell = p.get_cell(*ei++);
@@ -5153,9 +5145,9 @@ Graph::sh_first_smallest_max_neighbours()
 
       if(opt_use_comprec and p.cr_get_level(cell->first) != cr_level)
 	continue;
-	
+
       const Vertex& v = vertices[p.elements[cell->first]];
-      std::vector<unsigned int>::const_iterator ei = v.edges.begin();
+      auto ei = v.edges.begin();
       for(unsigned int j = v.nof_edges(); j > 0; j--)
 	{
 	  Partition::Cell* const neighbour_cell = p.get_cell(*ei++);
@@ -5207,7 +5199,7 @@ Graph::sh_first_largest_max_neighbours()
       if(opt_use_comprec and p.cr_get_level(cell->first) != cr_level)
 	continue;
       const Vertex& v = vertices[p.elements[cell->first]];
-      std::vector<unsigned int>::const_iterator ei = v.edges.begin();
+      auto ei = v.edges.begin();
       for(unsigned int j = v.nof_edges(); j > 0; j--)
 	{
 	  Partition::Cell* const neighbour_cell = p.get_cell(*ei++);
@@ -5296,14 +5288,14 @@ Graph::is_automorphism(unsigned int* const perm)
     {
       Vertex& v1 = vertices[i];
       edges1.clear();
-      for(std::vector<unsigned int>::iterator ei = v1.edges.begin();
+      for(auto ei = v1.edges.begin();
 	  ei != v1.edges.end();
 	  ei++)
 	edges1.insert(perm[*ei]);
-      
+
       Vertex& v2 = vertices[perm[i]];
       edges2.clear();
-      for(std::vector<unsigned int>::iterator ei = v2.edges.begin();
+      for(auto ei = v2.edges.begin();
 	  ei != v2.edges.end();
 	  ei++)
 	edges2.insert(*ei);
@@ -5332,14 +5324,14 @@ Graph::is_automorphism(const std::vector<unsigned int>& perm) const
     {
       const Vertex& v1 = vertices[i];
       edges1.clear();
-      for(std::vector<unsigned int>::const_iterator ei = v1.edges.begin();
+      for(auto ei = v1.edges.begin();
 	  ei != v1.edges.end();
 	  ei++)
 	edges1.insert(perm[*ei]);
-      
+
       const Vertex& v2 = vertices[perm[i]];
       edges2.clear();
-      for(std::vector<unsigned int>::const_iterator ei = v2.edges.begin();
+      for(auto ei = v2.edges.begin();
 	  ei != v2.edges.end();
 	  ei++)
 	edges2.insert(*ei);
@@ -5376,7 +5368,7 @@ Graph::nucr_find_first_component(const unsigned int level)
   /* The component is discrete, return false */
   if(!first_cell)
     return false;
-	
+
   std::vector<Partition::Cell*> component;
   first_cell->max_ival = 1;
   component.push_back(first_cell);
@@ -5384,13 +5376,13 @@ Graph::nucr_find_first_component(const unsigned int level)
   for(unsigned int i = 0; i < component.size(); i++)
     {
       Partition::Cell* const cell = component[i];
-	  
+
       const Vertex& v = vertices[p.elements[cell->first]];
-      std::vector<unsigned int>::const_iterator ei = v.edges.begin();
+      auto ei = v.edges.begin();
       for(unsigned int j = v.nof_edges(); j > 0; j--)
 	{
 	  const unsigned int neighbour = *ei++;
-	  
+
 	  Partition::Cell* const neighbour_cell = p.get_cell(neighbour);
 
 	  /* Skip unit neighbours */
@@ -5412,13 +5404,13 @@ Graph::nucr_find_first_component(const unsigned int level)
 	  const unsigned int start = neighbour_heap.remove();
 	  Partition::Cell* const neighbour_cell =
 	    p.get_cell(p.elements[start]);
-	  
+
 	  /* Skip saturated neighbour cells */
 	  if(neighbour_cell->max_ival_count == neighbour_cell->length)
 	    {
 	      neighbour_cell->max_ival_count = 0;
 	      continue;
-	    } 
+	    }
 	  neighbour_cell->max_ival_count = 0;
 	  neighbour_cell->max_ival = 1;
 	  component.push_back(neighbour_cell);
@@ -5486,11 +5478,11 @@ Graph::nucr_find_first_component(const unsigned int level,
       Partition::Cell* const cell = comp[i];
 
       const Vertex& v = vertices[p.elements[cell->first]];
-      std::vector<unsigned int>::const_iterator ei = v.edges.begin();
+      auto ei = v.edges.begin();
       for(unsigned int j = v.nof_edges(); j > 0; j--)
 	{
 	  const unsigned int neighbour = *ei++;
-	  
+
 	  Partition::Cell* const neighbour_cell = p.get_cell(neighbour);
 
 	  /* Skip unit neighbours */
@@ -5508,7 +5500,7 @@ Graph::nucr_find_first_component(const unsigned int level,
 	{
 	  Partition::Cell* const neighbour_cell = neighbours.pop();
 	  //neighbours.pop_back();
-	  
+
 	  /* Skip saturated neighbour cells */
 	  if(neighbour_cell->max_ival_count == neighbour_cell->length)
 	    {

--- a/SeQuant/external/bliss/graph.hh
+++ b/SeQuant/external/bliss/graph.hh
@@ -52,6 +52,8 @@ class AbstractGraph;
 #include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/view/iota.hpp>
 
+#include <boost/container/small_vector.hpp>
+
 namespace bliss {
 
 /**
@@ -568,7 +570,7 @@ class Graph : public AbstractGraph {
     void sort_edges();
 
     unsigned int color;
-    std::vector<unsigned int> edges;
+    boost::container::small_vector<unsigned int, 8> edges;
     unsigned int nof_edges() const { return edges.size(); }
   };
   std::vector<Vertex> vertices;
@@ -806,7 +808,7 @@ class Graph : public AbstractGraph {
       } else {
         os << ":" << v.color << "\"];\n";
       }
-      for (std::vector<unsigned int>::const_iterator ei = v.edges.begin();
+      for (auto ei = v.edges.begin();
            ei != v.edges.end(); ei++) {
         const unsigned int vnum2 = *ei;
         if (vnum2 > vnum) os << "v" << vnum << " -- v" << vnum2 << "\n";
@@ -930,8 +932,8 @@ class Digraph : public AbstractGraph {
     void remove_duplicate_edges(std::vector<bool>& tmp);
     void sort_edges();
     unsigned int color;
-    std::vector<unsigned int> edges_out;
-    std::vector<unsigned int> edges_in;
+    boost::container::small_vector<unsigned int, 8> edges_out;
+    boost::container::small_vector<unsigned int, 8> edges_in;
     unsigned int nof_edges_in() const { return edges_in.size(); }
     unsigned int nof_edges_out() const { return edges_out.size(); }
   };


### PR DESCRIPTION
this saves on dynamic memory allocation. Most of our graphs will have vertices with relatively low order