### PR TITLE
Optimize docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,5 +39,6 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           publish_branch: gh-pages
+          force_orphan: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ${{github.workspace}}/build/doc/html


### PR DESCRIPTION
#### Adds `force_orphan: true` option to gh-pages deployment action.

This should reduce the repo size and improve cloning time. 

For reference: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-force-orphan-force_orphan