### PR TITLE
`memoizing_hash` improvements

### DIFF
--- a/SeQuant/core/expr.hpp
+++ b/SeQuant/core/expr.hpp
@@ -832,7 +832,11 @@ class Constant : public Expr {
 
  private:
   hash_type memoizing_hash() const override {
-    hash_value_ = hash::value(value_);
+    if (!hash_value_) {
+      hash_value_ = hash::value(value_);
+    } else {
+      assert(*hash_value_ == hash::value(value_));
+    }
     return *hash_value_;
   }
 
@@ -878,9 +882,18 @@ class Variable : public Expr, public Labeled {
   std::wstring label_;
   bool conjugated_ = false;
 
+  /// @return the hash of this object
   hash_type memoizing_hash() const override {
-    hash_value_ = hash::value(label_);
-    hash::combine(hash_value_.value(), conjugated_);
+    auto compute_hash = [this]() {
+      auto val = hash::value(label_);
+      hash::combine(val, conjugated_);
+      return val;
+    };
+    if (!hash_value_) {
+      hash_value_ = compute_hash();
+    } else {
+      assert(*hash_value_ == compute_hash());
+    }
     return *hash_value_;
   }
 
@@ -1266,12 +1279,11 @@ class Product : public Expr {
         return value;
       }
     };
-    // if (!hash_value_) {
-    hash_value_ = compute_hash();
-    // }
-    // else {
-    //   assert(*hash_value_ == compute_hash());
-    // }
+    if (!hash_value_) {
+      hash_value_ = compute_hash();
+    } else {
+      assert(*hash_value_ == compute_hash());
+    }
     return *hash_value_;
   }
 
@@ -1574,12 +1586,11 @@ class Sum : public Expr {
         return value;
       }
     };
-    // if (!hash_value_) {
-    hash_value_ = compute_hash();
-    // }
-    // else {
-    //   assert(*hash_value_ == compute_hash());
-    // }
+    if (!hash_value_) {
+      hash_value_ = compute_hash();
+    } else {
+      assert(*hash_value_ == compute_hash());
+    }
     return *hash_value_;
   }
 

--- a/SeQuant/core/op.hpp
+++ b/SeQuant/core/op.hpp
@@ -406,10 +406,19 @@ class Operator : public container::svector<Op<S>>, public Expr {
   }
 
   hash_type memoizing_hash() const override {
-    using std::begin;
-    using std::end;
-    const auto &ops = static_cast<const base_type &>(*this);
-    return hash::range(begin(ops), end(ops));
+    auto compute_hash = [this]() {
+      using std::begin;
+      using std::end;
+      const auto &ops = static_cast<const base_type &>(*this);
+      auto value = hash::range(begin(ops), end(ops));
+      return value;
+    };
+    if (!hash_value_) {
+      hash_value_ = compute_hash();
+    } else {
+      assert(*hash_value_ == compute_hash());
+    }
+    return *hash_value_;
   }
 };
 

--- a/SeQuant/core/tensor.hpp
+++ b/SeQuant/core/tensor.hpp
@@ -358,7 +358,7 @@ class Tensor : public Expr, public AbstractTensor, public Labeled {
   }
 
   hash_type bra_hash_value() const {
-    if (!hash_value_)  // if hash not computed, or reset, recompute
+    if (!bra_hash_value_)  // if hash not computed, or reset, recompute
       memoizing_hash();
     return *bra_hash_value_;
   }
@@ -383,15 +383,22 @@ class Tensor : public Expr, public AbstractTensor, public Labeled {
   }
 
   hash_type memoizing_hash() const override {
-    using std::begin;
-    using std::end;
-    auto val = hash::range(begin(bra()), end(bra()));
-    bra_hash_value_ = val;
-    hash::range(val, begin(ket()), end(ket()));
-    hash::range(val, begin(aux()), end(aux()));
-    hash::combine(val, label_);
-    hash::combine(val, symmetry_);
-    hash_value_ = val;
+    auto compute_hash = [this]() {
+      using std::begin;
+      using std::end;
+      auto val = hash::range(begin(bra()), end(bra()));
+      bra_hash_value_ = val;
+      hash::range(val, begin(ket()), end(ket()));
+      hash::range(val, begin(aux()), end(aux()));
+      hash::combine(val, label_);
+      hash::combine(val, symmetry_);
+      return val;
+    };
+    if (!hash_value_) {
+      hash_value_ = compute_hash();
+    } else {
+      assert(*hash_value_ == compute_hash());
+    }
     return *hash_value_;
   }
   void reset_hash_value() const override {

--- a/SeQuant/domain/mbpt/op.ipp
+++ b/SeQuant/domain/mbpt/op.ipp
@@ -170,12 +170,20 @@ std::wstring Operator<QuantumNumbers, S>::to_latex() const {
 
 template <typename QuantumNumbers, Statistics S>
 Expr::hash_type Operator<QuantumNumbers, S>::memoizing_hash() const {
-  using std::begin;
-  using std::end;
-  auto qns = (*this)(QuantumNumbers{});
-  auto val = sequant::hash::value(qns);
-  sequant::hash::combine(val, std::wstring(this->label()));
-  this->hash_value_ = val;
+  auto compute_hash = [this]() {
+    using std::begin;
+    using std::end;
+    auto qns = (*this)(QuantumNumbers{});
+    auto val = sequant::hash::value(qns);
+    sequant::hash::combine(val, std::wstring(this->label()));
+    return val;
+  };
+  if (!this->hash_value_) {
+    this->hash_value_ = compute_hash();
+  }
+  else {
+    assert(*(this->hash_value_) == compute_hash());
+  }
   return *(this->hash_value_);
 }
 


### PR DESCRIPTION
- change {`Product`,`Sum`}::`memoizing_hash` so that for single {factor,summand} it produces hashes identical to the hash of the {factor,summand} itself
- `memoizing_hash` memoizes, and validates against memoized value in Debug builds