### PR TITLE
locale switch: `en_US.UTF8` -> `C.UTF8`

### DIFF
--- a/SeQuant/core/runtime.cpp
+++ b/SeQuant/core/runtime.cpp
@@ -9,9 +9,9 @@ namespace sequant {
 void set_locale() {
   // set global C++ locale (and C locale)
   std::locale target_locale{};
-  try {  // use en_US.UTF-8, if supported
-    target_locale = std::locale{"en_US.UTF-8"};
-  } catch (std::exception &) {  // use default if en_US.UTF-8 not available
+  try {  // use C.UTF-8, if supported
+    target_locale = std::locale{"C.UTF-8"};
+  } catch (std::exception &) {  // use default if C.UTF-8 not available
   }
   std::locale::global(target_locale);
   // set C++ streams locale to target

--- a/tests/integration/antisymmetrizer.cpp
+++ b/tests/integration/antisymmetrizer.cpp
@@ -76,15 +76,9 @@ void try_main() {
 }
 
 int main(int argc, char* argv[]) {
-  std::setlocale(LC_ALL, "en_US.UTF-8");
   std::wcout.precision(std::numeric_limits<double>::max_digits10);
   std::wcerr.precision(std::numeric_limits<double>::max_digits10);
-  std::wcout.sync_with_stdio(false);
-  std::wcerr.sync_with_stdio(false);
-  std::wcout.imbue(std::locale("en_US.UTF-8"));
-  std::wcerr.imbue(std::locale("en_US.UTF-8"));
-  std::wcout.sync_with_stdio(true);
-  std::wcerr.sync_with_stdio(true);
+  sequant::set_locale();
   sequant::detail::OpIdRegistrar op_id_registrar;
   sequant::set_default_context(Context(
       sequant::mbpt::make_min_sr_spaces(), Vacuum::Physical,

--- a/tests/integration/eomcc.cpp
+++ b/tests/integration/eomcc.cpp
@@ -165,15 +165,9 @@ class compute_all {
 }  // namespace
 
 int main(int argc, char* argv[]) {
-  std::setlocale(LC_ALL, "en_US.UTF-8");
   std::wcout.precision(std::numeric_limits<double>::max_digits10);
   std::wcerr.precision(std::numeric_limits<double>::max_digits10);
-  std::wcout.sync_with_stdio(false);
-  std::wcerr.sync_with_stdio(false);
-  std::wcout.imbue(std::locale("en_US.UTF-8"));
-  std::wcerr.imbue(std::locale("en_US.UTF-8"));
-  std::wcout.sync_with_stdio(true);
-  std::wcerr.sync_with_stdio(true);
+  sequant::set_locale();
 
 #ifndef NDEBUG
   constexpr size_t DEFAULT_NMAX = 3;

--- a/tests/integration/eval/btas/main.cpp
+++ b/tests/integration/eval/btas/main.cpp
@@ -6,6 +6,7 @@
 
 #include <btas/btas.h>
 #include <SeQuant/core/op.hpp>
+#include <SeQuant/core/runtime.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
 #include <SeQuant/domain/mbpt/context.hpp>
 #include <SeQuant/domain/mbpt/convention.hpp>
@@ -45,9 +46,7 @@ int main(int argc, char* argv[]) {
     // return 1;
   }
 
-  std::locale::global(std::locale("en_US.UTF-8"));
-  std::wcout.imbue(std::locale("en_US.UTF-8"));
-  std::wcerr.imbue(std::locale("en_US.UTF-8"));
+  sequant::set_locale();
 
   using namespace sequant;
   detail::OpIdRegistrar op_id_registrar;

--- a/tests/integration/eval/ta/main.cpp
+++ b/tests/integration/eval/ta/main.cpp
@@ -6,6 +6,7 @@
 
 #include <tiledarray.h>
 #include <SeQuant/core/op.hpp>
+#include <SeQuant/core/runtime.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
 #include <SeQuant/domain/mbpt/context.hpp>
 #include <SeQuant/domain/mbpt/convention.hpp>
@@ -63,10 +64,7 @@ int main(int argc, char* argv[]) {
     // return 1;
   }
 
-  std::locale::global(std::locale("en_US.UTF-8"));
-  std::wcout.imbue(std::locale("en_US.UTF-8"));
-  std::wcerr.imbue(std::locale("en_US.UTF-8"));
-
+  sequant::set_locale();
   auto& world = TA::initialize(argc, argv);
   using namespace sequant;
   detail::OpIdRegistrar op_id_registrar;

--- a/tests/integration/osstcc.cpp
+++ b/tests/integration/osstcc.cpp
@@ -1,4 +1,5 @@
 #include <SeQuant/core/op.hpp>
+#include <SeQuant/core/runtime.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
 #include <SeQuant/core/timer.hpp>
 #include <SeQuant/domain/mbpt/context.hpp>
@@ -19,15 +20,9 @@ using namespace sequant;
   }
 
 int main(int argc, char* argv[]) {
-  std::setlocale(LC_ALL, "en_US.UTF-8");
   std::wcout.precision(std::numeric_limits<double>::max_digits10);
   std::wcerr.precision(std::numeric_limits<double>::max_digits10);
-  std::wcout.sync_with_stdio(false);
-  std::wcerr.sync_with_stdio(false);
-  std::wcout.imbue(std::locale("en_US.UTF-8"));
-  std::wcerr.imbue(std::locale("en_US.UTF-8"));
-  std::wcout.sync_with_stdio(true);
-  std::wcerr.sync_with_stdio(true);
+  sequant::set_locale();
 
   sequant::set_default_context(Context(
       mbpt::make_min_sr_spaces(), Vacuum::SingleProduct, IndexSpaceMetric::Unit,

--- a/tests/integration/srcc.cpp
+++ b/tests/integration/srcc.cpp
@@ -222,15 +222,9 @@ class compute_all {
 }  // namespace
 
 int main(int argc, char* argv[]) {
-  std::setlocale(LC_ALL, "en_US.UTF-8");
   std::wcout.precision(std::numeric_limits<double>::max_digits10);
   std::wcerr.precision(std::numeric_limits<double>::max_digits10);
-  std::wcout.sync_with_stdio(false);
-  std::wcerr.sync_with_stdio(false);
-  std::wcout.imbue(std::locale("en_US.UTF-8"));
-  std::wcerr.imbue(std::locale("en_US.UTF-8"));
-  std::wcout.sync_with_stdio(true);
-  std::wcerr.sync_with_stdio(true);
+  sequant::set_locale();
 
   // set_num_threads(1);
 

--- a/tests/integration/stcc.cpp
+++ b/tests/integration/stcc.cpp
@@ -1,5 +1,6 @@
 #include <SeQuant/core/math.hpp>
 #include <SeQuant/core/op.hpp>
+#include <SeQuant/core/runtime.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
 #include <SeQuant/core/timer.hpp>
 #include <SeQuant/domain/mbpt/context.hpp>
@@ -21,15 +22,9 @@ using namespace sequant;
   }
 
 int main(int argc, char* argv[]) {
-  std::setlocale(LC_ALL, "en_US.UTF-8");
   std::wcout.precision(std::numeric_limits<double>::max_digits10);
   std::wcerr.precision(std::numeric_limits<double>::max_digits10);
-  std::wcout.sync_with_stdio(false);
-  std::wcerr.sync_with_stdio(false);
-  std::wcout.imbue(std::locale("en_US.UTF-8"));
-  std::wcerr.imbue(std::locale("en_US.UTF-8"));
-  std::wcout.sync_with_stdio(true);
-  std::wcerr.sync_with_stdio(true);
+  sequant::set_locale();
 
   sequant::set_default_context(Context(
       mbpt::make_min_sr_spaces(), Vacuum::SingleProduct, IndexSpaceMetric::Unit,

--- a/tests/integration/stcc_rigorous.cpp
+++ b/tests/integration/stcc_rigorous.cpp
@@ -1,5 +1,6 @@
 #include <SeQuant/core/math.hpp>
 #include <SeQuant/core/op.hpp>
+#include <SeQuant/core/runtime.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
 #include <SeQuant/core/timer.hpp>
 #include <SeQuant/domain/mbpt/context.hpp>
@@ -20,15 +21,9 @@ using namespace sequant;
   }
 
 int main(int argc, char* argv[]) {
-  std::setlocale(LC_ALL, "en_US.UTF-8");
   std::wcout.precision(std::numeric_limits<double>::max_digits10);
   std::wcerr.precision(std::numeric_limits<double>::max_digits10);
-  std::wcout.sync_with_stdio(false);
-  std::wcerr.sync_with_stdio(false);
-  std::wcout.imbue(std::locale("en_US.UTF-8"));
-  std::wcerr.imbue(std::locale("en_US.UTF-8"));
-  std::wcout.sync_with_stdio(true);
-  std::wcerr.sync_with_stdio(true);
+  sequant::set_locale();
 
   sequant::set_default_context(Context(
       mbpt::make_min_sr_spaces(), Vacuum::SingleProduct, IndexSpaceMetric::Unit,


### PR DESCRIPTION
this should allow to co-exist with packages that are not locale-neutral, like Catch2 3.8+.

resolves #336 