### PR TITLE
TNV3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,13 @@ set(SeQuant_src
         SeQuant/domain/mbpt/rules/csv.hpp
 )
 
+#### disable unity_build for v2:
+set_source_files_properties(
+        SeQuant/core/tensor_network_v2.cpp
+        SeQuant/core/tensor_network_v2.hpp
+        PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE
+)
+
 ### optional prereqs
 if (SEQUANT_EVAL_TESTS)
     include(FindOrFetchTiledArray)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,8 @@ set(SeQuant_src
         SeQuant/core/tensor_network.hpp
         SeQuant/core/tensor_network_v2.cpp
         SeQuant/core/tensor_network_v2.hpp
+        SeQuant/core/tensor_network_v3.cpp
+        SeQuant/core/tensor_network_v3.hpp
         SeQuant/core/tensor_network/canonicals.hpp
         SeQuant/core/tensor_network/slot.hpp
         SeQuant/core/tensor_network/vertex.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,7 @@ set(SeQuant_src
         SeQuant/core/tensor_network_v2.hpp
         SeQuant/core/tensor_network_v3.cpp
         SeQuant/core/tensor_network_v3.hpp
+        SeQuant/core/tensor_network/tn_utils.hpp
         SeQuant/core/tensor_network/canonicals.hpp
         SeQuant/core/tensor_network/slot.hpp
         SeQuant/core/tensor_network/vertex.hpp
@@ -299,13 +300,6 @@ set(SeQuant_src
         SeQuant/domain/mbpt/rules/df.hpp
         SeQuant/domain/mbpt/rules/csv.cpp
         SeQuant/domain/mbpt/rules/csv.hpp
-)
-
-#### disable unity_build for v2:
-set_source_files_properties(
-        SeQuant/core/tensor_network_v2.cpp
-        SeQuant/core/tensor_network_v2.hpp
-        PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE
 )
 
 ### optional prereqs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,7 @@ set(SeQuant_src
         SeQuant/core/tensor_network/vertex_painter.hpp
         SeQuant/core/timer.hpp
         SeQuant/core/utility/context.hpp
+        SeQuant/core/utility/debug.hpp
         SeQuant/core/utility/expr.cpp
         SeQuant/core/utility/expr.hpp
         SeQuant/core/utility/indices.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ set(SeQuant_src
         SeQuant/core/tensor_network_v2.hpp
         SeQuant/core/tensor_network_v3.cpp
         SeQuant/core/tensor_network_v3.hpp
-        SeQuant/core/tensor_network/tn_utils.hpp
+        SeQuant/core/tensor_network/utils.hpp
         SeQuant/core/tensor_network/canonicals.hpp
         SeQuant/core/tensor_network/slot.hpp
         SeQuant/core/tensor_network/vertex.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,13 @@ set(SeQuant_src
         SeQuant/domain/mbpt/rules/csv.hpp
 )
 
+#### disable unity_build for v2:
+set_source_files_properties(
+        SeQuant/core/tensor_network_v2.cpp
+        SeQuant/core/tensor_network_v2.hpp
+        PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE
+)
+
 ### optional prereqs
 if (SEQUANT_EVAL_TESTS)
     include(FindOrFetchTiledArray)

--- a/SeQuant/core/abstract_tensor.hpp
+++ b/SeQuant/core/abstract_tensor.hpp
@@ -86,6 +86,12 @@ class AbstractTensor {
  public:
   virtual ~AbstractTensor() = default;
 
+  /// clones this object
+  //// @throw missing_instantiation_for if not overloaded
+  virtual AbstractTensor* _clone() const {
+    throw missing_instantiation_for("_clone");
+  }
+
   using const_any_view_rand =
       ranges::any_view<const Index&, ranges::category::random_access>;
   using const_any_view_randsz =

--- a/SeQuant/core/abstract_tensor.hpp
+++ b/SeQuant/core/abstract_tensor.hpp
@@ -33,9 +33,9 @@ class TensorCanonicalizer;
 
 /// AbstractTensor is a [tensor](https://en.wikipedia.org/wiki/Tensor) over
 /// general (i.e., not necessarily commutative)
-/// rings. A tensor with \f$ k \geq 0 \f$ contravariant
-/// (ket, [Dirac notation](https://en.wikipedia.org/wiki/Bra-ket_notation) ) and
-/// \f$ b \geq 0 \f$ covariant (bra) modes
+/// rings. A tensor with \f$ k \geq 0 \f$ ket
+/// (see [Dirac notation](https://en.wikipedia.org/wiki/Bra-ket_notation) ) and
+/// \f$ b \geq 0 \f$ bra modes
 /// describes elements of a tensor product of \f$ b+k \f$ vector spaces.
 /// Equivalently it represents a linear map between the tensor product
 /// of \f$ k \f$ _primal_ vector spaces to the tensor product of \f$ b \f$
@@ -95,23 +95,24 @@ class AbstractTensor {
       ranges::any_view<Index&, ranges::category::random_access |
                                    ranges::category::sized>;
 
-  /// accessor bra (covariant) indices
-  /// @return view of a contiguous range of Index objects
+  /// accessor bra indices
+  /// @return view of a contiguous range of bra Index objects
   virtual const_any_view_randsz _bra() const {
     throw missing_instantiation_for("_bra");
   }
-  /// accesses ket (contravariant) indices
-  /// @return view of a contiguous range of Index objects
+  /// accesses ket indices
+  /// @return view of a contiguous range of ket Index objects
   virtual const_any_view_randsz _ket() const {
     throw missing_instantiation_for("_ket");
   }
-  /// accesses aux (invariant) indices
-  /// @return view of a contiguous range of Index objects
+  /// accesses aux (non-vector-space) indices
+  /// @return view of a contiguous range of aux Index objects
   virtual const_any_view_randsz _aux() const {
     throw missing_instantiation_for("_aux");
   }
   /// accesses bra and ket indices
-  /// view of a not necessarily contiguous range of Index objects
+  /// @return concatenated (hence, non contiguous) view of bra and ket Index
+  /// objects
   virtual const_any_view_rand _braket() const {
     throw missing_instantiation_for("_braket");
   }
@@ -142,7 +143,9 @@ class AbstractTensor {
   virtual BraKetSymmetry _braket_symmetry() const {
     throw missing_instantiation_for("_braket_symmetry");
   }
-  /// @return the symmetry of tensor under exchange of bra and ket
+  /// @return the symmetry of tensor under exchange of matching {bra,ket} slot
+  /// pairs
+  /// @note slots are left-aligned
   virtual ParticleSymmetry _particle_symmetry() const {
     throw missing_instantiation_for("_particle_symmetry");
   }

--- a/SeQuant/core/abstract_tensor.hpp
+++ b/SeQuant/core/abstract_tensor.hpp
@@ -168,6 +168,16 @@ class AbstractTensor {
     throw missing_instantiation_for("operator<");
   }
 
+  /// hashes the tensor's identity , i.e., this includes hashes of the index
+  /// labels (ordinals)
+  /// @return hash of the tensor's identity
+  /// @warning this hash value is not invariant with respect to tensor
+  /// symmetries, i.e. permuting bra indices will not leave the hash invariant
+  /// even if the tensor is
+  virtual std::size_t _hash_value() const {
+    throw missing_instantiation_for("_hash_value");
+  }
+
   virtual bool _transform_indices(
       const container::map<Index, Index>& index_map) {
     throw missing_instantiation_for("_transform_indices");

--- a/SeQuant/core/algorithm.hpp
+++ b/SeQuant/core/algorithm.hpp
@@ -24,6 +24,10 @@ using suitable_call_operator =
     decltype(std::declval<Callable>()(std::declval<Args>()...));
 
 /// @brief bubble sort that uses swap exclusively
+/// @tparam ForwardIter a forward iterator
+/// @tparam Sentinel a sentinel type
+/// @tparam Compare a less-than relationship that specifies a weak order
+/// @note does not assume `Compare` to be strict, unlike `std::sort`
 template <typename ForwardIter, typename Sentinel,
           typename Compare = std::less<>>
 void bubble_sort(ForwardIter begin, Sentinel end, Compare comp = {}) {

--- a/SeQuant/core/binary_node.hpp
+++ b/SeQuant/core/binary_node.hpp
@@ -498,7 +498,7 @@ Node fold_left_to_node(Rng rng, F op) {
   using ranges::views::tail;
   return ranges::accumulate(
       rng | tail | move, std::move(ranges::front(rng)),
-      [&op, invoke_on_node](auto&& l, auto&& r) {
+      [&op](auto&& l, auto&& r) {
         if constexpr (invoke_on_node) {
           auto&& val = op(l, r);
           return FullBinaryNode(std::move(val), std::move(l), std::move(r));

--- a/SeQuant/core/eval_expr.cpp
+++ b/SeQuant/core/eval_expr.cpp
@@ -10,7 +10,7 @@
 #include <SeQuant/core/parse.hpp>
 #include <SeQuant/core/tensor.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
-#include <SeQuant/core/tensor_network_v2.hpp>
+#include <SeQuant/core/tensor_network_v3.hpp>
 #include <SeQuant/core/utility/indices.hpp>
 #include <SeQuant/core/wstring.hpp>
 #include <SeQuant/external/bliss/graph.hh>
@@ -79,7 +79,7 @@ EvalExpr::EvalExpr(Tensor const& tnsr)
       expr_{tnsr.clone()} {
   if (is_tot(tnsr)) {
     ExprPtrList tlist{expr_};
-    auto tn = TensorNetworkV2(tlist);
+    auto tn = TensorNetworkV3(tlist);
     auto md =
         tn.canonicalize_slots(TensorCanonicalizer::cardinal_tensor_labels());
     hash_value_ = md.hash_value();
@@ -366,7 +366,7 @@ EvalExprNode binarize(Product const& prod) {
       collect_tensor_factors(left, subfacs);
       collect_tensor_factors(right, subfacs);
       auto ts = subfacs | transform([](auto&& t) { return t.expr; });
-      auto tn = TensorNetworkV2(ts);
+      auto tn = TensorNetworkV3(ts);
       auto canon =
           tn.canonicalize_slots(TensorCanonicalizer::cardinal_tensor_labels());
       hash::combine(h, canon.hash_value());

--- a/SeQuant/core/eval_expr.cpp
+++ b/SeQuant/core/eval_expr.cpp
@@ -108,10 +108,10 @@ EvalExpr::EvalExpr(EvalOp op, ResultType res, ExprPtr const& ex,
                    index_vector ixs, std::int8_t p, size_t h)
     : op_type_{op},
       result_type_{res},
-      expr_{ex.clone()},
+      hash_value_{h},
       canon_indices_{std::move(ixs)},
       canon_phase_{p},
-      hash_value_{h} {}
+      expr_{ex.clone()} {}
 
 const std::optional<EvalOp>& EvalExpr::op_type() const noexcept {
   return op_type_;

--- a/SeQuant/core/expr.cpp
+++ b/SeQuant/core/expr.cpp
@@ -352,7 +352,7 @@ ExprPtr Sum::canonicalize_impl(bool multipass) {
   for (auto pass = 0; pass != npasses; ++pass) {
     // recursively canonicalize summands ...
     // using for_each and directly access to summands
-    sequant::for_each(summands_, [this, pass](ExprPtr &summand) {
+    sequant::for_each(summands_, [pass](ExprPtr &summand) {
       auto bp = (pass % 2 == 0) ? summand->rapid_canonicalize()
                                 : summand->canonicalize();
       if (bp) {

--- a/SeQuant/core/expr.cpp
+++ b/SeQuant/core/expr.cpp
@@ -9,7 +9,7 @@
 #include <SeQuant/core/runtime.hpp>
 #include <SeQuant/core/tensor.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
-#include <SeQuant/core/tensor_network_v2.hpp>
+#include <SeQuant/core/tensor_network_v3.hpp>
 
 #include <range/v3/all.hpp>
 
@@ -209,7 +209,7 @@ ExprPtr Product::canonicalize_impl(bool rapid) {
   if (!contains_nontensors) {  // tensor network canonization is a special case
                                // that's done in
                                // TensorNetwork
-    TensorNetworkV2 tn(factors_);
+    TensorNetworkV3 tn(factors_);
     auto canon_factor =
         tn.canonicalize(TensorCanonicalizer::cardinal_tensor_labels(), rapid);
     const auto &tensors = tn.tensors();

--- a/SeQuant/core/index.hpp
+++ b/SeQuant/core/index.hpp
@@ -938,22 +938,26 @@ class Index : public Taggable {
 
   /// @brief The ordering operator
 
-  /// @return true if @c i1 preceeds @c i2 in the canonical order; Index objects
-  /// are ordered lexicographically, first by qns, followed by tags (if defined
+  /// The canonical order of Index objects is
+  /// lexicographical, first by qns, followed by tags (if defined
   /// for both), then by space, then by ordinal, then by protoindices (if any)
-  friend bool operator<(const Index &i1, const Index &i2) noexcept {
-    // compare qns, tags and spaces in that sequence
+  friend std::strong_ordering operator<=>(const Index &i1,
+                                          const Index &i2) noexcept {
+    using SO = std::strong_ordering;
 
     auto compare_space = [&i1, &i2]() {
       if (i1.space() != i2.space()) {
-        return i1.space() < i2.space();
+        return i1.space() < i2.space() ? SO::less : SO::greater;
       } else if (i1.space().attr() == default_space_attr &&
                  i1.space().base_key() != i2.space().base_key()) {
-        return i1.space().base_key() < i2.space().base_key();
+        return i1.space().base_key() < i2.space().base_key() ? SO::less
+                                                             : SO::greater;
       } else if (i1.ordinal_ != i2.ordinal_) {
-        return i1.ordinal_ < i2.ordinal_;
-      } else
-        return i1.proto_indices() < i2.proto_indices();
+        return i1.ordinal_ < i2.ordinal_ ? SO::less : SO::greater;
+      } else if (i1.proto_indices() == i2.proto_indices())
+        return SO::equal;
+      else
+        return i1.proto_indices() < i2.proto_indices() ? SO::less : SO::greater;
     };
 
     const auto i1_Q = i1.space().qns();
@@ -967,10 +971,10 @@ class Index : public Taggable {
         return compare_space();
       }
 
-      return i1.tag() < i2.tag();
+      return i1.tag() < i2.tag() ? SO::less : SO::greater;
     }
 
-    return i1_Q < i2_Q;
+    return i1_Q < i2_Q ? SO::less : SO::greater;
   }
 
 };  // class Index

--- a/SeQuant/core/index_space_registry.hpp
+++ b/SeQuant/core/index_space_registry.hpp
@@ -757,10 +757,10 @@ class IndexSpaceRegistry {
   /// increasing type()
   const std::vector<IndexSpace>& base_spaces() const {
     if (!base_spaces_) {
-      auto spaces =
-          *spaces_ |
-          ranges::views::filter([this](const auto& s) { return is_base(s); }) |
-          ranges::views::unique | ranges::to_vector;
+      auto spaces = *spaces_ | ranges::views::filter([this](const auto& s) {
+        return this->is_base(s);
+      }) | ranges::views::unique |
+                    ranges::to_vector;
       ranges::sort(spaces,
                    [](auto s1, auto s2) { return s1.type() < s2.type(); });
       std::scoped_lock guard{mtx_memoized_};
@@ -1365,7 +1365,7 @@ class IndexSpaceRegistry {
       // compute_approximate_size is used when populating the registry
       // so don't use base_spaces() here
       unsigned long size = ranges::accumulate(
-          *spaces_ | ranges::views::filter([this, &space_attr](auto& s) {
+          *spaces_ | ranges::views::filter([&space_attr](auto& s) {
             return s.qns() == space_attr.qns() && is_base(s.type()) &&
                    space_attr.type().intersection(s.type());
           }),

--- a/SeQuant/core/op.hpp
+++ b/SeQuant/core/op.hpp
@@ -840,6 +840,7 @@ class NormalOperator : public Operator<S>,
   bool _is_cnumber() const override final { return false; }
   std::wstring_view _label() const override final { return label(); }
   std::wstring _to_latex() const override final { return to_latex(); }
+  std::size_t _hash_value() const override final { return this->hash_value(); }
   bool _transform_indices(
       const container::map<Index, Index> &index_map) override final {
     return transform_indices(index_map);

--- a/SeQuant/core/op.hpp
+++ b/SeQuant/core/op.hpp
@@ -797,6 +797,10 @@ class NormalOperator : public Operator<S>,
   }
 
   // these implement the AbstractTensor interface
+  NormalOperator *_clone() const override final {
+    return new NormalOperator(*this);
+  }
+
   AbstractTensor::const_any_view_randsz _bra() const override final {
     return annihilators() |
            ranges::views::transform(

--- a/SeQuant/core/op.hpp
+++ b/SeQuant/core/op.hpp
@@ -870,6 +870,13 @@ class NormalOperator : public Operator<S>,
                [](auto &&op) -> Index & { return op.index(); });
   }
   AbstractTensor::any_view_randsz _aux_mutable() override final { return {}; }
+
+  void _permute_aux(std::span<const std::size_t> perm) override final {
+    if (perm.size() != 0)
+      throw std::invalid_argument(
+          "NormalOperator::_permute_aux(p): there are no aux indices, p must "
+          "be null");
+  }
 };
 
 static_assert(

--- a/SeQuant/core/parse.hpp
+++ b/SeQuant/core/parse.hpp
@@ -105,6 +105,7 @@ std::wstring deparse(const Expr &expr, bool annot_sym = true);
 std::wstring deparse(const Product &product, bool annot_sym);
 std::wstring deparse(const Sum &sum, bool annot_sym);
 std::wstring deparse(const Tensor &tensor, bool annot_sym = true);
+std::wstring deparse(const AbstractTensor &tensor, bool annot_sym = true);
 template <Statistics S>
 std::wstring deparse(const NormalOperator<S> &nop);
 std::wstring deparse(const Variable &variable);

--- a/SeQuant/core/parse/deparse.cpp
+++ b/SeQuant/core/parse/deparse.cpp
@@ -23,7 +23,7 @@ namespace sequant {
 namespace details {
 
 template <typename Range>
-std::wstring deparse_indices(const Range& indices) {
+std::wstring deparse_indices(Range&& indices) {
   std::wstring deparsed;
 
   for (std::size_t i = 0; i < indices.size(); ++i) {
@@ -225,6 +225,29 @@ std::wstring deparse(Tensor const& tensor, bool annot_sym) {
     deparsed += L":" + details::deparse_symm(tensor.symmetry());
     deparsed += L"-" + details::deparse_symm(tensor.braket_symmetry());
     deparsed += L"-" + details::deparse_symm(tensor.particle_symmetry());
+  }
+
+  return deparsed;
+}
+
+std::wstring deparse(AbstractTensor const& tensor, bool annot_sym) {
+  std::wstring deparsed(tensor._label());
+  deparsed += L"{" + details::deparse_indices(tensor._bra());
+  if (tensor._ket_rank() > 0) {
+    deparsed += L";" + details::deparse_indices(tensor._ket());
+  }
+  if (tensor._aux_rank() > 0) {
+    if (tensor._ket_rank() == 0) {
+      deparsed += L";";
+    }
+    deparsed += L";" + details::deparse_indices(tensor._aux());
+  }
+  deparsed += L"}";
+
+  if (annot_sym) {
+    deparsed += L":" + details::deparse_symm(tensor._symmetry());
+    deparsed += L"-" + details::deparse_symm(tensor._braket_symmetry());
+    deparsed += L"-" + details::deparse_symm(tensor._particle_symmetry());
   }
 
   return deparsed;

--- a/SeQuant/core/parse/parse.cpp
+++ b/SeQuant/core/parse/parse.cpp
@@ -258,6 +258,11 @@ parse::transform::DefaultSymmetries to_default_symms(
   if (particle_symm.has_value()) {
     std::get<2>(symms) = particle_symm.value();
   }
+  if (std::get<0>(symms) !=
+      Symmetry::nonsymm) {  // antisymmetry/symmetric bra and ket imply particle
+                            // symmetry
+    std::get<2>(symms) = ParticleSymmetry::symm;
+  }
 
   return symms;
 }

--- a/SeQuant/core/result_expr.cpp
+++ b/SeQuant/core/result_expr.cpp
@@ -39,12 +39,12 @@ ResultExpr::ResultExpr(IndexContainer bra, IndexContainer ket,
                        ParticleSymmetry particle_symm,
                        std::optional<std::wstring> label, ExprPtr expression)
     : m_expr(std::move(expression)),
-      m_braIndices(std::move(bra)),
-      m_ketIndices(std::move(ket)),
-      m_auxIndices(std::move(aux)),
       m_symm(symm),
       m_bksymm(braket_symm),
       m_psymm(particle_symm),
+      m_braIndices(std::move(bra)),
+      m_ketIndices(std::move(ket)),
+      m_auxIndices(std::move(aux)),
       m_label(std::move(label)) {}
 
 ResultExpr &ResultExpr::operator=(ExprPtr expression) {

--- a/SeQuant/core/tensor.hpp
+++ b/SeQuant/core/tensor.hpp
@@ -469,6 +469,8 @@ class Tensor : public Expr, public AbstractTensor, public Labeled {
                                         that_cast.aux().end());
   }
 
+  Tensor *_clone() const override final { return new Tensor(*this); }
+
   // these implement the AbstractTensor interface
   AbstractTensor::const_any_view_randsz _bra() const override final {
     return ranges::counted_view<const Index *>(

--- a/SeQuant/core/tensor.hpp
+++ b/SeQuant/core/tensor.hpp
@@ -502,6 +502,7 @@ class Tensor : public Expr, public AbstractTensor, public Labeled {
   bool _is_cnumber() const override final { return true; }
   std::wstring_view _label() const override final { return label_; }
   std::wstring _to_latex() const override final { return to_latex(); }
+  std::size_t _hash_value() const override final { return this->hash_value(); }
   bool _transform_indices(
       const container::map<Index, Index> &index_map) override final {
     return transform_indices(index_map);

--- a/SeQuant/core/tensor_canonicalizer.hpp
+++ b/SeQuant/core/tensor_canonicalizer.hpp
@@ -100,9 +100,15 @@ class TensorCanonicalizer {
   static void index_pair_comparer(index_pair_comparer_t comparer);
 
  protected:
-  inline auto bra_range(AbstractTensor& t) const { return t._bra_mutable(); }
-  inline auto ket_range(AbstractTensor& t) const { return t._ket_mutable(); }
-  inline auto aux_range(AbstractTensor& t) const { return t._aux_mutable(); }
+  inline auto mutable_bra_range(AbstractTensor& t) const {
+    return t._bra_mutable();
+  }
+  inline auto mutable_ket_range(AbstractTensor& t) const {
+    return t._ket_mutable();
+  }
+  inline auto mutable_aux_range(AbstractTensor& t) const {
+    return t._aux_mutable();
+  }
 
   /// the object used to compare indices
   static index_comparer_t index_comparer_;
@@ -181,8 +187,8 @@ class DefaultTensorCanonicalizer : public TensorCanonicalizer {
     switch (s) {
       case Symmetry::antisymm:
       case Symmetry::symm: {
-        auto _bra = bra_range(t);
-        auto _ket = ket_range(t);
+        auto _bra = mutable_bra_range(t);
+        auto _ket = mutable_ket_range(t);
         //      std::wcout << "canonicalizing " << to_latex(t);
         reset_ts_swap_counter<Index>();
         // std::{stable_}sort does not necessarily use swap! so must implement
@@ -198,8 +204,8 @@ class DefaultTensorCanonicalizer : public TensorCanonicalizer {
       case Symmetry::nonsymm: {
         // sort particles with bra and ket functions first,
         // then the particles with either bra or ket index
-        auto _bra = bra_range(t);
-        auto _ket = ket_range(t);
+        auto _bra = mutable_bra_range(t);
+        auto _ket = mutable_ket_range(t);
         auto _zip_braket = zip(take(_bra, _rank), take(_ket, _rank));
         bubble_sort(begin(_zip_braket), end(_zip_braket), paircmp);
         if (_bra_rank > _rank) {
@@ -218,7 +224,7 @@ class DefaultTensorCanonicalizer : public TensorCanonicalizer {
     }
 
     // TODO: Handle auxiliary index symmetries once they are introduced
-    // auto _aux = aux_range(t);
+    // auto _aux = mutable_aux_range(t);
     // ranges::sort(_aux, comp);
 
     ExprPtr result =

--- a/SeQuant/core/tensor_network.cpp
+++ b/SeQuant/core/tensor_network.cpp
@@ -651,7 +651,7 @@ TensorNetwork::GraphData TensorNetwork::make_bliss_graph(
       if (options.make_texlabels) {
         vertex_texlabels.emplace_back(std::nullopt);
       }
-      vertex_type.push_back(VertexType::Particle);
+      vertex_type.push_back(VertexType::TensorBraKet);
       // Color bk node in same color as tensor core
       vertex_color.push_back(colorizer(tref));
     }
@@ -697,7 +697,7 @@ TensorNetwork::GraphData TensorNetwork::make_bliss_graph(
         if (options.make_texlabels) {
           vertex_texlabels.emplace_back(std::nullopt);
         }
-        vertex_type.push_back(VertexType::Particle);
+        vertex_type.push_back(VertexType::TensorBraKet);
         vertex_color.push_back(colorizer(tref));
       }
     }

--- a/SeQuant/core/tensor_network/slot.hpp
+++ b/SeQuant/core/tensor_network/slot.hpp
@@ -28,7 +28,9 @@ enum class TensorIndexSlotType {
 /// @sa TensorNetworkV2
 enum class IndexSlotType {
   /// only part of proto index bundles
-  SPBundle,
+  IndexBundle,
+  /// legacy alias for IndexBundle
+  SPBundle = IndexBundle,
   /// in bra tensor vector index slot
   TensorBra,
   /// in ket tensor vector index slot

--- a/SeQuant/core/tensor_network/utils.hpp
+++ b/SeQuant/core/tensor_network/utils.hpp
@@ -1,0 +1,226 @@
+//
+// Created to resolve duplicate symbol issues between tensor_network_v2 and
+// tensor_network_v3 Contains shared utility functions and structs
+
+#ifndef SEQUANT_TENSOR_NETWORK_UTILITIES_HPP
+#define SEQUANT_TENSOR_NETWORK_UTILITIES_HPP
+
+#include <SeQuant/core/abstract_tensor.hpp>
+
+#include <algorithm>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <numeric>
+#include <ranges>
+#include <sstream>
+#include <string>
+#include <type_traits>
+
+#include <range/v3/algorithm/for_each.hpp>
+#include <range/v3/algorithm/none_of.hpp>
+#include <range/v3/functional/identity.hpp>
+#include <range/v3/iterator/basic_iterator.hpp>
+#include <range/v3/view/any_view.hpp>
+#include <range/v3/view/view.hpp>
+
+namespace sequant {
+
+inline bool tensors_commute(const AbstractTensor &lhs,
+                            const AbstractTensor &rhs) {
+  // tensors commute if their colors are different or either one of them
+  // is a c-number
+  return !(color(lhs) == color(rhs) && !is_cnumber(lhs) && !is_cnumber(rhs));
+}
+
+struct TensorBlockCompare {
+  bool operator()(const AbstractTensor &lhs, const AbstractTensor &rhs) const {
+    if (label(lhs) != label(rhs)) {
+      return label(lhs) < label(rhs);
+    }
+
+    if (bra_rank(lhs) != bra_rank(rhs)) {
+      return bra_rank(lhs) < bra_rank(rhs);
+    }
+    if (ket_rank(lhs) != ket_rank(rhs)) {
+      return ket_rank(lhs) < ket_rank(rhs);
+    }
+    if (aux_rank(lhs) != aux_rank(rhs)) {
+      return aux_rank(lhs) < aux_rank(rhs);
+    }
+
+    // Note: Accessing bra, ket and aux individually is a lot faster
+    // than accessing the combined index() object
+#define SEQUANT_CHECK_IDX_GROUP(group)                                  \
+  auto lhs_##group = lhs._##group();                                    \
+  auto rhs_##group = rhs._##group();                                    \
+  auto lhs_##group##_end = lhs_##group.end();                           \
+  auto rhs_##group##_end = rhs_##group.end();                           \
+  for (auto lhs_it = lhs_##group.begin(), rhs_it = rhs_##group.begin(); \
+       lhs_it != lhs_##group##_end && rhs_it != rhs_##group##_end;      \
+       ++lhs_it, ++rhs_it) {                                            \
+    if (lhs_it->space() != rhs_it->space()) {                           \
+      return lhs_it->space() < rhs_it->space();                         \
+    }                                                                   \
+  }
+
+    SEQUANT_CHECK_IDX_GROUP(bra);
+    SEQUANT_CHECK_IDX_GROUP(ket);
+    SEQUANT_CHECK_IDX_GROUP(aux);
+
+    // Tensors are identical
+    return false;
+  }
+};
+
+/// Compares tensors based on their label and orders them according to the order
+/// of the given cardinal tensor labels. If two tensors can't be discriminated
+/// via their label, they are compared based on regular
+/// AbstractTensor::operator< or based on their tensor block (the spaces of
+/// their indices) - depending on the configuration. If this doesn't
+/// discriminate the tensors, they are considered equal
+template <typename CardinalLabels>
+struct CanonicalTensorCompare {
+  const CardinalLabels &labels;
+  bool blocks_only;
+
+  CanonicalTensorCompare(const CardinalLabels &labels, bool blocks_only)
+      : labels(labels), blocks_only(blocks_only) {}
+
+  void set_blocks_only(bool blocks_only) { this->blocks_only = blocks_only; }
+
+  bool operator()(const AbstractTensorPtr &lhs_ptr,
+                  const AbstractTensorPtr &rhs_ptr) const {
+    assert(lhs_ptr);
+    assert(rhs_ptr);
+    const AbstractTensor &lhs = *lhs_ptr;
+    const AbstractTensor &rhs = *rhs_ptr;
+
+    if (!tensors_commute(lhs, rhs)) {
+      return false;
+    }
+
+    const auto get_label = [](const auto &t) {
+      if (label(t).back() == adjoint_label) {
+        // grab base label if adjoint label is present
+        return label(t).substr(0, label(t).size() - 1);
+      }
+      return label(t);
+    };
+
+    const auto lhs_it = std::find(labels.begin(), labels.end(), get_label(lhs));
+    const auto rhs_it = std::find(labels.begin(), labels.end(), get_label(rhs));
+
+    if (lhs_it != rhs_it) {
+      // At least one of the tensors is a cardinal one
+      // -> Order by the occurrence in the cardinal label list
+      return std::distance(labels.begin(), lhs_it) <
+             std::distance(labels.begin(), rhs_it);
+    }
+
+    // Either both are the same cardinal tensor or none is a cardinal tensor
+    if (blocks_only) {
+      TensorBlockCompare cmp;
+      return cmp(lhs, rhs);
+    } else {
+      return lhs < rhs;
+    }
+  }
+
+  template <typename AbstractTensorPtr_T>
+  bool operator()(const AbstractTensorPtr_T &lhs_ptr,
+                  const AbstractTensorPtr_T &rhs_ptr) const {
+    return (*this)(lhs_ptr.first, rhs_ptr.first);
+  }
+};
+
+template <typename ArrayLike, typename Permutation>
+auto permute(const ArrayLike &vector, const Permutation &perm) {
+  using std::size;
+  auto sz = size(vector);
+  std::decay_t<decltype(vector)> pvector(sz);
+  for (size_t i = 0; i != sz; ++i) pvector[perm[i]] = vector[i];
+  return pvector;
+}
+
+template <typename ReplacementMap>
+void apply_index_replacements(AbstractTensor &tensor,
+                              const ReplacementMap &replacements,
+                              const bool self_consistent) {
+#ifndef NDEBUG
+  // assert that tensors' indices are not tagged since going to tag indices
+  assert(ranges::none_of(
+      indices(tensor), [](const Index &idx) { return idx.tag().has_value(); }));
+#endif
+
+  bool pass_mutated;
+  do {
+    pass_mutated = transform_indices(tensor, replacements);
+  } while (self_consistent && pass_mutated);  // transform till stops changing
+
+  reset_tags(tensor);
+}
+
+template <typename ArrayLike, typename ReplacementMap>
+void apply_index_replacements(ArrayLike &tensors,
+                              const ReplacementMap &replacements,
+                              const bool self_consistent) {
+  for (auto &tensor : tensors) {
+    apply_index_replacements(*tensor, replacements, self_consistent);
+  }
+}
+
+template <typename Container>
+void order_to_indices(Container &container) {
+  std::vector<std::size_t> indices;
+  indices.resize(container.size());
+  std::iota(indices.begin(), indices.end(), 0);
+
+  std::sort(indices.begin(), indices.end(),
+            [&container](std::size_t lhs, std::size_t rhs) {
+              return container[lhs] < container[rhs];
+            });
+  // Overwrite container contents with indices
+  std::copy(indices.begin(), indices.end(), container.begin());
+}
+
+template <bool stable, typename Container, typename Comparator>
+void sort_via_indices(Container &container, const Comparator &cmp) {
+  std::vector<std::size_t> indices;
+  indices.resize(container.size());
+  std::iota(indices.begin(), indices.end(), 0);
+
+  if constexpr (stable) {
+    std::stable_sort(indices.begin(), indices.end(), cmp);
+  } else {
+    std::sort(indices.begin(), indices.end(), cmp);
+  }
+
+  // Bring elements in container into the order given by indices
+  // (the association is container[k] = container[indices[k]])
+  // -> implementation from https://stackoverflow.com/a/838789
+
+  for (std::size_t i = 0; i < container.size(); ++i) {
+    if (indices[i] == i) {
+      // This element is already where it is supposed to be
+      continue;
+    }
+
+    // Find the offset of the index pointing to i
+    // -> since we are going to change the content of the vector at position i,
+    // we have to update the index-mapping referencing i to point to the new
+    // location of the element that used to be at position i
+    std::size_t k;
+    for (k = i + 1; k < container.size(); ++k) {
+      if (indices[k] == i) {
+        break;
+      }
+    }
+    std::swap(container[i], container[indices[i]]);
+    std::swap(indices[i], indices[k]);
+  }
+}
+
+}  // namespace sequant
+
+#endif  // SEQUANT_TENSOR_NETWORK_UTILITIES_HPP

--- a/SeQuant/core/tensor_network/utils.hpp
+++ b/SeQuant/core/tensor_network/utils.hpp
@@ -221,6 +221,11 @@ void sort_via_indices(Container &container, const Comparator &cmp) {
   }
 }
 
+namespace tensor_network {
+using NamedIndexSet = container::set<Index, Index::FullLabelCompare>;
+using VertexColor = std::uint32_t;
+}  // namespace tensor_network
+
 }  // namespace sequant
 
 #endif  // SEQUANT_TENSOR_NETWORK_UTILITIES_HPP

--- a/SeQuant/core/tensor_network/vertex.hpp
+++ b/SeQuant/core/tensor_network/vertex.hpp
@@ -13,19 +13,28 @@ enum class VertexType {
   /// represent a Index object
   Index,
   /// represent a bundle of indices that serve as protoindices to Index objects
-  SPBundle,
+  IndexBundle,
+  /// legacy alias for IndexBundle
+  SPBundle = IndexBundle,
   /// represents a bra slot for an Index
   TensorBra,
   /// represents a ket slot for an Index
   TensorKet,
   /// represents an aux slot for an Index
   TensorAux,
+  /// represents a group of bra slots (TensorBra)
+  TensorBraBundle,
+  /// represents a group of ket slots (TensorKet)
+  TensorKetBundle,
+  /// represents a group of aux slots (TensorAux)
+  TensorAuxBundle,
   /// represents a slot for tensor label
   TensorCore,
-  /// connects bra slots to the matching ket slots:
+  /// connects bra slots (or their bundle) to the matching ket slots (or their
+  /// bundle):
   /// - for symmetric/antisymmetric case (i.e., tensor is
   /// symmetric/antisymmetric w.r.t. permutation of slots within bra or ket)
-  /// all bra and ket slots connect to same braket vertex;
+  /// bra and ket bundles connect to same braket vertex;
   /// - for particle-symmetric case (i.e., tensor is symmetric w.r.t.
   /// permutation of columns) there is one per column, all with the same color
   /// - for an asymmetric case there is also one per column, all with different

--- a/SeQuant/core/tensor_network/vertex.hpp
+++ b/SeQuant/core/tensor_network/vertex.hpp
@@ -8,14 +8,29 @@ namespace sequant {
 
 /// @sa TensorNetwork
 /// @sa TensorNetworkV2
+/// @sa TensorNetworkV3
 enum class VertexType {
+  /// represent a Index object
   Index,
+  /// represent a bundle of indices that serve as protoindices to Index objects
   SPBundle,
+  /// represents a bra slot for an Index
   TensorBra,
+  /// represents a ket slot for an Index
   TensorKet,
+  /// represents an aux slot for an Index
   TensorAux,
+  /// represents a slot for tensor label
   TensorCore,
-  Particle
+  /// connects bra slots to the matching ket slots:
+  /// - for symmetric/antisymmetric case (i.e., tensor is
+  /// symmetric/antisymmetric w.r.t. permutation of slots within bra or ket)
+  /// all bra and ket slots connect to same braket vertex;
+  /// - for particle-symmetric case (i.e., tensor is symmetric w.r.t.
+  /// permutation of columns) there is one per column, all with the same color
+  /// - for an asymmetric case there is also one per column, all with different
+  /// colors
+  TensorBraKet
 };
 
 }  // namespace sequant

--- a/SeQuant/core/tensor_network/vertex_painter.cpp
+++ b/SeQuant/core/tensor_network/vertex_painter.cpp
@@ -9,6 +9,18 @@ VertexPainter::VertexPainter(const VertexPainter::NamedIndexSet &named_indices,
       named_indices_(named_indices),
       distinct_named_indices_(distinct_named_indices) {}
 
+std::size_t VertexPainter::to_hash_value(const AbstractTensor &tensor) const {
+  auto hashes = {hash::value(tensor._label()),
+                 hash::value(tensor._bra_rank()),
+                 hash::value(tensor._ket_rank()),
+                 hash::value(tensor._aux_rank()),
+                 hash::value(tensor._symmetry()),
+                 hash::value(tensor._particle_symmetry()),
+                 hash::value(tensor._braket_symmetry())};
+
+  return to_hash_value(hashes);
+}
+
 VertexPainter::Color VertexPainter::operator()(const AbstractTensor &tensor) {
   Color color = to_color(hash::value(label(tensor)));
 
@@ -34,10 +46,27 @@ VertexPainter::Color VertexPainter::operator()(const AuxGroup &group) {
 }
 
 VertexPainter::Color VertexPainter::operator()(const ParticleGroup &group) {
-  Color color = to_color(group.id);
+  Color color;
+  if (group.size == 1) {  // legacy coloring works for groups of size 1
+    color = to_color(group.id);
+  } else {
+    color = to_color(
+        {group.id, group.size, static_cast<std::size_t>(group.symmetry)});
+  }
 
   return ensure_uniqueness(color, group);
 }
+
+void VertexPainter::apply_shade(std::size_t shade) { salt_ = shade; }
+
+VertexPainter::Color VertexPainter::apply_shade(const AbstractTensor &t) {
+  const auto hash = to_hash_value(t);
+  Color color = to_color(hash);
+  salt_ = to_hash_value(t);
+  return ensure_uniqueness(color, t);
+}
+
+void VertexPainter::reset_shade() { salt_.reset(); }
 
 VertexPainter::Color VertexPainter::operator()(const Index &idx) {
   auto it = named_indices_.find(idx);
@@ -68,42 +97,48 @@ VertexPainter::Color VertexPainter::operator()(const ProtoBundle &bundle) {
 }
 
 VertexPainter::Color VertexPainter::to_color(std::size_t color) const {
-  // Due to the way we compute the input color, different colors might only
-  // differ by a value of 1. This is fine for the algorithmic purpose (after
-  // all, colors need only be different - by how much is irrelevant), but
-  // sometimes we'll want to use those colors as actual colors to show to a
-  // human being. In those cases, having larger differences makes it easier to
-  // recognize different colors. Therefore, we hash-combine with an
-  // arbitrarily chosen salt with the goal that this will uniformly spread out
-  // all input values and therefore increase color differences.
-  constexpr std::size_t salt = 0x43d2c59cb15b73f0;
-  hash::combine(color, salt);
+  return to_color({color});
+}
+
+std::size_t VertexPainter::to_hash_value(
+    std::initializer_list<std::size_t> hash_values) const {
+  assert(hash_values.size() > 0);
+  std::size_t hash = *(hash_values.begin());
+  hash::combine(hash, salt());
+  for (auto it = hash_values.begin() + 1; it != hash_values.end(); ++it) {
+    hash::combine(hash, *it);
+  }
+  return hash;
+}
+
+VertexPainter::Color VertexPainter::to_color(
+    std::initializer_list<std::size_t> colors) const {
+  std::size_t color = to_hash_value(colors);
 
   if constexpr (sizeof(Color) >= sizeof(std::size_t)) {
     return color;
+  } else {
+    // Need to somehow fit the color into a lower precision integer. In the
+    // general case, this is necessarily a lossy conversion. We make the
+    // assumption that the input color is
+    // - a hash, or
+    // - computed from some object ID
+    // In the first case, we assume that the used hash function has a uniform
+    // distribution or if there is a bias, the bias is towards lower numbers.
+    // This allows us to simply reuse the lower x bits of the hash as a new hash
+    // (where x == CHAR_BIT * sizeof(VertexColor)). In the second case we assume
+    // that such values never exceed the possible value range of VertexColor so
+    // that again, we can simply take the lower x bits of color and in this case
+    // even retain the numeric value representing the color. Handily, this is
+    // exactly what happens when we perform a conversion into a narrower type.
+    // We only have to make sure that the underlying types are unsigned as
+    // otherwise the behavior is undefined.
+    static_assert(std::is_unsigned_v<VertexPainter::Color>,
+                  "Narrowing conversion are undefined for signed integers");
+    static_assert(std::is_unsigned_v<std::size_t>,
+                  "Narrowing conversion are undefined for signed integers");
+    return static_cast<Color>(color);
   }
-
-  // Need to somehow fit the color into a lower precision integer. In the
-  // general case, this is necessarily a lossy conversion. We make the
-  // assumption that the input color is
-  // - a hash, or
-  // - computed from some object ID
-  // In the first case, we assume that the used hash function has a uniform
-  // distribution or if there is a bias, the bias is towards lower numbers.
-  // This allows us to simply reuse the lower x bits of the hash as a new hash
-  // (where x == CHAR_BIT * sizeof(VertexColor)). In the second case we assume
-  // that such values never exceed the possible value range of VertexColor so
-  // that again, we can simply take the lower x bits of color and in this case
-  // even retain the numeric value representing the color. Handily, this is
-  // exactly what happens when we perform a conversion into a narrower type.
-  // We only have to make sure that the underlying types are unsigned as
-  // otherwise the behavior is undefined.
-  static_assert(sizeof(Color) < sizeof(std::size_t));
-  static_assert(std::is_unsigned_v<TensorNetworkV2::Graph::VertexColor>,
-                "Narrowing conversion are undefined for signed integers");
-  static_assert(std::is_unsigned_v<std::size_t>,
-                "Narrowing conversion are undefined for signed integers");
-  return static_cast<Color>(color);
 }
 
 bool VertexPainter::may_have_same_color(const VertexData &data,

--- a/SeQuant/core/tensor_network/vertex_painter.cpp
+++ b/SeQuant/core/tensor_network/vertex_painter.cpp
@@ -3,9 +3,8 @@
 
 namespace sequant {
 
-VertexPainter::VertexPainter(
-    const TensorNetworkV2::NamedIndexSet &named_indices,
-    bool distinct_named_indices)
+VertexPainter::VertexPainter(const VertexPainter::NamedIndexSet &named_indices,
+                             bool distinct_named_indices)
     : used_colors_(),
       named_indices_(named_indices),
       distinct_named_indices_(distinct_named_indices) {}

--- a/SeQuant/core/tensor_network/vertex_painter.hpp
+++ b/SeQuant/core/tensor_network/vertex_painter.hpp
@@ -29,10 +29,16 @@ struct AuxGroup {
 
   std::size_t id;
 };
+/// group of particles produces single braket slot
 struct ParticleGroup {
-  explicit ParticleGroup(std::size_t id) : id(id) {}
+  /// creates a group of particles of size @p size and symmetry @p symmetry
+  explicit ParticleGroup(std::size_t id, std::size_t size = 1,
+                         Symmetry symmetry = Symmetry::nonsymm)
+      : id(id), size(size), symmetry(symmetry) {}
 
   std::size_t id;
+  std::size_t size;
+  Symmetry symmetry;
 };
 
 /// Can be used to assign unique colors to a set of objects. The class
@@ -58,20 +64,75 @@ class VertexPainter {
 
   const ColorMap &used_colors() const;
 
-  Color operator()(const AbstractTensor &tensor);
+  Color operator()(const Index &idx);
+  Color operator()(const ProtoBundle &bundle);
+
+  /// computes color using tensor label only; the preferred way is apply_shade()
+  [[deprecated("use apply_shade()")]] Color operator()(
+      const AbstractTensor &tensor);
   Color operator()(const BraGroup &group);
   Color operator()(const KetGroup &group);
   Color operator()(const AuxGroup &group);
   Color operator()(const ParticleGroup &group);
-  Color operator()(const Index &idx);
-  Color operator()(const ProtoBundle &bundle);
+
+  /// will apply @p shade to all subsequent colors.
+  /// use this to shade colors of all tensor components by the color of its type
+  void apply_shade(std::size_t shade);
+
+  /// unlike the deprecated operator() computes a more complete hash
+  /// (see VertexPainter::to_hash_value(const AbstractTensor&)) and sets
+  /// it as the shade to all subsequent color computation.
+  /// Use this before coloring other vertices of this the tensor.
+  Color apply_shade(const AbstractTensor &t);
+
+  void reset_shade();
 
  private:
   ColorMap used_colors_;
   const NamedIndexSet &named_indices_;
   bool distinct_named_indices_ = true;
+  std::optional<std::size_t> salt_;
 
+  /// @return the salt value used for hashing; if not set by apply_shade use
+  /// default_salt_
+  std::size_t salt() const { return salt_ ? *salt_ : default_salt; }
+
+  // Due to the way we compute the input color, different colors might only
+  // differ by a value of 1. This is fine for the algorithmic purpose (after
+  // all, colors need only be different - by how much is irrelevant), but
+  // sometimes we'll want to use those colors as actual colors to show to a
+  // human being. In those cases, having larger differences makes it easier to
+  // recognize different colors. Therefore, we hash-combine with an
+  // arbitrarily chosen salt with the goal that this will uniformly spread out
+  // all input values and therefore increase color differences.
+  constexpr static std::size_t default_salt = 0x43d2c59cb15b73f0;
+
+  // combines hashes, injecting salt between first and second hashes
+  std::size_t to_hash_value(
+      std::initializer_list<std::size_t> hash_values) const;
+
+  /// @brief computes color of a tensor
+
+  /// @note The color should ideally depend on the "type" of the tensor. Unless
+  /// we assume that tensor labels are unique (this is too restrictive), the
+  /// type is defined by many things, including label, order (i.e. number of
+  /// bra, ket, and aux slots), types of each slot, symmetries etc. For tensors
+  /// with symmetries in general it is not possible to compute color uniquely
+  /// without doing some sort of canonicalization of the slots. To avoid
+  /// the need for canonicalization the color will only depend on the
+  /// attrributes that are invariant wrt to slot permutations. This means label,
+  /// order, and symmetries. More elaborate versions are possible, but have to
+  /// stop somewhere.
+  /// @sa to_hash_value()
+  /// @warning this includes the default_salt
+  std::size_t to_hash_value(const AbstractTensor &tensor) const;
+
+  /// produces a (not necessaryly unique) Color from an input size_t-sized color
   Color to_color(std::size_t color) const;
+
+  /// produces a (not necessaryly unique) Color from several input size_t-sized
+  /// hash values
+  Color to_color(std::initializer_list<std::size_t> hash_values) const;
 
   template <typename T>
   Color ensure_uniqueness(Color color, const T &val) {

--- a/SeQuant/core/tensor_network/vertex_painter.hpp
+++ b/SeQuant/core/tensor_network/vertex_painter.hpp
@@ -42,7 +42,8 @@ struct ParticleGroup {
 /// a colored graph representing a tensor network.
 class VertexPainter {
  public:
-  using Color = TensorNetworkV2::Graph::VertexColor;
+  using Color = tensor_network::VertexColor;
+  using NamedIndexSet = tensor_network::NamedIndexSet;
   using VertexData =
       std::variant<const AbstractTensor *, Index, const ProtoBundle *, BraGroup,
                    KetGroup, AuxGroup, ParticleGroup>;
@@ -52,7 +53,7 @@ class VertexPainter {
   /// their Index::color() \param distinct_named_indices if false, will use same
   /// color for all named indices that have same Index::color(), else will use
   /// distinct color for each named_index
-  VertexPainter(const TensorNetworkV2::NamedIndexSet &named_indices,
+  VertexPainter(const NamedIndexSet &named_indices,
                 bool distinct_named_indices = true);
 
   const ColorMap &used_colors() const;
@@ -67,7 +68,7 @@ class VertexPainter {
 
  private:
   ColorMap used_colors_;
-  const TensorNetworkV2::NamedIndexSet &named_indices_;
+  const NamedIndexSet &named_indices_;
   bool distinct_named_indices_ = true;
 
   Color to_color(std::size_t color) const;

--- a/SeQuant/core/tensor_network_v2.cpp
+++ b/SeQuant/core/tensor_network_v2.cpp
@@ -244,6 +244,7 @@ void TensorNetworkV2::canonicalize_graph(const NamedIndexSet &named_indices) {
 
   // Sort edges so that their order corresponds to the order of indices in the
   // canonical graph
+
   // Use this ordering to relabel anonymous indices
   const auto index_sorter = [&index_idx_to_vertex, &canonize_perm](
                                 std::size_t lhs_idx, std::size_t rhs_idx) {
@@ -255,7 +256,7 @@ void TensorNetworkV2::canonicalize_graph(const NamedIndexSet &named_indices) {
     return canonize_perm[lhs_vertex] < canonize_perm[rhs_vertex];
   };
 
-  sort_via_indices<false>(edges_, index_sorter);
+  sort_via_ordinals<OrderType::StrictWeak>(edges_, index_sorter);
 
   for (const Edge &current : edges_) {
     const Index &idx = current.idx();
@@ -323,7 +324,8 @@ void TensorNetworkV2::canonicalize_graph(const NamedIndexSet &named_indices) {
   }
 
   // Bring tensors into canonical order (analogously to how we reordered
-  // indices), but ensure to respect commutativity!
+  // indices); elements that do not commute are equivalent, due to this
+  // this specifies a non-strict weak order
   const auto tensor_sorter = [this, &canonize_perm, &tensor_idx_to_vertex](
                                  std::size_t lhs_idx, std::size_t rhs_idx) {
     const AbstractTensor &lhs = *tensors_[lhs_idx];
@@ -342,7 +344,7 @@ void TensorNetworkV2::canonicalize_graph(const NamedIndexSet &named_indices) {
     return canonize_perm[lhs_vertex] < canonize_perm[rhs_vertex];
   };
 
-  sort_via_indices<true>(tensors_, tensor_sorter);
+  sort_via_ordinals<OrderType::Weak>(tensors_, tensor_sorter);
 
   if (Logger::instance().canonicalize) {
     std::wcout << "TensorNetworkV2::canonicalize_graph: tensors after "

--- a/SeQuant/core/tensor_network_v2.cpp
+++ b/SeQuant/core/tensor_network_v2.cpp
@@ -257,7 +257,7 @@ void TensorNetworkV2::canonicalize_graph(const NamedIndexSet &named_indices) {
   for (const Edge &current : edges_) {
     const Index &idx = current.idx();
 
-    const auto is_named = current.vertex_count() != 2;
+    const auto is_named = current.vertex_count() == 1;
     if (is_named) continue;
 
     idxrepl_emplace(idx, idxfac.make(idx));

--- a/SeQuant/core/tensor_network_v2.cpp
+++ b/SeQuant/core/tensor_network_v2.cpp
@@ -15,6 +15,7 @@
 #include <SeQuant/core/logger.hpp>
 #include <SeQuant/core/tag.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
+#include <SeQuant/core/tensor_network/tn_utils.hpp>
 #include <SeQuant/core/tensor_network/vertex_painter.hpp>
 #include <SeQuant/core/tensor_network_v2.hpp>
 #include <SeQuant/core/utility/swap.hpp>
@@ -40,113 +41,13 @@
 
 namespace sequant {
 
-inline bool tensors_commute(const AbstractTensor &lhs,
-                            const AbstractTensor &rhs) {
-  // tensors commute if their colors are different or either one of them
-  // is a c-number
-  return !(color(lhs) == color(rhs) && !is_cnumber(lhs) && !is_cnumber(rhs));
-}
-
-struct TensorBlockCompare {
-  bool operator()(const AbstractTensor &lhs, const AbstractTensor &rhs) const {
-    if (label(lhs) != label(rhs)) {
-      return label(lhs) < label(rhs);
-    }
-
-    if (bra_rank(lhs) != bra_rank(rhs)) {
-      return bra_rank(lhs) < bra_rank(rhs);
-    }
-    if (ket_rank(lhs) != ket_rank(rhs)) {
-      return ket_rank(lhs) < ket_rank(rhs);
-    }
-    if (aux_rank(lhs) != aux_rank(rhs)) {
-      return aux_rank(lhs) < aux_rank(rhs);
-    }
-
-    // Note: Accessing bra, ket and aux individually is a lot faster
-    // than accessing the combined index() object
-#define SEQUANT_CHECK_IDX_GROUP(group)                                  \
-  auto lhs_##group = lhs._##group();                                    \
-  auto rhs_##group = rhs._##group();                                    \
-  auto lhs_##group##_end = lhs_##group.end();                           \
-  auto rhs_##group##_end = rhs_##group.end();                           \
-  for (auto lhs_it = lhs_##group.begin(), rhs_it = rhs_##group.begin(); \
-       lhs_it != lhs_##group##_end && rhs_it != rhs_##group##_end;      \
-       ++lhs_it, ++rhs_it) {                                            \
-    if (lhs_it->space() != rhs_it->space()) {                           \
-      return lhs_it->space() < rhs_it->space();                         \
-    }                                                                   \
-  }
-
-    SEQUANT_CHECK_IDX_GROUP(bra);
-    SEQUANT_CHECK_IDX_GROUP(ket);
-    SEQUANT_CHECK_IDX_GROUP(aux);
-
-    // Tensors are identical
-    return false;
-  }
-};
-
-/// Compares tensors based on their label and orders them according to the order
-/// of the given cardinal tensor labels. If two tensors can't be discriminated
-/// via their label, they are compared based on regular
-/// AbstractTensor::operator< or based on their tensor block (the spaces of
-/// their indices) - depending on the configuration. If this doesn't
-/// discriminate the tensors, they are considered equal
-template <typename CardinalLabels>
-struct CanonicalTensorCompare {
-  const CardinalLabels &labels;
-  bool blocks_only;
-
-  CanonicalTensorCompare(const CardinalLabels &labels, bool blocks_only)
-      : labels(labels), blocks_only(blocks_only) {}
-
-  void set_blocks_only(bool blocks_only) { this->blocks_only = blocks_only; }
-
-  bool operator()(const AbstractTensorPtr &lhs_ptr,
-                  const AbstractTensorPtr &rhs_ptr) const {
-    assert(lhs_ptr);
-    assert(rhs_ptr);
-    const AbstractTensor &lhs = *lhs_ptr;
-    const AbstractTensor &rhs = *rhs_ptr;
-
-    if (!tensors_commute(lhs, rhs)) {
-      return false;
-    }
-
-    const auto get_label = [](const auto &t) {
-      if (label(t).back() == adjoint_label) {
-        // grab base label if adjoint label is present
-        return label(t).substr(0, label(t).size() - 1);
-      }
-      return label(t);
-    };
-
-    const auto lhs_it = std::find(labels.begin(), labels.end(), get_label(lhs));
-    const auto rhs_it = std::find(labels.begin(), labels.end(), get_label(rhs));
-
-    if (lhs_it != rhs_it) {
-      // At least one of the tensors is a cardinal one
-      // -> Order by the occurrence in the cardinal label list
-      return std::distance(labels.begin(), lhs_it) <
-             std::distance(labels.begin(), rhs_it);
-    }
-
-    // Either both are the same cardinal tensor or none is a cardinal tensor
-    if (blocks_only) {
-      TensorBlockCompare cmp;
-      return cmp(lhs, rhs);
-    } else {
-      return lhs < rhs;
-    }
-  }
-
-  template <typename AbstractTensorPtr_T>
-  bool operator()(const AbstractTensorPtr_T &lhs_ptr,
-                  const AbstractTensorPtr_T &rhs_ptr) const {
-    return (*this)(lhs_ptr.first, rhs_ptr.first);
-  }
-};
+using tensor_network_utils::apply_index_replacements;
+using tensor_network_utils::CanonicalTensorCompare;
+using tensor_network_utils::order_to_indices;
+using tensor_network_utils::permute;
+using tensor_network_utils::sort_via_indices;
+using tensor_network_utils::TensorBlockCompare;
+using tensor_network_utils::tensors_commute;
 
 TensorNetworkV2::Vertex::Vertex(Origin origin, std::size_t terminal_idx,
                                 std::size_t index_slot, Symmetry terminal_symm)
@@ -237,93 +138,6 @@ std::size_t TensorNetworkV2::Graph::vertex_to_tensor_idx(
   assert(tensor_idx > 0);
 
   return tensor_idx - 1;
-}
-
-template <typename ArrayLike, typename Permutation>
-auto permute(const ArrayLike &vector, const Permutation &perm) {
-  using std::size;
-  auto sz = size(vector);
-  std::decay_t<decltype(vector)> pvector(sz);
-  for (size_t i = 0; i != sz; ++i) pvector[perm[i]] = vector[i];
-  return pvector;
-}
-
-template <typename ReplacementMap>
-void apply_index_replacements(AbstractTensor &tensor,
-                              const ReplacementMap &replacements,
-                              const bool self_consistent) {
-#ifndef NDEBUG
-  // assert that tensors' indices are not tagged since going to tag indices
-  assert(ranges::none_of(
-      indices(tensor), [](const Index &idx) { return idx.tag().has_value(); }));
-#endif
-
-  bool pass_mutated;
-  do {
-    pass_mutated = transform_indices(tensor, replacements);
-  } while (self_consistent && pass_mutated);  // transform till stops changing
-
-  reset_tags(tensor);
-}
-
-template <typename ArrayLike, typename ReplacementMap>
-void apply_index_replacements(ArrayLike &tensors,
-                              const ReplacementMap &replacements,
-                              const bool self_consistent) {
-  for (auto &tensor : tensors) {
-    apply_index_replacements(*tensor, replacements, self_consistent);
-  }
-}
-
-template <typename Container>
-void order_to_indices(Container &container) {
-  std::vector<std::size_t> indices;
-  indices.resize(container.size());
-  std::iota(indices.begin(), indices.end(), 0);
-
-  std::sort(indices.begin(), indices.end(),
-            [&container](std::size_t lhs, std::size_t rhs) {
-              return container[lhs] < container[rhs];
-            });
-  // Overwrite container contents with indices
-  std::copy(indices.begin(), indices.end(), container.begin());
-}
-
-template <bool stable, typename Container, typename Comparator>
-void sort_via_indices(Container &container, const Comparator &cmp) {
-  std::vector<std::size_t> indices;
-  indices.resize(container.size());
-  std::iota(indices.begin(), indices.end(), 0);
-
-  if constexpr (stable) {
-    std::stable_sort(indices.begin(), indices.end(), cmp);
-  } else {
-    std::sort(indices.begin(), indices.end(), cmp);
-  }
-
-  // Bring elements in container into the order given by indices
-  // (the association is container[k] = container[indices[k]])
-  // -> implementation from https://stackoverflow.com/a/838789
-
-  for (std::size_t i = 0; i < container.size(); ++i) {
-    if (indices[i] == i) {
-      // This element is already where it is supposed to be
-      continue;
-    }
-
-    // Find the offset of the index pointing to i
-    // -> since we are going to change the content of the vector at position i,
-    // we have to update the index-mapping referencing i to point to the new
-    // location of the element that used to be at position i
-    std::size_t k;
-    for (k = i + 1; k < container.size(); ++k) {
-      if (indices[k] == i) {
-        break;
-      }
-    }
-    std::swap(container[i], container[indices[i]]);
-    std::swap(indices[i], indices[k]);
-  }
 }
 
 void TensorNetworkV2::canonicalize_graph(const NamedIndexSet &named_indices) {

--- a/SeQuant/core/tensor_network_v2.cpp
+++ b/SeQuant/core/tensor_network_v2.cpp
@@ -203,7 +203,7 @@ void TensorNetworkV2::canonicalize_graph(const NamedIndexSet &named_indices) {
       case VertexType::Index:
         index_idx_to_vertex.emplace_back(index_idx_to_vertex.size()) = vertex;
         break;
-      case VertexType::Particle: {
+      case VertexType::TensorBraKet: {
         assert(tensor_idx > 0);
         const std::size_t base_tensor_idx = tensor_idx - 1;
         assert(symmetry(*tensors_.at(base_tensor_idx)) == Symmetry::nonsymm);
@@ -772,7 +772,7 @@ TensorNetworkV2::Graph TensorNetworkV2::create_graph(
           graph.vertex_labels.emplace_back(L"p_" + std::to_wstring(i + 1));
         if (options.make_texlabels)
           graph.vertex_texlabels.emplace_back(std::nullopt);
-        graph.vertex_types.push_back(VertexType::Particle);
+        graph.vertex_types.push_back(VertexType::TensorBraKet);
         // Particles are indistinguishable -> always use same ID
         graph.vertex_colors.push_back(colorizer(ParticleGroup{0}));
         edges.push_back(std::make_pair(tensor_vertex, nvertex - 1));

--- a/SeQuant/core/tensor_network_v2.cpp
+++ b/SeQuant/core/tensor_network_v2.cpp
@@ -219,6 +219,9 @@ void TensorNetworkV2::canonicalize_graph(const NamedIndexSet &named_indices) {
       case VertexType::TensorBra:
       case VertexType::TensorKet:
       case VertexType::TensorAux:
+      case VertexType::TensorBraBundle:
+      case VertexType::TensorKetBundle:
+      case VertexType::TensorAuxBundle:
       case VertexType::SPBundle:
         break;
     }
@@ -229,9 +232,9 @@ void TensorNetworkV2::canonicalize_graph(const NamedIndexSet &named_indices) {
   assert(tensor_idx_to_vertex.size() == tensors_.size());
   assert(tensor_idx_to_particle_order.size() <= tensors_.size());
 
-  // order_to_indices(index_order);
+  // sort_then_replace_by_ordinals(index_order);
   for (auto &current : tensor_idx_to_particle_order) {
-    order_to_indices(current.second);
+    sort_then_replace_by_ordinals(current.second);
   }
 
   container::map<Index, Index> idxrepl;

--- a/SeQuant/core/tensor_network_v2.cpp
+++ b/SeQuant/core/tensor_network_v2.cpp
@@ -15,7 +15,7 @@
 #include <SeQuant/core/logger.hpp>
 #include <SeQuant/core/tag.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
-#include <SeQuant/core/tensor_network/tn_utils.hpp>
+#include <SeQuant/core/tensor_network/utils.hpp>
 #include <SeQuant/core/tensor_network/vertex_painter.hpp>
 #include <SeQuant/core/tensor_network_v2.hpp>
 #include <SeQuant/core/utility/swap.hpp>
@@ -40,14 +40,6 @@
 #include <range/v3/view/view.hpp>
 
 namespace sequant {
-
-using tensor_network_utils::apply_index_replacements;
-using tensor_network_utils::CanonicalTensorCompare;
-using tensor_network_utils::order_to_indices;
-using tensor_network_utils::permute;
-using tensor_network_utils::sort_via_indices;
-using tensor_network_utils::TensorBlockCompare;
-using tensor_network_utils::tensors_commute;
 
 TensorNetworkV2::Vertex::Vertex(Origin origin, std::size_t terminal_idx,
                                 std::size_t index_slot, Symmetry terminal_symm)

--- a/SeQuant/core/tensor_network_v2.hpp
+++ b/SeQuant/core/tensor_network_v2.hpp
@@ -11,6 +11,7 @@
 #include <SeQuant/core/index.hpp>
 #include <SeQuant/core/tensor_network/canonicals.hpp>
 #include <SeQuant/core/tensor_network/slot.hpp>
+#include <SeQuant/core/tensor_network/utils.hpp>
 #include <SeQuant/core/tensor_network/vertex.hpp>
 
 #include <range/v3/range/traits.hpp>
@@ -182,7 +183,7 @@ class TensorNetworkV2 {
     /// The type used to encode the color of a vertex. The restriction of this
     /// being as 32-bit integer comes from how BLISS is trying to convert these
     /// into RGB values.
-    using VertexColor = std::uint32_t;
+    using VertexColor = tensor_network::VertexColor;
 
     std::unique_ptr<bliss::Graph> bliss_graph;
     std::vector<std::wstring> vertex_labels;
@@ -234,7 +235,7 @@ class TensorNetworkV2 {
 
   const auto &tensor_input_ordinals() const { return tensor_input_ordinals_; }
 
-  using NamedIndexSet = container::set<Index, Index::FullLabelCompare>;
+  using NamedIndexSet = tensor_network::NamedIndexSet;
 
   /// @param cardinal_tensor_labels move all tensors with these labels to the
   /// front before canonicalizing indices

--- a/SeQuant/core/tensor_network_v2.hpp
+++ b/SeQuant/core/tensor_network_v2.hpp
@@ -351,7 +351,7 @@ class TensorNetworkV2 {
     /// if false, will use same color for all
     /// named indices that have same Index::color(), else will use distinct
     /// color for each
-    bool distinct_named_indices = true;
+    bool distinct_named_indices = false;
 
     /// if false, will not generate the labels
     bool make_labels = true;
@@ -385,7 +385,7 @@ class TensorNetworkV2 {
   ///     terminal's type (bra/ket).
   Graph create_graph(const CreateGraphOptions &options = {
                          .named_indices = nullptr,
-                         .distinct_named_indices = true,
+                         .distinct_named_indices = false,
                          .make_labels = true,
                          .make_texlabels = true,
                          .make_idx_to_vertex = false}) const;

--- a/SeQuant/core/tensor_network_v2.hpp
+++ b/SeQuant/core/tensor_network_v2.hpp
@@ -42,6 +42,7 @@ namespace sequant {
 /// graph), with Tensor objects represented by one or more vertices.
 class TensorNetworkV2 {
  public:
+  // for unit testing only
   friend class TensorNetworkV2Accessor;
 
   enum class Origin {

--- a/SeQuant/core/tensor_network_v3.cpp
+++ b/SeQuant/core/tensor_network_v3.cpp
@@ -15,6 +15,7 @@
 #include <SeQuant/core/logger.hpp>
 #include <SeQuant/core/tag.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
+#include <SeQuant/core/tensor_network/tn_utils.hpp>
 #include <SeQuant/core/tensor_network/vertex_painter.hpp>
 #include <SeQuant/core/tensor_network_v3.hpp>
 #include <SeQuant/core/utility/swap.hpp>
@@ -40,112 +41,13 @@
 
 namespace sequant {
 
-bool tensors_commute(const AbstractTensor &lhs, const AbstractTensor &rhs) {
-  // tensors commute if their colors are different or either one of them
-  // is a c-number
-  return !(color(lhs) == color(rhs) && !is_cnumber(lhs) && !is_cnumber(rhs));
-}
-
-struct TensorBlockCompare {
-  bool operator()(const AbstractTensor &lhs, const AbstractTensor &rhs) const {
-    if (label(lhs) != label(rhs)) {
-      return label(lhs) < label(rhs);
-    }
-
-    if (bra_rank(lhs) != bra_rank(rhs)) {
-      return bra_rank(lhs) < bra_rank(rhs);
-    }
-    if (ket_rank(lhs) != ket_rank(rhs)) {
-      return ket_rank(lhs) < ket_rank(rhs);
-    }
-    if (aux_rank(lhs) != aux_rank(rhs)) {
-      return aux_rank(lhs) < aux_rank(rhs);
-    }
-
-    // Note: Accessing bra, ket and aux individually is a lot faster
-    // than accessing the combined index() object
-#define SEQUANT_CHECK_IDX_GROUP(group)                                  \
-  auto lhs_##group = lhs._##group();                                    \
-  auto rhs_##group = rhs._##group();                                    \
-  auto lhs_##group##_end = lhs_##group.end();                           \
-  auto rhs_##group##_end = rhs_##group.end();                           \
-  for (auto lhs_it = lhs_##group.begin(), rhs_it = rhs_##group.begin(); \
-       lhs_it != lhs_##group##_end && rhs_it != rhs_##group##_end;      \
-       ++lhs_it, ++rhs_it) {                                            \
-    if (lhs_it->space() != rhs_it->space()) {                           \
-      return lhs_it->space() < rhs_it->space();                         \
-    }                                                                   \
-  }
-
-    SEQUANT_CHECK_IDX_GROUP(bra);
-    SEQUANT_CHECK_IDX_GROUP(ket);
-    SEQUANT_CHECK_IDX_GROUP(aux);
-
-    // Tensors are identical
-    return false;
-  }
-};
-
-/// Compares tensors based on their label and orders them according to the order
-/// of the given cardinal tensor labels. If two tensors can't be discriminated
-/// via their label, they are compared based on regular
-/// AbstractTensor::operator< or based on their tensor block (the spaces of
-/// their indices) - depending on the configuration. If this doesn't
-/// discriminate the tensors, they are considered equal
-template <typename CardinalLabels>
-struct CanonicalTensorCompare {
-  const CardinalLabels &labels;
-  bool blocks_only;
-
-  CanonicalTensorCompare(const CardinalLabels &labels, bool blocks_only)
-      : labels(labels), blocks_only(blocks_only) {}
-
-  void set_blocks_only(bool blocks_only) { this->blocks_only = blocks_only; }
-
-  bool operator()(const AbstractTensorPtr &lhs_ptr,
-                  const AbstractTensorPtr &rhs_ptr) const {
-    assert(lhs_ptr);
-    assert(rhs_ptr);
-    const AbstractTensor &lhs = *lhs_ptr;
-    const AbstractTensor &rhs = *rhs_ptr;
-
-    if (!tensors_commute(lhs, rhs)) {
-      return false;
-    }
-
-    const auto get_label = [](const auto &t) {
-      if (label(t).back() == adjoint_label) {
-        // grab base label if adjoint label is present
-        return label(t).substr(0, label(t).size() - 1);
-      }
-      return label(t);
-    };
-
-    const auto lhs_it = std::find(labels.begin(), labels.end(), get_label(lhs));
-    const auto rhs_it = std::find(labels.begin(), labels.end(), get_label(rhs));
-
-    if (lhs_it != rhs_it) {
-      // At least one of the tensors is a cardinal one
-      // -> Order by the occurrence in the cardinal label list
-      return std::distance(labels.begin(), lhs_it) <
-             std::distance(labels.begin(), rhs_it);
-    }
-
-    // Either both are the same cardinal tensor or none is a cardinal tensor
-    if (blocks_only) {
-      TensorBlockCompare cmp;
-      return cmp(lhs, rhs);
-    } else {
-      return lhs < rhs;
-    }
-  }
-
-  template <typename AbstractTensorPtr_T>
-  bool operator()(const AbstractTensorPtr_T &lhs_ptr,
-                  const AbstractTensorPtr_T &rhs_ptr) const {
-    return (*this)(lhs_ptr.first, rhs_ptr.first);
-  }
-};
+using tensor_network_utils::apply_index_replacements;
+using tensor_network_utils::CanonicalTensorCompare;
+using tensor_network_utils::order_to_indices;
+using tensor_network_utils::permute;
+using tensor_network_utils::sort_via_indices;
+using tensor_network_utils::TensorBlockCompare;
+using tensor_network_utils::tensors_commute;
 
 TensorNetworkV3::Vertex::Vertex(Origin origin, std::size_t terminal_idx,
                                 std::size_t index_slot, Symmetry terminal_symm)
@@ -236,93 +138,6 @@ std::size_t TensorNetworkV3::Graph::vertex_to_tensor_idx(
   assert(tensor_idx > 0);
 
   return tensor_idx - 1;
-}
-
-template <typename ArrayLike, typename Permutation>
-auto permute(const ArrayLike &vector, const Permutation &perm) {
-  using std::size;
-  auto sz = size(vector);
-  std::decay_t<decltype(vector)> pvector(sz);
-  for (size_t i = 0; i != sz; ++i) pvector[perm[i]] = vector[i];
-  return pvector;
-}
-
-template <typename ReplacementMap>
-void apply_index_replacements(AbstractTensor &tensor,
-                              const ReplacementMap &replacements,
-                              const bool self_consistent) {
-#ifndef NDEBUG
-  // assert that tensors' indices are not tagged since going to tag indices
-  assert(ranges::none_of(
-      indices(tensor), [](const Index &idx) { return idx.tag().has_value(); }));
-#endif
-
-  bool pass_mutated;
-  do {
-    pass_mutated = transform_indices(tensor, replacements);
-  } while (self_consistent && pass_mutated);  // transform till stops changing
-
-  reset_tags(tensor);
-}
-
-template <typename ArrayLike, typename ReplacementMap>
-void apply_index_replacements(ArrayLike &tensors,
-                              const ReplacementMap &replacements,
-                              const bool self_consistent) {
-  for (auto &tensor : tensors) {
-    apply_index_replacements(*tensor, replacements, self_consistent);
-  }
-}
-
-template <typename Container>
-void order_to_indices(Container &container) {
-  std::vector<std::size_t> indices;
-  indices.resize(container.size());
-  std::iota(indices.begin(), indices.end(), 0);
-
-  std::sort(indices.begin(), indices.end(),
-            [&container](std::size_t lhs, std::size_t rhs) {
-              return container[lhs] < container[rhs];
-            });
-  // Overwrite container contents with indices
-  std::copy(indices.begin(), indices.end(), container.begin());
-}
-
-template <bool stable, typename Container, typename Comparator>
-void sort_via_indices(Container &container, const Comparator &cmp) {
-  std::vector<std::size_t> indices;
-  indices.resize(container.size());
-  std::iota(indices.begin(), indices.end(), 0);
-
-  if constexpr (stable) {
-    std::stable_sort(indices.begin(), indices.end(), cmp);
-  } else {
-    std::sort(indices.begin(), indices.end(), cmp);
-  }
-
-  // Bring elements in container into the order given by indices
-  // (the association is container[k] = container[indices[k]])
-  // -> implementation from https://stackoverflow.com/a/838789
-
-  for (std::size_t i = 0; i < container.size(); ++i) {
-    if (indices[i] == i) {
-      // This element is already where it is supposed to be
-      continue;
-    }
-
-    // Find the offset of the index pointing to i
-    // -> since we are going to change the content of the vector at position i,
-    // we have to update the index-mapping referencing i to point to the new
-    // location of the element that used to be at position i
-    std::size_t k;
-    for (k = i + 1; k < container.size(); ++k) {
-      if (indices[k] == i) {
-        break;
-      }
-    }
-    std::swap(container[i], container[indices[i]]);
-    std::swap(indices[i], indices[k]);
-  }
 }
 
 void TensorNetworkV3::canonicalize_graph(const NamedIndexSet &named_indices) {

--- a/SeQuant/core/tensor_network_v3.cpp
+++ b/SeQuant/core/tensor_network_v3.cpp
@@ -15,7 +15,7 @@
 #include <SeQuant/core/logger.hpp>
 #include <SeQuant/core/tag.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
-#include <SeQuant/core/tensor_network/tn_utils.hpp>
+#include <SeQuant/core/tensor_network/utils.hpp>
 #include <SeQuant/core/tensor_network/vertex_painter.hpp>
 #include <SeQuant/core/tensor_network_v3.hpp>
 #include <SeQuant/core/utility/swap.hpp>
@@ -40,14 +40,6 @@
 #include <range/v3/view/view.hpp>
 
 namespace sequant {
-
-using tensor_network_utils::apply_index_replacements;
-using tensor_network_utils::CanonicalTensorCompare;
-using tensor_network_utils::order_to_indices;
-using tensor_network_utils::permute;
-using tensor_network_utils::sort_via_indices;
-using tensor_network_utils::TensorBlockCompare;
-using tensor_network_utils::tensors_commute;
 
 TensorNetworkV3::Vertex::Vertex(Origin origin, std::size_t terminal_idx,
                                 std::size_t index_slot, Symmetry terminal_symm)

--- a/SeQuant/core/tensor_network_v3.cpp
+++ b/SeQuant/core/tensor_network_v3.cpp
@@ -602,12 +602,12 @@ TensorNetworkV3::canonicalize_slots(
         // connected ... the latter would only occur if this index is named
         // due to also being a protoindex on one of the named indices!
         if (edge_it->vertex_count() == 1) {
-          if (edge_it->first_vertex().getOrigin() == Origin::Aux)
+          if (edge_it->vertex(0).getOrigin() == Origin::Aux)
             slot_type = IndexSlotType::TensorAux;
-          else if (edge_it->first_vertex().getOrigin() == Origin::Bra)
+          else if (edge_it->vertex(0).getOrigin() == Origin::Bra)
             slot_type = IndexSlotType::TensorBra;
           else {
-            assert(edge_it->first_vertex().getOrigin() == Origin::Ket);
+            assert(edge_it->vertex(0).getOrigin() == Origin::Ket);
             slot_type = IndexSlotType::TensorKet;
           }
         } else {  // if
@@ -930,8 +930,7 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
     // Connect index to the tensor(s) it is connected to
     for (std::size_t i = 0; i < current_edge.vertex_count(); ++i) {
       assert(i <= 1);
-      const Vertex &vertex =
-          i == 0 ? current_edge.first_vertex() : current_edge.second_vertex();
+      const Vertex &vertex = current_edge.vertex(i);
 
       assert(vertex.getTerminalIndex() < tensor_vertices.size());
       assert(tensor_vertices[vertex.getTerminalIndex()] !=

--- a/SeQuant/core/tensor_network_v3.cpp
+++ b/SeQuant/core/tensor_network_v3.cpp
@@ -257,7 +257,7 @@ void TensorNetworkV3::canonicalize_graph(const NamedIndexSet &named_indices) {
   for (const Edge &current : edges_) {
     const Index &idx = current.idx();
 
-    const auto is_named = current.vertex_count() != 2;
+    const auto is_named = current.vertex_count() == 1;
     if (is_named) continue;
 
     idxrepl_emplace(idx, idxfac.make(idx));

--- a/SeQuant/core/tensor_network_v3.cpp
+++ b/SeQuant/core/tensor_network_v3.cpp
@@ -1,5 +1,5 @@
 //
-// Created by Eduard Valeyev on 2019-02-26.
+// Created by Eduard Valeyev on 2025-24-07.
 //
 
 #include <SeQuant/core/abstract_tensor.hpp>
@@ -16,7 +16,7 @@
 #include <SeQuant/core/tag.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
 #include <SeQuant/core/tensor_network/vertex_painter.hpp>
-#include <SeQuant/core/tensor_network_v2.hpp>
+#include <SeQuant/core/tensor_network_v3.hpp>
 #include <SeQuant/core/utility/swap.hpp>
 #include <SeQuant/core/utility/tuple.hpp>
 #include <SeQuant/core/wstring.hpp>
@@ -40,8 +40,7 @@
 
 namespace sequant {
 
-inline bool tensors_commute(const AbstractTensor &lhs,
-                            const AbstractTensor &rhs) {
+bool tensors_commute(const AbstractTensor &lhs, const AbstractTensor &rhs) {
   // tensors commute if their colors are different or either one of them
   // is a c-number
   return !(color(lhs) == color(rhs) && !is_cnumber(lhs) && !is_cnumber(rhs));
@@ -148,28 +147,28 @@ struct CanonicalTensorCompare {
   }
 };
 
-TensorNetworkV2::Vertex::Vertex(Origin origin, std::size_t terminal_idx,
+TensorNetworkV3::Vertex::Vertex(Origin origin, std::size_t terminal_idx,
                                 std::size_t index_slot, Symmetry terminal_symm)
     : origin(origin),
       terminal_idx(terminal_idx),
       index_slot(index_slot),
       terminal_symm(terminal_symm) {}
 
-TensorNetworkV2::Origin TensorNetworkV2::Vertex::getOrigin() const {
+TensorNetworkV3::Origin TensorNetworkV3::Vertex::getOrigin() const {
   return origin;
 }
 
-std::size_t TensorNetworkV2::Vertex::getTerminalIndex() const {
+std::size_t TensorNetworkV3::Vertex::getTerminalIndex() const {
   return terminal_idx;
 }
 
-std::size_t TensorNetworkV2::Vertex::getIndexSlot() const { return index_slot; }
+std::size_t TensorNetworkV3::Vertex::getIndexSlot() const { return index_slot; }
 
-Symmetry TensorNetworkV2::Vertex::getTerminalSymmetry() const {
+Symmetry TensorNetworkV3::Vertex::getTerminalSymmetry() const {
   return terminal_symm;
 }
 
-bool TensorNetworkV2::Vertex::operator<(const Vertex &rhs) const {
+bool TensorNetworkV3::Vertex::operator<(const Vertex &rhs) const {
   if (terminal_idx != rhs.terminal_idx) {
     return terminal_idx < rhs.terminal_idx;
   }
@@ -191,7 +190,7 @@ bool TensorNetworkV2::Vertex::operator<(const Vertex &rhs) const {
   }
 }
 
-bool TensorNetworkV2::Vertex::operator==(const Vertex &rhs) const {
+bool TensorNetworkV3::Vertex::operator==(const Vertex &rhs) const {
   // Slot position is only taken into account for non_symmetric tensors
   const std::size_t lhs_slot =
       (terminal_symm == Symmetry::nonsymm) * index_slot;
@@ -207,7 +206,7 @@ bool TensorNetworkV2::Vertex::operator==(const Vertex &rhs) const {
          origin == rhs.origin;
 }
 
-std::size_t TensorNetworkV2::Graph::vertex_to_index_idx(
+std::size_t TensorNetworkV3::Graph::vertex_to_index_idx(
     std::size_t vertex) const {
   assert(vertex_types.at(vertex) == VertexType::Index);
 
@@ -223,7 +222,7 @@ std::size_t TensorNetworkV2::Graph::vertex_to_index_idx(
   return index_idx - 1;
 }
 
-std::size_t TensorNetworkV2::Graph::vertex_to_tensor_idx(
+std::size_t TensorNetworkV3::Graph::vertex_to_tensor_idx(
     std::size_t vertex) const {
   assert(vertex_types.at(vertex) == VertexType::TensorCore);
 
@@ -326,9 +325,9 @@ void sort_via_indices(Container &container, const Comparator &cmp) {
   }
 }
 
-void TensorNetworkV2::canonicalize_graph(const NamedIndexSet &named_indices) {
+void TensorNetworkV3::canonicalize_graph(const NamedIndexSet &named_indices) {
   if (Logger::instance().canonicalize) {
-    std::wcout << "TensorNetworkV2::canonicalize_graph: input tensors\n";
+    std::wcout << "TensorNetworkV3::canonicalize_graph: input tensors\n";
     size_t cnt = 0;
     ranges::for_each(tensors_, [&](const auto &t) {
       std::wcout << "tensor " << cnt++ << ": " << to_latex(*t) << std::endl;
@@ -459,7 +458,7 @@ void TensorNetworkV2::canonicalize_graph(const NamedIndexSet &named_indices) {
 
   if (Logger::instance().canonicalize) {
     for (const auto &idxpair : idxrepl) {
-      std::wcout << "TensorNetworkV2::canonicalize_graph: replacing "
+      std::wcout << "TensorNetworkV3::canonicalize_graph: replacing "
                  << to_latex(idxpair.first) << " with "
                  << to_latex(idxpair.second) << std::endl;
     }
@@ -504,7 +503,7 @@ void TensorNetworkV2::canonicalize_graph(const NamedIndexSet &named_indices) {
       if (Logger::instance().canonicalize) {
         for (const auto &idxpair : idxrepl) {
           std::wcout
-              << "TensorNetworkV2::canonicalize_graph: permuting particles in "
+              << "TensorNetworkV3::canonicalize_graph: permuting particles in "
               << to_latex(tensor) << " by replacing " << to_latex(idxpair.first)
               << " with " << to_latex(idxpair.second) << std::endl;
         }
@@ -536,7 +535,7 @@ void TensorNetworkV2::canonicalize_graph(const NamedIndexSet &named_indices) {
   sort_via_indices<true>(tensors_, tensor_sorter);
 
   if (Logger::instance().canonicalize) {
-    std::wcout << "TensorNetworkV2::canonicalize_graph: tensors after "
+    std::wcout << "TensorNetworkV3::canonicalize_graph: tensors after "
                   "canonicalization\n";
     size_t cnt = 0;
     ranges::for_each(tensors_, [&](const auto &t) {
@@ -545,11 +544,11 @@ void TensorNetworkV2::canonicalize_graph(const NamedIndexSet &named_indices) {
   }
 }
 
-ExprPtr TensorNetworkV2::canonicalize(
+ExprPtr TensorNetworkV3::canonicalize(
     const container::vector<std::wstring> &cardinal_tensor_labels, bool fast,
     const NamedIndexSet *named_indices_ptr) {
   if (Logger::instance().canonicalize) {
-    std::wcout << "TensorNetworkV2::canonicalize(" << (fast ? "fast" : "slow")
+    std::wcout << "TensorNetworkV3::canonicalize(" << (fast ? "fast" : "slow")
                << "): input tensors\n";
     size_t cnt = 0;
     ranges::for_each(tensors_, [&](const auto &t) {
@@ -598,7 +597,7 @@ ExprPtr TensorNetworkV2::canonicalize(
   init_edges();
 
   if (Logger::instance().canonicalize) {
-    std::wcout << "TensorNetworkV2::canonicalize(" << (fast ? "fast" : "slow")
+    std::wcout << "TensorNetworkV3::canonicalize(" << (fast ? "fast" : "slow")
                << "): tensors after initial sort\n";
     size_t cnt = 0;
     ranges::for_each(tensors_, [&](const auto &t) {
@@ -653,7 +652,7 @@ ExprPtr TensorNetworkV2::canonicalize(
 
   if (Logger::instance().canonicalize) {
     for (const auto &idxpair : idxrepl) {
-      std::wcout << "TensorNetworkV2::canonicalize(" << (fast ? "fast" : "slow")
+      std::wcout << "TensorNetworkV3::canonicalize(" << (fast ? "fast" : "slow")
                  << "): replacing " << to_latex(idxpair.first) << " with "
                  << to_latex(idxpair.second) << std::endl;
     }
@@ -675,11 +674,11 @@ ExprPtr TensorNetworkV2::canonicalize(
   return (byproduct->as<Constant>().value() == 1) ? nullptr : byproduct;
 }
 
-TensorNetworkV2::SlotCanonicalizationMetadata
-TensorNetworkV2::canonicalize_slots(
+TensorNetworkV3::SlotCanonicalizationMetadata
+TensorNetworkV3::canonicalize_slots(
     const container::vector<std::wstring> &cardinal_tensor_labels,
     const NamedIndexSet *named_indices_ptr,
-    TensorNetworkV2::SlotCanonicalizationMetadata::named_index_compare_t
+    TensorNetworkV3::SlotCanonicalizationMetadata::named_index_compare_t
         named_index_compare) {
   if (!named_index_compare)
     named_index_compare = [](const auto &idxptr_slottype_1,
@@ -689,10 +688,10 @@ TensorNetworkV2::canonicalize_slots(
       return idxptr1->space() < idxptr2->space();
     };
 
-  TensorNetworkV2::SlotCanonicalizationMetadata metadata;
+  TensorNetworkV3::SlotCanonicalizationMetadata metadata;
 
   if (Logger::instance().canonicalize) {
-    std::wcout << "TensorNetworkV2::canonicalize_slots(): input tensors\n";
+    std::wcout << "TensorNetworkV3::canonicalize_slots(): input tensors\n";
     size_t cnt = 0;
     ranges::for_each(tensors_, [&](const auto &t) {
       std::wcout << "tensor " << cnt++ << ": " << to_latex(*t) << std::endl;
@@ -885,7 +884,7 @@ TensorNetworkV2::canonicalize_slots(
   return metadata;
 }
 
-TensorNetworkV2::Graph TensorNetworkV2::create_graph(
+TensorNetworkV3::Graph TensorNetworkV3::create_graph(
     const CreateGraphOptions &options) const {
   assert(have_edges_);
 
@@ -1256,7 +1255,7 @@ TensorNetworkV2::Graph TensorNetworkV2::create_graph(
   return graph;
 }
 
-void TensorNetworkV2::init_edges() {
+void TensorNetworkV3::init_edges() {
   have_edges_ = false;
   edges_.clear();
   ext_indices_.clear();
@@ -1264,7 +1263,7 @@ void TensorNetworkV2::init_edges() {
 
   auto idx_insert = [this](const Index &idx, Vertex vertex) {
     if (Logger::instance().tensor_network) {
-      std::wcout << "TensorNetworkV2::init_edges: idx=" << to_latex(idx)
+      std::wcout << "TensorNetworkV3::init_edges: idx=" << to_latex(idx)
                  << " attached to tensor " << vertex.getTerminalIndex() << " ("
                  << vertex.getOrigin() << ") at position "
                  << vertex.getIndexSlot()
@@ -1349,7 +1348,7 @@ void TensorNetworkV2::init_edges() {
       // for now no recursive proto indices
       if (proto_idx.has_proto_indices())
         throw std::runtime_error(
-            "TensorNetworkV2 does not support recursive protoindices");
+            "TensorNetworkV3 does not support recursive protoindices");
       proto_indices.emplace(proto_idx);
     }
   }
@@ -1393,27 +1392,27 @@ void TensorNetworkV2::init_edges() {
   have_edges_ = true;
 }
 
-container::svector<std::pair<long, long>> TensorNetworkV2::factorize() {
+container::svector<std::pair<long, long>> TensorNetworkV3::factorize() {
   abort();  // not yet implemented
 }
 
-size_t TensorNetworkV2::SlotCanonicalizationMetadata::hash_value() const {
+size_t TensorNetworkV3::SlotCanonicalizationMetadata::hash_value() const {
   return graph->get_hash();
 }
 
-ExprPtr TensorNetworkV2::canonicalize_individual_tensor_blocks(
+ExprPtr TensorNetworkV3::canonicalize_individual_tensor_blocks(
     const NamedIndexSet &named_indices) {
   return do_individual_canonicalization(
       TensorBlockCanonicalizer(named_indices));
 }
 
-ExprPtr TensorNetworkV2::canonicalize_individual_tensors(
+ExprPtr TensorNetworkV3::canonicalize_individual_tensors(
     const NamedIndexSet &named_indices) {
   return do_individual_canonicalization(
       DefaultTensorCanonicalizer(named_indices));
 }
 
-ExprPtr TensorNetworkV2::do_individual_canonicalization(
+ExprPtr TensorNetworkV3::do_individual_canonicalization(
     const TensorCanonicalizer &canonicalizer) {
   ExprPtr byproduct = ex<Constant>(1);
 

--- a/SeQuant/core/tensor_network_v3.cpp
+++ b/SeQuant/core/tensor_network_v3.cpp
@@ -278,8 +278,8 @@ ExprPtr TensorNetworkV3::canonicalize_graph(
   // Sort edges so that their order corresponds to the order of indices in the
   // canonical graph
   // Use this ordering to relabel anonymous indices
-  const auto index_sorter = [&index_idx_to_vertex, &canonize_perm](
-                                std::size_t lhs_idx, std::size_t rhs_idx) {
+  const auto index_less_than = [&index_idx_to_vertex, &canonize_perm](
+                                   std::size_t lhs_idx, std::size_t rhs_idx) {
     assert(lhs_idx < index_idx_to_vertex.size());
     const std::size_t lhs_vertex = index_idx_to_vertex[lhs_idx];
     assert(rhs_idx < index_idx_to_vertex.size());
@@ -288,7 +288,7 @@ ExprPtr TensorNetworkV3::canonicalize_graph(
     return canonize_perm[lhs_vertex] < canonize_perm[rhs_vertex];
   };
 
-  sort_via_ordinals<OrderType::StrictWeak>(edges_, index_sorter);
+  sort_via_ordinals<OrderType::StrictWeak>(edges_, index_less_than);
 
   for (const Edge &current : edges_) {
     const Index &idx = current.idx();

--- a/SeQuant/core/tensor_network_v3.cpp
+++ b/SeQuant/core/tensor_network_v3.cpp
@@ -20,17 +20,13 @@
 #include <SeQuant/core/tensor_network_v3.hpp>
 #include <SeQuant/core/utility/swap.hpp>
 #include <SeQuant/core/utility/tuple.hpp>
-#include <SeQuant/core/wstring.hpp>
 
 #include <algorithm>
 #include <iostream>
 #include <iterator>
 #include <limits>
-#include <numeric>
-#include <ranges>
 #include <sstream>
 #include <string>
-#include <type_traits>
 
 #include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/algorithm/none_of.hpp>
@@ -132,7 +128,10 @@ std::size_t TensorNetworkV3::Graph::vertex_to_tensor_idx(
   return tensor_idx - 1;
 }
 
-void TensorNetworkV3::canonicalize_graph(const NamedIndexSet &named_indices) {
+ExprPtr TensorNetworkV3::canonicalize_graph(
+    const NamedIndexSet &named_indices) {
+  int parity = 1;
+
   if (Logger::instance().canonicalize) {
     std::wcout << "TensorNetworkV3::canonicalize_graph: input tensors\n";
     size_t cnt = 0;
@@ -160,7 +159,6 @@ void TensorNetworkV3::canonicalize_graph(const NamedIndexSet &named_indices) {
                       Logger::instance().canonicalize_dot,
        .make_texlabels = Logger::instance().canonicalize_input_graph ||
                          Logger::instance().canonicalize_dot});
-  // graph.bliss_graph->write_dot(std::wcout, graph.vertex_labels);
 
   if (Logger::instance().canonicalize_input_graph) {
     std::wcout << "Input graph for canonicalization:\n";
@@ -190,36 +188,68 @@ void TensorNetworkV3::canonicalize_graph(const NamedIndexSet &named_indices) {
   // maps tensor ordinal -> input vertex ordinal
   std::vector<std::size_t> tensor_idx_to_vertex;
   tensor_idx_to_vertex.reserve(tensors_.size());
-  std::size_t tensor_idx = 0;
-  // for nonsymmetric tensors only: maps tensor ordinal -> canonical order of
-  // its columns'/particles' vertex ordinals
-  container::map<std::size_t, container::svector<std::size_t, 3>>
-      tensor_idx_to_particle_order;
+  std::size_t tensor_count = 0;
+
+  // for symmetric tensors only: maps tensor ordinal -> canonical order of
+  // its bra and ket slots
+  container::map<
+      std::size_t,
+      std::array<std::pair</* permutation parity */ std::optional<int>,
+                           container::svector<std::size_t, 4>>,
+                 /* bra + ket = */ 2>>
+      canonical_slot_order;
+  // for nonsymmetric particle-symmetric tensors only: maps tensor ordinal ->
+  // canonical order of its braket slots
+  container::map<std::size_t, container::svector<std::size_t, 4>>
+      canonical_braket_slot_order;
+
   std::vector<std::size_t> index_idx_to_vertex;
   index_idx_to_vertex.reserve(edges_.size() + pure_proto_indices_.size());
 
   for (std::size_t vertex = 0; vertex < graph.vertex_types.size(); ++vertex) {
-    switch (graph.vertex_types[vertex]) {
+    const auto vertex_type = graph.vertex_types[vertex];
+    switch (vertex_type) {
       case VertexType::Index:
         index_idx_to_vertex.emplace_back(index_idx_to_vertex.size()) = vertex;
         break;
-      case VertexType::TensorBraKet: {
-        assert(tensor_idx > 0);
-        const std::size_t base_tensor_idx = tensor_idx - 1;
-        assert(symmetry(*tensors_.at(base_tensor_idx)) == Symmetry::nonsymm);
-        tensor_idx_to_particle_order[base_tensor_idx].push_back(
-            canonize_perm[vertex]);
+
+      case VertexType::TensorBra:
+      case VertexType::TensorKet: {
+        assert(tensor_count > 0);
+        const auto bra = vertex_type == VertexType::TensorBra;
+        const std::size_t tensor_ord = tensor_count - 1;
+        const AbstractTensor &tensor = *tensors_.at(tensor_ord);
+        const auto symm = symmetry(tensor);
+        if (symm == Symmetry::symm || symm == Symmetry::antisymm) {
+          canonical_slot_order[tensor_ord][bra ? 0 : 1].second.emplace_back(
+              canonize_perm[vertex]);
+        }
         break;
       }
-      case VertexType::TensorCore:
-        assert(tensor_idx_to_vertex.size() == tensor_idx);
-        tensor_idx_to_vertex.emplace_back(tensor_idx_to_vertex.size()) = vertex;
-        tensor_idx++;
+
+      case VertexType::TensorBraKet: {
+        assert(tensor_count > 0);
+        const std::size_t tensor_ord = tensor_count - 1;
+        const AbstractTensor &tensor = *tensors_.at(tensor_ord);
+        const auto psymm = particle_symmetry(tensor);
+        if (psymm == ParticleSymmetry::symm) {
+          canonical_braket_slot_order[tensor_ord].emplace_back(
+              canonize_perm[vertex]);
+        }
         break;
-      case VertexType::TensorBra:
-      case VertexType::TensorKet:
+      }
+
+      case VertexType::TensorCore:
+        assert(tensor_idx_to_vertex.size() == tensor_count);
+        tensor_idx_to_vertex.emplace_back(tensor_idx_to_vertex.size()) = vertex;
+        ++tensor_count;
+        break;
+
       case VertexType::TensorAux:
-      case VertexType::SPBundle:
+      case VertexType::TensorBraBundle:
+      case VertexType::TensorKetBundle:
+      case VertexType::TensorAuxBundle:
+      case VertexType::IndexBundle:
         break;
     }
   }
@@ -227,11 +257,17 @@ void TensorNetworkV3::canonicalize_graph(const NamedIndexSet &named_indices) {
   assert(index_idx_to_vertex.size() ==
          edges_.size() + pure_proto_indices_.size());
   assert(tensor_idx_to_vertex.size() == tensors_.size());
-  assert(tensor_idx_to_particle_order.size() <= tensors_.size());
+  assert(canonical_slot_order.size() <= tensors_.size());
 
-  // order_to_indices(index_order);
-  for (auto &current : tensor_idx_to_particle_order) {
-    order_to_indices(current.second);
+  // canonical slot arrays right now contain vertex ordinals, convert to
+  // permutations
+  for (auto &[ord, braparslots_ketparslots] : canonical_slot_order) {
+    auto &[braparslots, ketparslots] = braparslots_ketparslots;
+    braparslots.first = sort_then_replace_by_ordinals(braparslots.second);
+    ketparslots.first = sort_then_replace_by_ordinals(ketparslots.second);
+  }
+  for (auto &[ord, slots] : canonical_braket_slot_order) {
+    sort_then_replace_by_ordinals(slots);
   }
 
   container::map<Index, Index> idxrepl;
@@ -277,45 +313,75 @@ void TensorNetworkV3::canonicalize_graph(const NamedIndexSet &named_indices) {
 
   apply_index_replacements(tensors_, idxrepl, true);
 
-  // Perform particle-1,2-swaps as indicated by the graph canonization
+  // Permute {bra, ket} or braket slots of particle-symmetric tensors as
+  // indicated by graph canonization
   for (std::size_t i = 0; i < tensors_.size(); ++i) {
     AbstractTensor &tensor = *tensors_[i];
-    const std::size_t num_particles =
-        std::min(bra_rank(tensor), ket_rank(tensor));
 
-    auto it = tensor_idx_to_particle_order.find(i);
-    if (it == tensor_idx_to_particle_order.end()) {
-      assert(num_particles == 0 || symmetry(*tensors_[i]) != Symmetry::nonsymm);
-      continue;
-    }
+    if (particle_symmetry(tensor) != ParticleSymmetry::symm) continue;
+    const auto asymm = symmetry(tensor) == Symmetry::nonsymm;
 
-    const auto &particle_order = it->second;
-    auto bra_indices = tensor._bra();
-    auto ket_indices = tensor._ket();
+    if (asymm) {  // asymmetric tensor? order braket slots only
 
-    assert(num_particles == particle_order.size());
+      auto it = canonical_braket_slot_order.find(i);
+      if (it == canonical_braket_slot_order.end()) continue;
 
-    // Swap indices column-wise
-    idxrepl.clear();
-    for (std::size_t col = 0; col < num_particles; ++col) {
-      if (particle_order[col] == col) {
-        continue;
-      }
+      auto &sorted_ordinals = it->second;
 
-      idxrepl_emplace(bra_indices[col], bra_indices[particle_order[col]]);
-      idxrepl_emplace(ket_indices[col], ket_indices[particle_order[col]]);
-    }
-
-    if (!idxrepl.empty()) {
       if (Logger::instance().canonicalize) {
-        for (const auto &idxpair : idxrepl) {
-          std::wcout
-              << "TensorNetworkV3::canonicalize_graph: permuting particles in "
-              << to_latex(tensor) << " by replacing " << to_latex(idxpair.first)
-              << " with " << to_latex(idxpair.second) << std::endl;
+        if (!ranges::is_sorted(sorted_ordinals)) {
+          for (const auto &idxpair : idxrepl) {
+            std::wcout << "TensorNetworkV3::canonicalize_graph: permuting "
+                          "braket slots in "
+                       << to_latex(tensor) << ":\n";
+            for (auto i = 0; i != sorted_ordinals.size(); ++i) {
+              std::wcout << "  {" << to_latex(tensor._bra()[sorted_ordinals[i]])
+                         << "," << to_latex(tensor._ket()[sorted_ordinals[i]])
+                         << "} -> {" << to_latex(tensor._bra()[i]) << ","
+                         << to_latex(tensor._ket()[i]) << "}\n";
+            }
+            std::wcout << std::endl;
+          }
         }
       }
-      apply_index_replacements(tensor, idxrepl, false);
+
+      tensor._permute_braket(
+          std::span(sorted_ordinals.data(), sorted_ordinals.size()));
+    } else {  // symmetric/antisymmetric bra
+      auto it = canonical_slot_order.find(i);
+      if (it == canonical_slot_order.end()) continue;
+
+      auto &[braparslots, ketparslots] = it->second;
+      auto &[braparity, braslots] = braparslots;
+      auto &[ketparity, ketslots] = ketparslots;
+
+      if (Logger::instance().canonicalize) {
+        for (auto bk : {Origin::Bra, Origin::Ket}) {
+          const auto bra = bk == Origin::Bra;
+          auto &sorted_ordinals = bra ? braslots : ketslots;
+          if (!ranges::is_sorted(sorted_ordinals)) {
+            for (const auto &idxpair : idxrepl) {
+              std::wcout << "TensorNetworkV3::canonicalize_graph: permuting "
+                         << (bra ? "bra" : "ket") << " slots in "
+                         << to_latex(tensor) << ":\n";
+              auto indices = bra ? tensor._bra() : tensor._ket();
+              for (auto i = 0; i != indices.size(); ++i) {
+                std::wcout << "  " << to_latex(indices[sorted_ordinals[i]])
+                           << " -> " << to_latex(indices[i]) << "\n";
+              }
+              std::wcout << std::endl;
+            }
+          }
+        }
+      }
+
+      tensor._permute_bra(std::span(braslots.data(), braslots.size()));
+      tensor._permute_ket(std::span(ketslots.data(), ketslots.size()));
+
+      // parity of slot permutations only matters for antisymmetric tensors
+      if (symmetry(tensor) == Symmetry::antisymm) {
+        parity *= braparity.value_or(1) * ketparity.value_or(1);
+      }
     }
   }
 
@@ -340,6 +406,7 @@ void TensorNetworkV3::canonicalize_graph(const NamedIndexSet &named_indices) {
   };
 
   sort_via_indices<true>(tensors_, tensor_sorter);
+  // ouch, tensor_input_ordinals_ are not updated!!!
 
   if (Logger::instance().canonicalize) {
     std::wcout << "TensorNetworkV3::canonicalize_graph: tensors after "
@@ -349,6 +416,11 @@ void TensorNetworkV3::canonicalize_graph(const NamedIndexSet &named_indices) {
       std::wcout << "tensor " << cnt++ << ": " << to_latex(*t) << std::endl;
     });
   }
+
+  if (parity < 0)
+    return ex<Constant>(-1);
+  else
+    return {};
 }
 
 ExprPtr TensorNetworkV3::canonicalize(
@@ -380,16 +452,17 @@ ExprPtr TensorNetworkV3::canonicalize(
                      [](auto &&i) { std::wcout << i.full_label() << L" "; });
   }
 
+  ExprPtr byproduct;
   if (!fast) {
     // The graph-based canonization is required in all cases in which there are
     // indistinguishable tensors present in the expression. Their order and
     // indexing can only be determined via this rigorous canonization.
-    canonicalize_graph(named_indices);
+    byproduct = canonicalize_graph(named_indices);
   }
 
   // Ensure each individual tensor is written in the way that its tensor
   // block (== order of index spaces) is canonical
-  ExprPtr byproduct = canonicalize_individual_tensor_blocks(named_indices);
+  byproduct *= canonicalize_individual_tensor_blocks(named_indices);
 
   CanonicalTensorCompare<decltype(cardinal_tensor_labels)> tensor_sorter(
       cardinal_tensor_labels, true);
@@ -612,10 +685,10 @@ TensorNetworkV3::canonicalize_slots(
           }
         } else {  // if
           assert(edge_it->vertex_count() == 2);
-          slot_type = IndexSlotType::SPBundle;
+          slot_type = IndexSlotType::IndexBundle;
         }
       } else
-        slot_type = IndexSlotType::SPBundle;
+        slot_type = IndexSlotType::IndexBundle;
       const auto idxptr_slottype = std::make_pair(&idx, slot_type);
       auto it = idx2cord.find(idxptr_slottype);
 
@@ -702,18 +775,18 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
 
   VertexPainter colorizer(named_indices, options.distinct_named_indices);
 
-  // core, bra, ket, auxiliary and optionally (for non-symmetric tensors) a
-  // particle vertex
   constexpr std::size_t num_tensor_components = 5;
 
   // results
   Graph graph;
   std::size_t nvertex = 0;
+  // predicting exact vertex count is too much work, make a rough estimate only
   // We know that at the very least all indices and all tensors will yield
-  // vertex representations
-  std::size_t vertex_count_estimate = edges_.size() +
-                                      pure_proto_indices_.size() +
-                                      num_tensor_components * tensors_.size();
+  // vertex representations; for tensors estimate the average number of verices
+  // at 5
+
+  std::size_t vertex_count_estimate =
+      edges_.size() + pure_proto_indices_.size() + 5 * tensors_.size();
   if (options.make_labels) graph.vertex_labels.reserve(vertex_count_estimate);
   if (options.make_texlabels)
     graph.vertex_texlabels.reserve(vertex_count_estimate);
@@ -732,6 +805,33 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
   container::vector<std::pair<std::size_t, std::size_t>> edges;
   edges.reserve(edges_.size() + tensors_.size());
 
+  // computes ordinal of the vertex representing slot in origin at index_ordinal
+  // of tensor to obtain ordinal of the slot add this to the ordinal of tensor
+  // core vertex
+  auto index_slot_offset = [](const AbstractTensor &tensor, Origin origin,
+                              std::size_t index_ordinal) {
+    const Symmetry tensor_sym = symmetry(tensor);
+    const bool is_symm = tensor_sym != Symmetry::nonsymm;
+    std::size_t offset = 0;
+    // number of vertices before first index slot vertex varies with symmetry
+    if (is_symm) {
+      offset += 3;
+    } else {
+      auto nbraket = std::max(bra_rank(tensor), ket_rank(tensor));
+      offset += nbraket;  // braket vertices first
+    }
+
+    // now count slot vertices
+    if (origin == Origin::Bra)
+      offset += index_ordinal;
+    else if (origin == Origin::Ket)
+      offset += bra_rank(tensor) + index_ordinal;
+    else
+      offset += bra_rank(tensor) + ket_rank(tensor) + index_ordinal;
+
+    return offset + 1;  // +1 to account for tensor core vertex
+  };
+
   // Add vertices for tensors
   for (std::size_t tensor_idx = 0; tensor_idx < tensors_.size(); ++tensor_idx) {
     assert(tensor_idx < tensor_vertices.size());
@@ -741,121 +841,182 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
 
     // Tensor core
     const auto tlabel = label(tensor);
-    ++nvertex;
     if (options.make_labels) graph.vertex_labels.emplace_back(tlabel);
     if (options.make_texlabels)
       graph.vertex_texlabels.emplace_back(L"$" + utf_to_latex(tlabel) + L"$");
     graph.vertex_types.emplace_back(VertexType::TensorCore);
-    graph.vertex_colors.push_back(colorizer(tensor));
+    const auto tensor_color =
+        colorizer.apply_shade(tensor);  // subsequent vertices will be shaded by
+                                        // the color of this tensor
+    graph.vertex_colors.push_back(tensor_color);
 
-    const std::size_t tensor_vertex = nvertex - 1;
+    const std::size_t tensor_vertex = nvertex;
     tensor_vertices[tensor_idx] = tensor_vertex;
+    ++nvertex;
 
-    // Create vertices to group indices
     const Symmetry tensor_sym = symmetry(tensor);
-    if (tensor_sym == Symmetry::nonsymm) {
-      // Create separate vertices for every index
-      // Additionally, we need particle vertices to group indices that belong to
-      // the same particle (are in the same "column" in the usual tensor
-      // notation)
-      const std::size_t num_particle_vertices =
-          std::min(bra_rank(tensor), ket_rank(tensor));
-      const bool is_part_symm =
-          particle_symmetry(tensor) == ParticleSymmetry::symm;
-      // TODO: How to handle BraKetSymmetry::conjugate?
-      const bool is_braket_symm =
-          braket_symmetry(tensor) == BraKetSymmetry::symm;
+    const bool is_symm = tensor_sym != Symmetry::nonsymm;
+    // max (number of bra slots, number of ket slots) slots, i.e. the number of
+    // 1-index and 2-index columns
+    const std::size_t num_particles =
+        std::max(bra_rank(tensor), ket_rank(tensor));
+    // min (number of bra slots, number of ket slots) slots, i.e. the number of
+    // 2-index columns
+    const std::size_t num_paired_particles =
+        std::max(bra_rank(tensor), ket_rank(tensor));
 
-      for (std::size_t i = 0; i < num_particle_vertices; ++i) {
-        ++nvertex;
-        if (options.make_labels)
-          graph.vertex_labels.emplace_back(L"p_" + std::to_wstring(i + 1));
+    // - there is 1 braket vertex per particle for asymmetric tensors,
+    // and only 1 total for antisymmetric/symmetric tensors
+    const std::size_t num_braket_vertices = !is_symm ? num_particles : 1;
+    const bool is_part_symm =
+        particle_symmetry(tensor) == ParticleSymmetry::symm;
+    const bool is_braket_symm = braket_symmetry(tensor) == BraKetSymmetry::symm;
+
+    // make braket slots first
+    for (std::size_t i = 0; i < num_braket_vertices; ++i) {
+      if (options.make_labels) {
+        std::wstring label =
+            !is_symm ? (L"p_" + std::to_wstring(i + 1))
+                     : (std::wstring(L"bk") +
+                        ((tensor_sym == Symmetry::antisymm) ? L"a" : L"s"));
+        graph.vertex_labels.emplace_back(label);
+      }
+      if (options.make_texlabels)
+        graph.vertex_texlabels.emplace_back(std::nullopt);
+      graph.vertex_types.push_back(VertexType::TensorBraKet);
+      // If tensor is particle-symmetric use same color for all braket vertices,
+      // else use different colors
+      graph.vertex_colors.push_back(
+          colorizer(ParticleGroup{is_part_symm ? 0 : i}));
+      edges.push_back(std::make_pair(tensor_vertex, nvertex));
+      ++nvertex;
+    }
+
+    // create single slot of symmetric/anstisymmetric bra/ket
+    // TNV1/TNV2 created such vertices also but did not create index slots in
+    // such case
+    if (is_symm) {
+      for (auto s : {Origin::Bra, Origin::Ket}) {
+        const bool bra = s == Origin::Bra;
+        const auto size = bra ? bra_rank(tensor) : ket_rank(tensor);
+        if (options.make_labels) {
+          std::wstring label =
+              std::wstring(bra ? L"bra" : L"ket") + std::to_wstring(size) +
+              ((tensor_sym == Symmetry::antisymm) ? L"a" : L"s");
+          graph.vertex_labels.emplace_back(label);
+        }
         if (options.make_texlabels)
           graph.vertex_texlabels.emplace_back(std::nullopt);
-        graph.vertex_types.push_back(VertexType::TensorBraKet);
-        // Particles are indistinguishable -> always use same ID
-        graph.vertex_colors.push_back(colorizer(ParticleGroup{0}));
-        edges.push_back(std::make_pair(tensor_vertex, nvertex - 1));
-      }
+        graph.vertex_types.push_back(bra ? VertexType::TensorBraBundle
+                                         : VertexType::TensorKetBundle);
+        graph.vertex_colors.push_back(bra ? colorizer(BraGroup{size})
+                                          : colorizer(KetGroup{size}));
 
-      for (std::size_t i = 0; i < bra_rank(tensor); ++i) {
-        const bool is_unpaired_idx = i >= num_particle_vertices;
-        const bool color_idx = is_unpaired_idx || !is_part_symm;
-
+        const auto braket_vertex = tensor_vertex + 1;
+        edges.push_back(std::make_pair(braket_vertex, nvertex));
         ++nvertex;
+      }
+    }
+
+    // - Create vertex for every index slot, regardless of symmetry (V1 and V2
+    // only created slots for antisymmetric/symmetric tensors)
+    {
+      for (std::size_t i = 0; i < bra_rank(tensor); ++i) {
+        // N.B. currently AbstractTensor only supports "left"-aligned bra/ket
+        // slot sets (i.e. bra[0] is paired with ket[0], etc.) no gaps between
+        // occupied slots) we need to assign different colors to braket slots of
+        // different types so must track types of braket slots:
+        // - if tensor is not particle symmetric braket slots will already be
+        // colored uniquely (by particle index)
+        // - if tensor is symmetric/antisymmetric braket slots have same color
+        // - if tensor is particle symmetric then assign different colors to
+        // braket slots of different types (paired vs unpaired)
+        const auto is_paired_particle = i < num_paired_particles;
+        std::size_t color_id = i;
+        if (is_symm)
+          color_id = 0;
+        else if (is_part_symm) {
+          if (is_paired_particle)
+            color_id = 0;
+          else
+            color_id = 1;
+        }
+
         if (options.make_labels)
           graph.vertex_labels.emplace_back(L"bra_" + std::to_wstring(i + 1));
         if (options.make_texlabels)
           graph.vertex_texlabels.emplace_back(std::nullopt);
         graph.vertex_types.push_back(VertexType::TensorBra);
-        graph.vertex_colors.push_back(colorizer(BraGroup{color_idx ? i : 0}));
+        // use different colors for each index slot if not particle symmetric
+        graph.vertex_colors.push_back(colorizer(BraGroup{color_id}));
 
-        const std::size_t connect_vertex =
-            tensor_vertex + (is_unpaired_idx ? 0 : (i + 1));
-        edges.push_back(std::make_pair(connect_vertex, nvertex - 1));
+        const std::size_t braket_vertex =
+            tensor_vertex + (is_symm ? 2 : (i + 1));
+        edges.push_back(std::make_pair(braket_vertex, nvertex));
+        // make sure logic in index_slot_offset is correct
+        assert(nvertex ==
+               tensor_vertex + index_slot_offset(tensor, Origin::Bra, i));
+        ++nvertex;
       }
 
       for (std::size_t i = 0; i < ket_rank(tensor); ++i) {
-        const bool is_unpaired_idx = i >= num_particle_vertices;
-        const bool color_idx = is_unpaired_idx || !is_part_symm;
+        // N.B. currently AbstractTensor only supports "left"-aligned bra/ket
+        // slot sets (i.e. bra[0] is paired with ket[0], etc.) no gaps between
+        // occupied slots) we need to assign different colors to braket slots of
+        // different types so must track types of braket slots:
+        // - if tensor is not particle symmetric braket slots will already be
+        // colored uniquely (by particle index)
+        // - if tensor is symmetric/antisymmetric braket slots have same color
+        // - if tensor is particle symmetric then assign different colors to
+        // braket slots of different types (paired vs unpaired)
+        const auto is_paired_particle = i < num_paired_particles;
+        std::size_t color_id = i;
+        if (is_symm)
+          color_id = 0;
+        else if (is_part_symm) {
+          if (is_paired_particle)
+            color_id = 0;
+          else
+            color_id = 1;
+        }
 
-        ++nvertex;
         if (options.make_labels)
           graph.vertex_labels.emplace_back(L"ket_" + std::to_wstring(i + 1));
         if (options.make_texlabels)
           graph.vertex_texlabels.emplace_back(std::nullopt);
         graph.vertex_types.push_back(VertexType::TensorKet);
+        // - use same color for kets if symmetric wrt bra<->ket
+        // - use different colors for each index slot if not particle symmetric
         if (is_braket_symm) {
-          // Use BraGroup for kets as well as they are supposed to be
-          // indistinguishable
-          graph.vertex_colors.push_back(colorizer(BraGroup{color_idx ? i : 0}));
+          graph.vertex_colors.push_back(colorizer(BraGroup{color_id}));
         } else {
-          graph.vertex_colors.push_back(colorizer(KetGroup{color_idx ? i : 0}));
+          graph.vertex_colors.push_back(colorizer(KetGroup{color_id}));
         }
 
-        const std::size_t connect_vertex =
-            tensor_vertex + (is_unpaired_idx ? 0 : (i + 1));
-        edges.push_back(std::make_pair(connect_vertex, nvertex - 1));
+        const std::size_t braket_vertex =
+            tensor_vertex + (is_symm ? 3 : (i + 1));
+        edges.push_back(std::make_pair(braket_vertex, nvertex));
+        // make sure logic in index_slot_offset is correct
+        assert(nvertex ==
+               tensor_vertex + index_slot_offset(tensor, Origin::Ket, i));
+        ++nvertex;
       }
-    } else {
-      // Shared set of bra/ket vertices for all indices
-      std::wstring suffix = tensor_sym == Symmetry::symm ? L"_s" : L"_a";
-
-      ++nvertex;
-      if (options.make_labels) graph.vertex_labels.push_back(L"bra" + suffix);
-      if (options.make_texlabels)
-        graph.vertex_texlabels.emplace_back(std::nullopt);
-      graph.vertex_types.push_back(VertexType::TensorBra);
-      graph.vertex_colors.push_back(colorizer(BraGroup{0}));
-      edges.push_back(std::make_pair(tensor_vertex, nvertex - 1));
-
-      ++nvertex;
-      if (options.make_labels) graph.vertex_labels.push_back(L"ket" + suffix);
-      if (options.make_texlabels)
-        graph.vertex_texlabels.emplace_back(std::nullopt);
-      graph.vertex_types.push_back(VertexType::TensorKet);
-      // TODO: figure out how to handle BraKetSymmetry::conjugate
-      if (braket_symmetry(tensor) == BraKetSymmetry::symm) {
-        // Use BraGroup for kets as well as they should be indistinguishable
-        graph.vertex_colors.push_back(colorizer(BraGroup{0}));
-      } else {
-        graph.vertex_colors.push_back(colorizer(KetGroup{0}));
-      }
-      edges.push_back(std::make_pair(tensor_vertex, nvertex - 1));
     }
 
     // TODO: handle aux indices permutation symmetries once they are supported
     // for now, auxiliary indices are considered to always be asymmetric
     for (std::size_t i = 0; i < aux_rank(tensor); ++i) {
-      ++nvertex;
       if (options.make_labels)
         graph.vertex_labels.emplace_back(L"aux_" + std::to_wstring(i + 1));
       if (options.make_texlabels)
         graph.vertex_texlabels.emplace_back(std::nullopt);
       graph.vertex_types.push_back(VertexType::TensorAux);
       graph.vertex_colors.push_back(colorizer(AuxGroup{i}));
-      edges.push_back(std::make_pair(tensor_vertex, nvertex - 1));
+      edges.push_back(std::make_pair(tensor_vertex, nvertex));
+      ++nvertex;
     }
+
+    colorizer.reset_shade();
   }
 
   // Now add all indices (edges_ + pure_proto_indices_) to the graph
@@ -867,7 +1028,6 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
     const Edge &current_edge = edges_[i];
 
     const Index &index = current_edge.idx();
-    ++nvertex;
     if (options.make_labels)
       graph.vertex_labels.push_back(std::wstring(index.full_label()));
     using namespace std::string_literals;
@@ -876,7 +1036,8 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
     graph.vertex_types.push_back(VertexType::Index);
     graph.vertex_colors.push_back(colorizer(index));
 
-    const std::size_t index_vertex = nvertex - 1;
+    const std::size_t index_vertex = nvertex;
+    ++nvertex;
 
     assert(index_vertices.at(i) == uninitialized_vertex);
     index_vertices[i] = index_vertex;
@@ -894,34 +1055,34 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
         proto_vertex = it->second;
       } else {
         // Create a new vertex for this bundle of proto indices
-        ++nvertex;
         if (options.make_labels) {
           using namespace std::literals;
-          std::wstring spbundle_label =
+          std::wstring index_bundle_label =
               L"<" +
               (ranges::views::transform(
                    index.proto_indices(),
                    [](const Index &idx) { return idx.full_label(); }) |
                ranges::views::join(L","sv) | ranges::to<std::wstring>()) +
               L">";
-          graph.vertex_labels.push_back(std::move(spbundle_label));
+          graph.vertex_labels.push_back(std::move(index_bundle_label));
         }
         if (options.make_texlabels) {
           using namespace std::literals;
-          std::wstring spbundle_texlabel =
+          std::wstring index_bundle_texlabel =
               L"$\\langle" +
               (ranges::views::transform(
                    index.proto_indices(),
                    [](const Index &idx) { return idx.to_latex(); }) |
                ranges::views::join(L","sv) | ranges::to<std::wstring>()) +
               L"\\rangle$";
-          graph.vertex_texlabels.push_back(std::move(spbundle_texlabel));
+          graph.vertex_texlabels.push_back(std::move(index_bundle_texlabel));
         }
-        graph.vertex_types.push_back(VertexType::SPBundle);
+        graph.vertex_types.push_back(VertexType::IndexBundle);
         graph.vertex_colors.push_back(colorizer(index.proto_indices()));
 
-        proto_vertex = nvertex - 1;
+        proto_vertex = nvertex;
         proto_bundles.emplace_back(index.proto_indices(), proto_vertex);
+        ++nvertex;
       }
 
       edges.push_back(std::make_pair(index_vertex, proto_vertex));
@@ -943,32 +1104,8 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
       const bool tensor_is_nonsymm =
           vertex.getTerminalSymmetry() == Symmetry::nonsymm;
       const AbstractTensor &tensor = *tensors_[vertex.getTerminalIndex()];
-      std::size_t offset;
-      if (tensor_is_nonsymm) {
-        // We have to find the correct vertex to connect this index to (for
-        // non-symmetric tensors each index has its dedicated "group" vertex)
-
-        // Move off the tensor core's vertex
-        offset = 1;
-        // Move past the explicit particle vertices
-        offset += std::min(bra_rank(tensor), ket_rank(tensor));
-
-        if (vertex.getOrigin() > Origin::Bra) {
-          offset += bra_rank(tensor);
-        }
-
-        offset += vertex.getIndexSlot();
-      } else {
-        static_assert(static_cast<int>(Origin::Bra) == 1);
-        static_assert(static_cast<int>(Origin::Ket) == 2);
-        static_assert(static_cast<int>(Origin::Aux) == 3);
-        offset = static_cast<std::size_t>(vertex.getOrigin());
-      }
-
-      if (vertex.getOrigin() > Origin::Ket) {
-        offset += ket_rank(tensor);
-      }
-
+      const std::size_t offset =
+          index_slot_offset(tensor, vertex.getOrigin(), vertex.getIndexSlot());
       const std::size_t tensor_component_vertex = tensor_vertex + offset;
 
       assert(tensor_component_vertex < nvertex);

--- a/SeQuant/core/tensor_network_v3.cpp
+++ b/SeQuant/core/tensor_network_v3.cpp
@@ -203,7 +203,7 @@ void TensorNetworkV3::canonicalize_graph(const NamedIndexSet &named_indices) {
       case VertexType::Index:
         index_idx_to_vertex.emplace_back(index_idx_to_vertex.size()) = vertex;
         break;
-      case VertexType::Particle: {
+      case VertexType::TensorBraKet: {
         assert(tensor_idx > 0);
         const std::size_t base_tensor_idx = tensor_idx - 1;
         assert(symmetry(*tensors_.at(base_tensor_idx)) == Symmetry::nonsymm);
@@ -772,7 +772,7 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
           graph.vertex_labels.emplace_back(L"p_" + std::to_wstring(i + 1));
         if (options.make_texlabels)
           graph.vertex_texlabels.emplace_back(std::nullopt);
-        graph.vertex_types.push_back(VertexType::Particle);
+        graph.vertex_types.push_back(VertexType::TensorBraKet);
         // Particles are indistinguishable -> always use same ID
         graph.vertex_colors.push_back(colorizer(ParticleGroup{0}));
         edges.push_back(std::make_pair(tensor_vertex, nvertex - 1));

--- a/SeQuant/core/tensor_network_v3.hpp
+++ b/SeQuant/core/tensor_network_v3.hpp
@@ -351,7 +351,7 @@ class TensorNetworkV3 {
     /// if false, will use same color for all
     /// named indices that have same Index::color(), else will use distinct
     /// color for each
-    bool distinct_named_indices = true;
+    bool distinct_named_indices = false;
 
     /// if false, will not generate the labels
     bool make_labels = true;
@@ -404,7 +404,7 @@ class TensorNetworkV3 {
   // clang-format on
   Graph create_graph(const CreateGraphOptions &options = {
                          .named_indices = nullptr,
-                         .distinct_named_indices = true,
+                         .distinct_named_indices = false,
                          .make_labels = true,
                          .make_texlabels = true,
                          .make_idx_to_vertex = false}) const;

--- a/SeQuant/core/tensor_network_v3.hpp
+++ b/SeQuant/core/tensor_network_v3.hpp
@@ -155,7 +155,7 @@ class TensorNetworkV3 {
       return *(vertices.begin() + i);
     }
 
-    /// @return the number of attached terminals (0, 1, or 2)
+    /// @return the number of attached terminals (0 or more)
     std::size_t vertex_count() const { return vertices.size(); }
 
     const Index &idx() const {

--- a/SeQuant/core/tensor_network_v3.hpp
+++ b/SeQuant/core/tensor_network_v3.hpp
@@ -1,0 +1,467 @@
+//
+// Created by Eduard Valeyev on 2025-24-07.
+//
+
+#ifndef SEQUANT_TENSOR_NETWORK_V3_H
+#define SEQUANT_TENSOR_NETWORK_V3_H
+
+#include <SeQuant/core/abstract_tensor.hpp>
+#include <SeQuant/core/container.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index.hpp>
+#include <SeQuant/core/tensor_network/canonicals.hpp>
+#include <SeQuant/core/tensor_network/slot.hpp>
+#include <SeQuant/core/tensor_network/vertex.hpp>
+
+#include <range/v3/range/traits.hpp>
+
+#include <cassert>
+#include <cstdlib>
+#include <iosfwd>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+// forward declarations
+namespace bliss {
+class Graph;
+}
+
+namespace sequant {
+
+/// @brief A (non-directed) graph view of a sequence of AbstractTensor objects
+
+/// @note The main role of this is to canonize itself. Since Tensor objects can
+/// be connected by multiple Index'es (thus edges are colored), what is
+/// canonized is actually the graph of indices (roughly the dual of the tensor
+/// graph), with Tensor objects represented by one or more vertices.
+class TensorNetworkV3 {
+ public:
+  friend class TensorNetworkV3Accessor;
+
+  enum class Origin {
+    Bra = 1,
+    Ket,
+    Aux,
+  };
+
+  class Vertex {
+   public:
+    Vertex(Origin origin, std::size_t terminal_idx, std::size_t index_slot,
+           Symmetry terminal_symm);
+
+    Origin getOrigin() const;
+    std::size_t getTerminalIndex() const;
+    std::size_t getIndexSlot() const;
+    Symmetry getTerminalSymmetry() const;
+
+    bool operator<(const Vertex &rhs) const;
+    bool operator==(const Vertex &rhs) const;
+
+   private:
+    Origin origin;
+    std::size_t terminal_idx;
+    std::size_t index_slot;
+    Symmetry terminal_symm;
+  };
+
+  // clang-format off
+  /// @brief Edge in a TensorNetworkV2 = the Index annotating it + a pair of indices to identify which Tensor terminals it's connected to
+
+  /// @note tensor terminals in a sequence of tensors are indexed as follows:
+  /// - >0 for bra terminals (i.e. "+7" indicated connection to a bra terminal
+  /// of 7th tensor object in the sequence)
+  /// - <0 for ket terminals
+  /// - 0 if free (not attached to any tensor objects)
+  /// - position records the terminal's location in the sequence of bra/ket
+  /// terminals (always 0 for symmetric/antisymmetric tensors) Terminal indices
+  /// are sorted by the tensor index (i.e. by the absolute value of the terminal
+  /// index), followed by position
+  // clang-format on
+  class Edge {
+   public:
+    Edge() = default;
+    explicit Edge(Vertex vertex) : first(std::move(vertex)), second() {}
+    Edge(Vertex vertex, const Index *index)
+        : first(std::move(vertex)), second(), index(index) {}
+
+    Edge &connect_to(Vertex vertex) {
+      assert(!second.has_value());
+
+      if (!first.has_value()) {
+        // unconnected Edge
+        first = std::move(vertex);
+      } else {
+        // - cannot connect braket slot to aux slot
+        if ((first->getOrigin() == Origin::Aux &&
+             vertex.getOrigin() != Origin::Aux) ||
+            (first->getOrigin() != Origin::Aux &&
+             vertex.getOrigin() == Origin::Aux)) {
+          throw std::logic_error(
+              "TensorNetwork::Edge::connect_to: aux slot cannot be connected "
+              "to a non-aux slot");
+        }
+        // - can connect bra slot to ket slot, and vice versa
+        if (first->getOrigin() == Origin::Bra &&
+            vertex.getOrigin() != Origin::Ket) {
+          throw std::logic_error(
+              "TensorNetwork::Edge::connect_to: bra slot can only be connected "
+              "to a ket slot");
+        }
+        if (first->getOrigin() == Origin::Ket &&
+            vertex.getOrigin() != Origin::Bra) {
+          throw std::logic_error(
+              "TensorNetwork::Edge::connect_to: ket slot can only be connected "
+              "to a bra slot");
+        }
+        second = std::move(vertex);
+        if (second < first) {
+          // Ensure first <= second
+          std::swap(first, second);
+        }
+      }
+
+      return *this;
+    }
+
+    bool operator<(const Edge &other) const {
+      if (vertex_count() != other.vertex_count()) {
+        // Ensure external indices (edges that are only attached to a tensor on
+        // one side) always come before internal ones
+        return vertex_count() < other.vertex_count();
+      }
+
+      if (!(first == other.first)) {
+        return first < other.first;
+      }
+
+      if (second < other.second) {
+        return second < other.second;
+      }
+
+      assert(index && other.index);
+      return index->space() < other.index->space();
+    }
+
+    bool operator==(const Edge &other) const {
+      return first == other.first && second == other.second;
+    }
+
+    const Vertex &first_vertex() const {
+      assert(first.has_value());
+      return first.value();
+    }
+    const Vertex &second_vertex() const {
+      assert(second.has_value());
+      return second.value();
+    }
+
+    /// @return the number of attached terminals (0, 1, or 2)
+    std::size_t vertex_count() const {
+      return second.has_value() ? 2 : (first.has_value() ? 1 : 0);
+    }
+
+    const Index &idx() const {
+      assert(index);
+      return *index;
+    }
+
+   private:
+    std::optional<Vertex> first;
+    std::optional<Vertex> second;
+    const Index *index = nullptr;
+  };
+
+  struct Graph {
+    /// The type used to encode the color of a vertex. The restriction of this
+    /// being as 32-bit integer comes from how BLISS is trying to convert these
+    /// into RGB values.
+    using VertexColor = std::uint32_t;
+
+    std::unique_ptr<bliss::Graph> bliss_graph;
+    std::vector<std::wstring> vertex_labels;
+    std::vector<std::optional<std::wstring>> vertex_texlabels;
+    std::vector<VertexColor> vertex_colors;
+    std::vector<VertexType> vertex_types;
+    container::map<Index, std::size_t> idx_to_vertex;
+
+    Graph() = default;
+
+    std::size_t vertex_to_index_idx(std::size_t vertex) const;
+    std::size_t vertex_to_tensor_idx(std::size_t vertex) const;
+  };
+
+  TensorNetworkV3(const Expr &expr) {
+    if (expr.size() > 0) {
+      for (const ExprPtr &subexpr : expr) {
+        add_expr(*subexpr);
+      }
+    } else {
+      add_expr(expr);
+    }
+
+    init_edges();
+  }
+
+  TensorNetworkV3(const ExprPtr &expr) : TensorNetworkV3(*expr) {}
+
+  template <
+      typename ExprPtrRange,
+      typename = std::enable_if_t<!std::is_base_of_v<ExprPtr, ExprPtrRange> &&
+                                  !std::is_base_of_v<Expr, ExprPtrRange>>>
+  TensorNetworkV3(const ExprPtrRange &exprptr_range) {
+    static_assert(
+        std::is_base_of_v<ExprPtr, ranges::range_value_t<ExprPtrRange>>);
+    for (const ExprPtr &current : exprptr_range) {
+      add_expr(*current);
+    }
+
+    init_edges();
+  }
+
+  /// @return const reference to the sequence of tensors
+  /// @note after invoking TensorNetwork::canonicalize() the order of
+  /// tensors may be different from that provided as input; use
+  /// tensor_input_ordinals() to obtain the input ordinals of
+  /// the tensors in the result
+  const auto &tensors() const { return tensors_; }
+
+  const auto &tensor_input_ordinals() const { return tensor_input_ordinals_; }
+
+  using NamedIndexSet = container::set<Index, Index::FullLabelCompare>;
+
+  /// @param cardinal_tensor_labels move all tensors with these labels to the
+  /// front before canonicalizing indices
+  /// @param fast if true (default), does fast canonicalization that is only
+  /// optimal if all tensors are distinct; set to false to perform complete
+  /// canonicalization
+  /// @param named_indices specifies the indices that cannot be renamed, i.e.
+  /// their labels are meaningful; default is nullptr, which results in external
+  /// indices treated as named indices
+  /// @return byproduct of canonicalization (e.g. phase); if none, returns
+  /// nullptr
+  ExprPtr canonicalize(
+      const container::vector<std::wstring> &cardinal_tensor_labels = {},
+      bool fast = true, const NamedIndexSet *named_indices = nullptr);
+
+  /// metadata produced by canonicalize_slots()
+  struct SlotCanonicalizationMetadata {
+    /// list of named indices
+    NamedIndexSet named_indices;
+
+    /// type of less-than comparison function for named indices, receives {Index
+    /// ptr, its slot type}
+    using named_index_compare_t =
+        std::function<bool(const std::pair<const Index *, IndexSlotType> &,
+                           const std::pair<const Index *, IndexSlotType> &)>;
+
+    /// less-than comparison function for named indices, used for
+    /// coarse-grained sorting of named indices,
+    /// before sorting to canonical order
+    named_index_compare_t named_index_compare;
+
+    /// list of named indices, sorted first by named_index_compare,
+    /// then by canonical order; iterators point to named_indices
+    container::svector<NamedIndexSet::const_iterator> named_indices_canonical;
+
+    /// canonicalized colored graph, use graph->cmp to compare against another
+    /// to detect equivalence
+    std::shared_ptr<bliss::Graph> graph;
+
+    [[nodiscard]] size_t hash_value() const;
+
+    [[nodiscard]] inline auto get_index_view() const {
+      return named_indices_canonical  //
+             | ranges::views::indirect;
+    }
+
+    template <typename Cont>
+    auto get_indices() const {
+      return get_index_view() | ranges::to<Cont>;
+    }
+
+    /// if tensor network contains tensors with antisymmetric bra/ket this
+    /// reports the phase change due to permutation of slots relative to their
+    /// input order
+    std::int8_t phase = +1;  // +1 or -1
+  };
+
+  /// Like canonicalize(), but only use graph-based canonicalization to
+  /// produce canonical list of slots occupied by named indices.
+  /// This is sufficient to be able to match 2 tensor networks that
+  /// differ in anonymous and named indices.
+  /// @param cardinal_tensor_labels move all tensors with these labels to the
+  /// front before canonicalizing indices
+  /// @param named_indices specifies the indices that cannot be renamed, i.e.
+  /// their labels are meaningful; default is nullptr, which results in external
+  /// indices treated as named indices
+  /// @param named_index_compare less-than comparison function for
+  /// named indices, used for coarse-grained sorting of named indices,
+  /// before sorting to canonical order; the default is to sort
+  /// by Index::space()
+  /// @return the computed canonicalization metadata
+  SlotCanonicalizationMetadata canonicalize_slots(
+      const container::vector<std::wstring> &cardinal_tensor_labels = {},
+      const NamedIndexSet *named_indices = nullptr,
+      SlotCanonicalizationMetadata::named_index_compare_t named_index_compare =
+          default_idxptr_slottype_lesscompare{});
+
+  /// Factorizes tensor network
+  /// @return sequence of binary products; each element encodes the tensors to
+  /// be
+  ///         multiplied (values >0 refer to the tensors in tensors(),
+  ///         values <0 refer to the elements of this sequence. E.g. sequences
+  ///         @c {{0,1},{-1,2},{-2,3}} , @c {{0,2},{1,3},{-1,-2}} , @c
+  ///         {{3,1},{2,-1},{0,-2}} encode the following respective
+  ///         factorizations @c (((T0*T1)*T2)*T3) , @c ((T0*T2)*(T1*T3)) , and
+  ///         @c (((T3*T1)*T2)*T0) .
+  container::svector<std::pair<long, long>> factorize();
+
+  /// accessor for the Edge object sequence
+  /// @return const reference to the sequence container of Edge objects, sorted
+  /// by their Index's full label
+  /// @sa Edge
+  const auto &edges() const {
+    assert(have_edges_);
+    return edges_;
+  }
+
+  /// @brief Returns a range of external indices, i.e. those indices that do not
+  /// connect tensors
+  const auto &ext_indices() const {
+    assert(have_edges_);
+    return ext_indices_;
+  }
+
+  /// options for generating Graph from an object of this type
+  struct CreateGraphOptions {
+    /// pointer to the set of named indices (ordinarily,
+    /// this includes all external indices);
+    /// default is nullptr, which means use all external indices for
+    /// named indices
+    const NamedIndexSet *named_indices = nullptr;
+
+    /// if false, will use same color for all
+    /// named indices that have same Index::color(), else will use distinct
+    /// color for each
+    bool distinct_named_indices = true;
+
+    /// if false, will not generate the labels
+    bool make_labels = true;
+
+    /// if false, will not generate the TeX labels
+    bool make_texlabels = true;
+
+    /// if false, will not generate the Index->vertex map
+    bool make_idx_to_vertex = false;
+  };
+
+  /// @brief converts the network into a Bliss graph whose vertices are indices
+  /// and tensor vertex representations
+  /// @param[in] options the options for generating the graph
+  /// @return The created Graph object
+
+  /// @note Rules for constructing the graph:
+  ///   - Indices with protoindices are connected to their protoindices,
+  ///   either directly or (if protoindices are symmetric) via a protoindex
+  ///   vertex.
+  ///   - Indices are colored by their space, which in general encodes also
+  ///   the space of the protoindices.
+  ///   - An anti/symmetric n-body tensor has 2 terminals, each connected to
+  ///   each other + to n index vertices.
+  ///   - A nonsymmetric n-body tensor has n terminals, each connected to 2
+  ///   indices and 1 tensor vertex which is connected to all n terminal
+  ///   indices.
+  ///   - tensor vertices are colored by the label+rank+symmetry of the
+  ///   tensor; terminal vertices are colored by the color of its tensor,
+  ///     with the color of symm/antisymm terminals augmented by the
+  ///     terminal's type (bra/ket).
+  Graph create_graph(const CreateGraphOptions &options = {
+                         .named_indices = nullptr,
+                         .distinct_named_indices = true,
+                         .make_labels = true,
+                         .make_texlabels = true,
+                         .make_idx_to_vertex = false}) const;
+
+ private:
+  /// list of tensors
+  /// - before canonicalize(): input
+  /// - after canonicalize(): canonical
+  container::svector<AbstractTensorPtr> tensors_;
+  /// input ordinals of tensors in tensors_
+  container::svector<std::size_t> tensor_input_ordinals_;
+
+  container::vector<Edge> edges_;
+  bool have_edges_ = false;
+  /// ext indices do not connect tensors
+  /// sorted by full label of the corresponding value (Index)
+  /// N.B. this may contain some indices in pure_proto_indices_ if there are
+  /// external indices that depend on them
+  NamedIndexSet ext_indices_;
+  /// some proto indices may not be in edges_ if they appear exclusively among
+  /// proto indices
+  /// @note these will need to be processed separately from the rest
+  /// to appear as vertices on the graph
+  NamedIndexSet pure_proto_indices_;
+
+  /// initializes edges_, ext_indices_, and pure_proto_indices_
+  void init_edges();
+
+  /// Canonicalizes the network graph representation
+  /// Note: The explicit order of tensors and labelling of indices
+  /// remains undefined.
+  void canonicalize_graph(const NamedIndexSet &named_indices);
+
+  /// Canonicalizes every individual tensor for itself, taking into account only
+  /// tensor blocks
+  /// @returns The byproduct of the canonicalizations
+  ExprPtr canonicalize_individual_tensor_blocks(
+      const NamedIndexSet &named_indices);
+
+  /// Canonicalizes every individual tensor for itself
+  /// @returns The byproduct of the canonicalizations
+  ExprPtr canonicalize_individual_tensors(const NamedIndexSet &named_indices);
+
+  ExprPtr do_individual_canonicalization(
+      const TensorCanonicalizer &canonicalizer);
+
+  void add_expr(const Expr &expr) {
+    ExprPtr clone = expr.clone();
+
+    auto tensor_ptr = std::dynamic_pointer_cast<AbstractTensor>(clone);
+    if (!tensor_ptr) {
+      throw std::invalid_argument(
+          "TensorNetworkV3::TensorNetworkV3: tried to add non-tensor to "
+          "network");
+    }
+
+    tensors_.push_back(std::move(tensor_ptr));
+    tensor_input_ordinals_.push_back(tensor_input_ordinals_.size());
+  }
+};
+
+template <typename CharT, typename Traits>
+std::basic_ostream<CharT, Traits> &operator<<(
+    std::basic_ostream<CharT, Traits> &stream, TensorNetworkV3::Origin origin) {
+  switch (origin) {
+    case TensorNetworkV3::Origin::Bra:
+      stream << "Bra";
+      break;
+    case TensorNetworkV3::Origin::Ket:
+      stream << "Ket";
+      break;
+    case TensorNetworkV3::Origin::Aux:
+      stream << "Aux";
+      break;
+  }
+  return stream;
+}
+
+}  // namespace sequant
+
+#endif  // SEQUANT_TENSOR_NETWORK_H

--- a/SeQuant/core/tensor_network_v3.hpp
+++ b/SeQuant/core/tensor_network_v3.hpp
@@ -42,6 +42,7 @@ namespace sequant {
 /// graph), with Tensor objects represented by one or more vertices.
 class TensorNetworkV3 {
  public:
+  // for unit testing only
   friend class TensorNetworkV3Accessor;
 
   enum class Origin {
@@ -82,7 +83,7 @@ class TensorNetworkV3 {
     explicit Edge(const Vertex &vertex) : vertices{vertex} {}
     explicit Edge(std::initializer_list<Vertex> vertices) {
       ranges::for_each(vertices,
-                       [this](const Vertex &v) { this->add_vertex(v); });
+                       [this](const Vertex &v) { this->connect_to(v); });
     }
     Edge(const Vertex &vertex, const Index *index)
         : vertices{vertex}, index(index) {}

--- a/SeQuant/core/utility/debug.hpp
+++ b/SeQuant/core/utility/debug.hpp
@@ -1,0 +1,24 @@
+//
+// Created by Eduard Valeyev on 7/30/25.
+//
+
+#ifndef SEQUANT_CORE_UTILITY_DEBUG_HPP
+#define SEQUANT_CORE_UTILITY_DEBUG_HPP
+
+#include <cstdio>
+#include <sstream>
+
+namespace sequant {
+
+/// uses std::wostringstream + std::wprintf to print to stdout even if wcout is
+/// captured (e.g., by Catch2)
+template <typename... Args>
+void wprintf(Args&&... args) {
+  std::wostringstream oss;
+  (oss << ... << std::forward<Args>(args)) << std::endl;
+  std::wprintf(oss.str().c_str());
+}
+
+}  // namespace sequant
+
+#endif  // SEQUANT_CORE_UTILITY_DEBUG_HPP

--- a/SeQuant/core/utility/permutation.hpp
+++ b/SeQuant/core/utility/permutation.hpp
@@ -80,6 +80,36 @@ std::size_t count_cycles(Seq0&& v0, const Seq1& v1) {
   return n_cycles;
 };
 
+/// computes parity of a permutation of 0 ... N-1
+///
+/// @param p permutation
+/// @param overwrite if true, will overwrite @p p
+template <std::integral T>
+int permutation_parity(std::span<T> p, bool overwrite = false) {
+  // https://stackoverflow.com/a/20703469
+  // compute cycles, mutating elements of p to mark used elements
+  const std::size_t N = p.size();
+  int parity = 1;
+  // search for next element to start cycle with
+  for (std::size_t k = 0; k != N; ++k) {
+    if (p[k] >= N) continue;
+    std::size_t i = k;
+    std::size_t cycle_length = 1;
+    do {
+      i = p[i];
+      p[i] += N;
+      ++cycle_length;
+    } while (p[i] < N);
+    if (cycle_length % 2 == 0) parity *= -1;
+  }
+
+  if (overwrite) {
+    ranges::for_each(p, [N](auto& e) { e -= N; });
+  }
+
+  return parity;
+}
+
 }  // namespace sequant
 
 #endif

--- a/SeQuant/core/utility/swap.hpp
+++ b/SeQuant/core/utility/swap.hpp
@@ -75,6 +75,14 @@ class SwapCountable {
   template <typename U>
   explicit SwapCountable(U&& v) : value_(std::forward<U>(v)) {}
 
+  template <typename U>
+  SwapCountable& operator=(U&& v) {
+    value_ = std::forward<U>(v);
+    return *this;
+  }
+
+  operator T() const { return value_; }
+
  private:
   T value_;
 

--- a/SeQuant/core/wick.impl.hpp
+++ b/SeQuant/core/wick.impl.hpp
@@ -5,14 +5,14 @@
 #ifndef SEQUANT_WICK_IMPL_HPP
 #define SEQUANT_WICK_IMPL_HPP
 
-// change to 1 to try TNV2
-#define USE_TENSOR_NETWORK_V2 0
+// change to 1 to try TNV3
+#define USE_TENSOR_NETWORK_V3 0
 
 #include <SeQuant/core/bliss.hpp>
 #include <SeQuant/core/logger.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
-#if USE_TENSOR_NETWORK_V2
-#include <SeQuant/core/tensor_network_v2.hpp>
+#if USE_TENSOR_NETWORK_V3
+#include <SeQuant/core/tensor_network_v3.hpp>
 #else
 #include <SeQuant/core/tensor_network.hpp>
 #endif
@@ -606,8 +606,8 @@ ExprPtr WickTheorem<S>::compute(const bool count_only,
                 << to_latex(expr_input_) << std::endl;
 
             // construct graph representation of the tensor product
-#if USE_TENSOR_NETWORK_V2
-          TensorNetworkV2 tn(expr_input_->as<Product>().factors());
+#if USE_TENSOR_NETWORK_V3
+          TensorNetworkV3 tn(expr_input_->as<Product>().factors());
           auto g = tn.create_graph();
           const auto &graph = g.bliss_graph;
           const auto &vlabels = g.vertex_labels;
@@ -629,11 +629,7 @@ ExprPtr WickTheorem<S>::compute(const bool count_only,
 
           if (Logger::instance().wick_topology) {
             std::basic_ostringstream<wchar_t> oss;
-#if USE_TENSOR_NETWORK_V2
             graph->write_dot(oss, vlabels);
-#else
-            graph->write_dot(oss, vlabels);
-#endif
             std::wcout
                 << "WickTheorem<S>::compute: colored graph produced from TN = "
                 << std::endl
@@ -916,14 +912,14 @@ ExprPtr WickTheorem<S>::compute(const bool count_only,
             auto connected_to_same_nop =
                 [&tn_tensors](const auto &edge1, const auto &edge2) -> bool {
               const auto nt1 =
-#if USE_TENSOR_NETWORK_V2
+#if USE_TENSOR_NETWORK_V3
                   edge1.vertex_count();
 #else
                   edge1.size();
 #endif
               assert(nt1 <= 2);
               const auto nt2 =
-#if USE_TENSOR_NETWORK_V2
+#if USE_TENSOR_NETWORK_V3
                   edge2.vertex_count();
 #else
                   edge2.size();
@@ -931,17 +927,17 @@ ExprPtr WickTheorem<S>::compute(const bool count_only,
               assert(nt2 <= 2);
               for (auto i1 = 0; i1 != nt1; ++i1) {
                 const auto tensor1_ord =
-#if USE_TENSOR_NETWORK_V2
-                    i1 == 0 ? edge1.first_vertex().getTerminalIndex()
-                            : edge1.second_vertex().getTerminalIndex();
+#if USE_TENSOR_NETWORK_V3
+                    i1 == 0 ? edge1.vertex(0).getTerminalIndex()
+                            : edge1.vertex(1).getTerminalIndex();
 #else
                     edge1[i1].tensor_ord;
 #endif
                 for (auto i2 = 0; i2 != nt2; ++i2) {
                   const auto tensor2_ord =
-#if USE_TENSOR_NETWORK_V2
-                      i2 == 0 ? edge2.first_vertex().getTerminalIndex()
-                              : edge2.second_vertex().getTerminalIndex();
+#if USE_TENSOR_NETWORK_V3
+                      i2 == 0 ? edge2.vertex(0).getTerminalIndex()
+                              : edge2.vertex(1).getTerminalIndex();
 #else
                       edge2[i2].tensor_ord;
 #endif

--- a/SeQuant/domain/eval/eval.hpp
+++ b/SeQuant/domain/eval/eval.hpp
@@ -481,7 +481,8 @@ ResultPtr evaluate(Args&&... args) {
 /// \tparam EvalTrace If Trace::On, trace is written to the logger's stream.
 ///                   Default is to follow Trace::Default, which is itself
 ///                   equal to Trace::On or Trace::Off.
-/// \brief Calls @code evaluate followd by the particle-symmetrization function.
+/// \brief Calls @code evaluate followed by the particle-symmetrization
+///        function.
 ///        The number of particles is inferred by the tensor present in the
 ///        evaluation node(s). Presence of odd-ranked tensors in the evaluation
 ///        node(s) is an error.
@@ -509,7 +510,7 @@ ResultPtr evaluate_symm(Args&&... args) {
 /// \tparam EvalTrace If Trace::On, trace is written to the logger's stream.
 ///                   Default is to follow Trace::Default, which is itself
 ///                   equal to Trace::On or Trace::Off.
-/// \brief Calls @code evaluate followd by the anti-symmetrization function on
+/// \brief Calls @code evaluate followed by the anti-symmetrization function on
 ///        the bra indices and the ket indices. The bra and ket indices are
 ///        inferred from the evaluation node(s).
 /// \return Evaluated result as ResultPtr.

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -1060,7 +1060,10 @@ ExprPtr vac_av(ExprPtr expr, std::vector<std::pair<int, int>> nop_connections,
   FWickTheorem wick{expr};
   wick.use_topology(use_top).set_nop_connections(nop_connections);
   wick.full_contractions(full_contractions);
-  auto result = wick.compute();
+  auto result = wick.compute(/* count_only = */ false,
+                             /* skip_input_canonicalization? true since already
+                                did simplification above */
+                             true);
   simplify(result);
 
   if (Logger::instance().wick_stats) {

--- a/benchmarks/tensor_network.cpp
+++ b/benchmarks/tensor_network.cpp
@@ -40,23 +40,21 @@ ProductPtr create_random_network(const std::size_t testcase,
     return nullptr;
   }
 
-  container::vector<Index> covariant_indices;
+  container::vector<Index> bra_indices;
   for (auto i = 0; i != num_indices; ++i) {
-    covariant_indices.emplace_back(std::format(L"i_{}", i));
+    bra_indices.emplace_back(std::format(L"i_{}", i));
   }
 
-  auto contravariant_indices = covariant_indices;
+  auto ket_indices = bra_indices;
 
   std::random_device rd;
 
   // Randomize connectivity by randomizing index sets
-  std::shuffle(covariant_indices.begin(), covariant_indices.end(),
-               std::mt19937{rd()});
-  std::shuffle(contravariant_indices.begin(), contravariant_indices.end(),
-               std::mt19937{rd()});
+  std::shuffle(bra_indices.begin(), bra_indices.end(), std::mt19937{rd()});
+  std::shuffle(ket_indices.begin(), ket_indices.end(), std::mt19937{rd()});
 
   auto utensors =
-      covariant_indices | ranges::views::chunk(num_indices / n) |
+      bra_indices | ranges::views::chunk(num_indices / n) |
       ranges::views::transform([&](const auto& idxs) {
         return ex<Tensor>(
             L"u", bra(idxs), ket{},
@@ -68,7 +66,7 @@ ProductPtr create_random_network(const std::size_t testcase,
   assert(utensors.size() == static_cast<std::size_t>(n));
 
   auto dtensors =
-      contravariant_indices | ranges::views::chunk(num_indices) |
+      ket_indices | ranges::views::chunk(num_indices) |
       ranges::views::transform([&](const auto& idxs) {
         return ex<Tensor>(L"d", bra{}, ket(idxs), Symmetry::nonsymm);
       }) |

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,9 +2,10 @@ include(FindOrFetchCatch2)
 include(Catch)
 
 add_executable(unit_tests-sequant ${BUILD_BY_DEFAULT}
+    "test_abstract_tensor.cpp"
     "test_asy_cost.cpp"
     "test_binary_node.cpp"
-	"test_biorthogonalization.cpp"
+    "test_biorthogonalization.cpp"
     "test_bliss.cpp"
     "test_canonicalize.cpp"
     "test_eval_expr.cpp"

--- a/tests/unit/test_abstract_tensor.cpp
+++ b/tests/unit/test_abstract_tensor.cpp
@@ -1,0 +1,112 @@
+//
+// Created by Eduard Valeyev on 8/1/25.
+//
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "catch2_sequant.hpp"
+
+#include "SeQuant/core/op.hpp"
+#include "SeQuant/core/tensor.hpp"
+
+#include <array>
+#include <span>
+
+TEST_CASE("abstract_tensor", "[elements]") {
+  using namespace sequant;
+
+  std::map<SlotType, std::array<const wchar_t*, 3>> orig_idxs;
+  std::array braidxs{L"p_1", L"p_2", L"p_3"};
+  std::array ketidxs{L"p_4", L"p_5", L"p_6"};
+  std::array auxidxs{L"p_7", L"p_8", L"p_9"};
+  orig_idxs[SlotType::Bra] = braidxs;
+  orig_idxs[SlotType::Ket] = ketidxs;
+  orig_idxs[SlotType::Aux] = auxidxs;
+  std::shared_ptr<AbstractTensor> tensor = std::make_shared<Tensor>(
+      L"t", bra<decltype(braidxs)>{braidxs}, ket<decltype(ketidxs)>{ketidxs},
+      aux<decltype(auxidxs)>{auxidxs});
+  std::shared_ptr<AbstractTensor> nop = std::make_shared<FNOperator>(
+      cre<decltype(ketidxs)>{ketidxs}, ann<decltype(braidxs)>{braidxs});
+
+  SECTION("permute") {
+    SECTION("1-index") {
+      for (auto& tptr : {tensor, nop}) {
+        auto& t = *tptr;
+
+        // permute 1-index slots
+        for (auto slottype : {SlotType::Bra, SlotType::Ket, SlotType::Aux}) {
+          // skip aux for nop
+          if (t._label() != L"t" && slottype == SlotType::Aux) continue;
+
+          auto idxs = [&]() {
+            switch (slottype) {
+              case SlotType::Bra:
+                return t._bra();
+              case SlotType::Ket:
+                return t._ket();
+              case SlotType::Aux:
+                return t._aux();
+              default:
+                abort();
+            }
+          };
+          auto permute = [&](auto& p) {
+            switch (slottype) {
+              case SlotType::Bra:
+                return t._permute_bra(p);
+              case SlotType::Ket:
+                return t._permute_ket(p);
+              case SlotType::Aux:
+                return t._permute_aux(p);
+              default:
+                abort();
+            }
+          };
+
+          const std::array<std::size_t, 3> pdata{1, 0, 2};
+          std::span p{pdata.data(), 3};
+          // permutation moves indices around, i.e. no reallocation, pointers
+          // are stable
+          auto original_idxptrs =
+              idxs() |
+              ranges::views::transform([](const auto& idx) { return &idx; }) |
+              ranges::to_vector;
+          permute(p);
+          for (auto i = 0; i != 3; ++i) {
+            REQUIRE(idxs()[i].label() == orig_idxs[slottype][pdata[i]]);
+          }
+          auto idxptrs =
+              idxs() |
+              ranges::views::transform([](const auto& idx) { return &idx; }) |
+              ranges::to_vector;
+          REQUIRE(original_idxptrs == idxptrs);
+        }
+      }
+    }  // SECTION("1-index")
+
+    // permute 2-index (braket) slots
+    SECTION("2-index") {
+      for (auto& tptr : {tensor, nop}) {
+        auto& t = *tptr;
+        const std::array<std::size_t, 3> pdata{1, 0, 2};
+        std::span p{pdata.data(), 3};
+        // permutation moves indices around, i.e. no reallocation, pointers are
+        // stable
+        auto original_idxptrs =
+            t._braket() |
+            ranges::views::transform([](const auto& idx) { return &idx; }) |
+            ranges::to_vector;
+        t._permute_braket(p);
+        for (auto i = 0; i != 3; ++i) {
+          REQUIRE(t._bra()[i].label() == braidxs[pdata[i]]);
+          REQUIRE(t._ket()[i].label() == ketidxs[pdata[i]]);
+        }
+        auto idxptrs =
+            t._braket() |
+            ranges::views::transform([](const auto& idx) { return &idx; }) |
+            ranges::to_vector;
+        REQUIRE(original_idxptrs == idxptrs);
+      }
+    }  // SECTION("2-index")
+  }
+}

--- a/tests/unit/test_canonicalize.cpp
+++ b/tests/unit/test_canonicalize.cpp
@@ -315,7 +315,7 @@ TEST_CASE("canonicalization", "[algorithms]") {
         canonicalize(input);
         REQUIRE_THAT(
             input,
-            SimplifiesTo(
+            EquivalentTo(
                 "-8 S{i1,i2,i3;a1,a2,a3} f{i4;i3} t{a1,a2,a3;i1,i4,i2}"));
       }
 
@@ -337,16 +337,16 @@ TEST_CASE("canonicalization", "[algorithms]") {
         canonicalize(term1);
         canonicalize(term2);
         REQUIRE_THAT(term1,
-                     SimplifiesTo("-4 S{i_1,i_2,i_3;a_1,a_2,a_3} f{i_4;i_3} "
+                     EquivalentTo("-4 S{i_1,i_2,i_3;a_1,a_2,a_3} f{i_4;i_3} "
                                   "t{a_1,a_2,a_3;i_1,i_4,i_2}"));
         REQUIRE_THAT(term2,
-                     SimplifiesTo("-4 S{i_1,i_2,i_3;a_1,a_2,a_3} f{i_4;i_3} "
+                     EquivalentTo("-4 S{i_1,i_2,i_3;a_1,a_2,a_3} f{i_4;i_3} "
                                   "t{a_1,a_2,a_3;i_1,i_4,i_2}"));
         auto sum_of_terms = term1 + term2;
         simplify(sum_of_terms);
         REQUIRE_THAT(
             sum_of_terms,
-            SimplifiesTo(
+            EquivalentTo(
                 "-8 S{i1,i2,i3;a1,a2,a3} f{i4;i3} t{a1,a2,a3;i1,i4,i2}"));
       }
 
@@ -366,7 +366,7 @@ TEST_CASE("canonicalization", "[algorithms]") {
                            ket{L"i_2", L"i_3", L"i_4"}, Symmetry::nonsymm);
         canonicalize(input);
         REQUIRE_THAT(
-            input, SimplifiesTo(
+            input, EquivalentTo(
                        "4 S{i1,i2,i3;a1,a2,a3} f{i4;i3} t{a1,a2,a3;i4,i1,i2}"));
       }
     }

--- a/tests/unit/test_eval_expr.cpp
+++ b/tests/unit/test_eval_expr.cpp
@@ -215,6 +215,7 @@ TEST_CASE("eval_expr", "[EvalExpr]") {
 
     // todo:
     // REQUIRE(x12.expr()->as<Tensor>().symmetry() == Symmetry::antisymm);
+    REQUIRE(x12.expr()->as<Tensor>().symmetry() == Symmetry::nonsymm);
 
     // whole bra <-> ket contraction between two symmetric tensors
     const auto t3 =
@@ -226,6 +227,7 @@ TEST_CASE("eval_expr", "[EvalExpr]") {
 
     // todo:
     // REQUIRE(x34.expr()->as<Tensor>().symmetry() == Symmetry::symm);
+    REQUIRE(x34.expr()->as<Tensor>().symmetry() == Symmetry::nonsymm);
 
     // outer product of the same tensor
     const auto t5 = parse_expr(L"f_{i1}^{a1}", Symmetry::nonsymm)->as<Tensor>();
@@ -235,15 +237,14 @@ TEST_CASE("eval_expr", "[EvalExpr]") {
 
     // todo:
     // REQUIRE(x56.expr()->as<Tensor>().symmetry() == Symmetry::antisymm);
+    REQUIRE(x56.expr()->as<Tensor>().symmetry() == Symmetry::nonsymm);
 
     // contraction of some indices from a bra to a ket
     const auto t7 = parse_tensor(L"g_{a1,a2}^{i1,a3}", Symmetry::antisymm);
     const auto t8 = parse_tensor(L"t_{a3}^{i2}", Symmetry::antisymm);
 
     const auto x78 = result_expr(EvalExpr{t7}, EvalExpr{t8}, EvalOp::Product);
-
-    // todo:
-    // REQUIRE(x78.expr()->as<Tensor>().symmetry() == Symmetry::nonsymm);
+    REQUIRE(x78.expr()->as<Tensor>().symmetry() == Symmetry::nonsymm);
 
     // whole bra <-> ket contraction between symmetric and antisymmetric tensors
     auto const t9 =
@@ -253,6 +254,7 @@ TEST_CASE("eval_expr", "[EvalExpr]") {
     auto const x910 = result_expr(EvalExpr{t9}, EvalExpr{t10}, EvalOp::Product);
     // todo:
     // REQUIRE(x910.expr()->as<Tensor>().symmetry() == Symmetry::symm);
+    REQUIRE(x910.expr()->as<Tensor>().symmetry() == Symmetry::nonsymm);
   }
 
   SECTION("Symmetry of sum") {

--- a/tests/unit/test_index.cpp
+++ b/tests/unit/test_index.cpp
@@ -185,14 +185,29 @@ TEST_CASE("index", "[elements][index]") {
   }
 
   SECTION("ordering") {
+    using SO = std::strong_ordering;
+
     // compare by qns, then tag, then space, then label, then proto indices
     Index i1(L"i_1");
     Index i2(L"i_2");
     Index i3(L"i_11");
+
     REQUIRE(i1 < i2);
     REQUIRE(!(i2 < i1));
+    REQUIRE(i1 <=> i2 == SO::less);
+    REQUIRE(i1 <= i2);
+    REQUIRE(!(i1 >= i2));
+
     REQUIRE(!(i1 < i1));
+    REQUIRE(i1 <=> i1 == SO::equal);
+    REQUIRE(i1 <= i1);
+    REQUIRE(i1 >= i1);
+
     REQUIRE(i1 < i3);
+    REQUIRE(i1 <=> i3 == SO::less);
+    REQUIRE(i1 <= i3);
+    REQUIRE(!(i1 >= i3));
+
     REQUIRE(!(i3 < i1));
     REQUIRE(i2 < i3);
     REQUIRE(!(i3 < i2));
@@ -204,15 +219,19 @@ TEST_CASE("index", "[elements][index]") {
     // tags override rest, but ignored if defined for one and not the other
     i2.tag().assign(1);
     REQUIRE(i1 < i2);
+    REQUIRE(i1 <=> i2 == SO::less);
     i1.tag().assign(2);
     REQUIRE(!(i1 < i2));
     REQUIRE(i2 < i1);
+    REQUIRE(i2 <=> i1 == SO::less);
     a1.tag().assign(1);
     REQUIRE(!(i1 < a1));
     REQUIRE(a1 < i1);
     REQUIRE(i2 < a1);
+    REQUIRE(i2 <=> a1 == SO::less);
     a1.tag().reset().assign(0);
     REQUIRE(a1 < i2);
+    REQUIRE(a1 <=> i2 == SO::less);
 
     // qns override rest
     IndexSpace p_upspace(L"p", 0b11, 0b01);
@@ -239,6 +258,12 @@ TEST_CASE("index", "[elements][index]") {
     REQUIRE(p1A < p2A);
     p1A.tag().assign(2);
     REQUIRE(p2A < p1A);
+    REQUIRE(p2A <=> p1A == SO::less);
+    Index i1_p1Ap2A(L"i_1", {p1A, p2A});
+    Index i1_p1Bp2A(L"i_1", {p1B, p2A});
+    REQUIRE(i1_p1Ap2A < i1_p1Bp2A);
+    REQUIRE(i1_p1Ap2A <=> i1_p1Bp2A == SO::less);
+    REQUIRE(i1_p1Ap2A <=> i1_p1Ap2A == SO::equal);
 
     // with default Context label is used for comparisons
     {
@@ -250,6 +275,9 @@ TEST_CASE("index", "[elements][index]") {
       REQUIRE(i < j1);
       REQUIRE(j < j1);
       REQUIRE(!(j1 < j1));
+      REQUIRE(i <=> j == SO::less);
+      REQUIRE(i <=> j1 == SO::less);
+      REQUIRE(j <=> j1 == SO::less);
     }
   }
 

--- a/tests/unit/test_mbpt_cc.cpp
+++ b/tests/unit/test_mbpt_cc.cpp
@@ -17,8 +17,8 @@ TEST_CASE("mbpt_cc", "[mbpt/cc]") {
     SECTION("t") {
       // TCC R1
       SEQUANT_PROFILE_SINGLE("CCSD t", {
-        [[maybe_unused]] auto l = sequant::Logger::instance();
-        // l->canonicalize = true;
+        [[maybe_unused]] auto& l = sequant::Logger::instance();
+        // l.canonicalize = true;
         const auto N = 2;
         auto t_eqs = CC{N}.t();
         REQUIRE(t_eqs.size() == N + 1);

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -53,7 +53,7 @@ TEST_CASE("optimize", "[optimize]") {
       return opt::single_term_opt(prod, [](Index const& ix) {
         auto lbl = to_string(ix.label());
         auto sz = ix.space().approximate_size();
-        return ix.space().approximate_size();
+        return sz;
       });
     };
 

--- a/tests/unit/test_tensor_network.cpp
+++ b/tests/unit/test_tensor_network.cpp
@@ -238,12 +238,19 @@ TEMPLATE_TEST_CASE("tensor_network_shared", "[elements]", TensorNetwork,
     SECTION("Named index ordering") {
       REQUIRE(IndexSpace("i") < IndexSpace("a"));
 
+      using idxvec_t = std::vector<std::wstring>;
+      constexpr bool v3 =
+          std::is_same_v<TN,
+                         TensorNetworkV3>;  // v3 colors vertices differently,
+                                            // so canonical order differs
       for (const auto& [input, str_indices] :
            std::vector<std::pair<std::wstring, std::vector<std::wstring>>>{
                {L"G{;;a1,a2,a3,a4} T{;;i3,i2,a3,a4}",
-                {L"i_2", L"i_3", L"a_1", L"a_2"}},
+                v3 ? idxvec_t{L"i_3", L"i_2", L"a_2", L"a_1"}
+                   : idxvec_t{L"i_2", L"i_3", L"a_1", L"a_2"}},
                {L"G{;;a1,a2,a3,a4} T{;;i2,i3,a3,a4}",
-                {L"i_3", L"i_2", L"a_1", L"a_2"}},
+                v3 ? idxvec_t{L"i_2", L"i_3", L"a_2", L"a_1"}
+                   : idxvec_t{L"i_3", L"i_2", L"a_1", L"a_2"}},
            }) {
         const std::vector<Index> expected_indices =
             str_indices | ranges::views::transform([](const std::wstring& str) {

--- a/tests/unit/test_tensor_network.cpp
+++ b/tests/unit/test_tensor_network.cpp
@@ -21,6 +21,7 @@
 #include <SeQuant/core/tensor_canonicalizer.hpp>
 #include <SeQuant/core/tensor_network.hpp>
 #include <SeQuant/core/tensor_network_v2.hpp>
+#include <SeQuant/core/tensor_network_v3.hpp>
 #include <SeQuant/core/timer.hpp>
 #include <SeQuant/core/utility/string.hpp>
 
@@ -54,7 +55,7 @@ using namespace sequant;
 using namespace std::literals;
 
 TEMPLATE_TEST_CASE("tensor_network_shared", "[elements]", TensorNetwork,
-                   TensorNetworkV2) {
+                   TensorNetworkV2, TensorNetworkV3) {
   TensorCanonicalizer::register_instance(
       std::make_shared<DefaultTensorCanonicalizer>());
   auto isr = sequant::mbpt::make_legacy_spaces();
@@ -323,16 +324,17 @@ TEST_CASE("tensor_network", "[elements]") {
   using sequant::Context;
   namespace t = sequant::mbpt::tensor;
   namespace o = sequant::mbpt::op;
+  using TN = TensorNetwork;
 
   SECTION("constructors") {
     {  // with Tensors
       auto t1 = ex<Tensor>(L"F", bra{L"i_1"}, ket{L"i_2"});
       auto t2 = ex<Tensor>(L"t", bra{L"i_1"}, ket{L"i_2"});
       auto t1_x_t2 = t1 * t2;
-      REQUIRE_NOTHROW(TensorNetwork(*t1_x_t2));
+      REQUIRE_NOTHROW(TN(*t1_x_t2));
 
       auto t1_x_t2_p_t2 = t1 * (t2 + t2);  // can only use a flat tensor product
-      REQUIRE_THROWS_AS(TensorNetwork(*t1_x_t2_p_t2), std::logic_error);
+      REQUIRE_THROWS_AS(TN(*t1_x_t2_p_t2), std::logic_error);
     }
 
     {  // with NormalOperators
@@ -340,12 +342,12 @@ TEST_CASE("tensor_network", "[elements]") {
       auto t1 = ex<FNOperator>(cre({L"i_1"}), ann({L"i_2"}), V);
       auto t2 = ex<FNOperator>(cre({L"i_2"}), ann({L"i_1"}), V);
       auto t1_x_t2 = t1 * t2;
-      REQUIRE_NOTHROW(TensorNetwork(*t1_x_t2));
+      REQUIRE_NOTHROW(TN(*t1_x_t2));
     }
 
     {  // with Tensors and NormalOperators
       auto tmp = t::A(nₚ(-2)) * t::H_(2) * t::T_(2) * t::T_(2);
-      REQUIRE_NOTHROW(TensorNetwork(tmp->as<Product>().factors()));
+      REQUIRE_NOTHROW(TN(tmp->as<Product>().factors()));
     }
 
   }  // SECTION("constructors")
@@ -356,8 +358,8 @@ TEST_CASE("tensor_network", "[elements]") {
       auto t1 = ex<Tensor>(L"F", bra{L"i_1"}, ket{L"i_2"});
       auto t2 = ex<FNOperator>(cre({L"i_1"}), ann({L"i_3"}), V);
       auto t1_x_t2 = t1 * t2;
-      REQUIRE_NOTHROW(TensorNetwork(*t1_x_t2));
-      TensorNetwork tn(*t1_x_t2);
+      REQUIRE_NOTHROW(TN(*t1_x_t2));
+      TN tn(*t1_x_t2);
 
       // edges
       auto edges = tn.edges();
@@ -390,7 +392,7 @@ TEST_CASE("tensor_network", "[elements]") {
         auto t1 = ex<Tensor>(L"F", bra{L"i_1"}, ket{L"i_2"});
         auto t2 = ex<FNOperator>(cre({L"i_1"}), ann({L"i_2"}), V);
         auto t1_x_t2 = t1 * t2;
-        TensorNetwork tn(*t1_x_t2);
+        TN tn(*t1_x_t2);
         tn.canonicalize(TensorCanonicalizer::cardinal_tensor_labels(), false);
 
         REQUIRE(size(tn.tensors()) == 2);
@@ -417,7 +419,7 @@ TEST_CASE("tensor_network", "[elements]") {
 
         // with all external named indices
         {
-          TensorNetwork tn(*t1_x_t2);
+          TN tn(*t1_x_t2);
           tn.canonicalize(TensorCanonicalizer::cardinal_tensor_labels(), false);
 
           REQUIRE(size(tn.tensors()) == 2);
@@ -437,9 +439,9 @@ TEST_CASE("tensor_network", "[elements]") {
         // with explicit named indices
         {
           Index::reset_tmp_index();
-          TensorNetwork tn(*t1_x_t2);
+          TN tn(*t1_x_t2);
 
-          using named_indices_t = TensorNetwork::named_indices_t;
+          using named_indices_t = TN::named_indices_t;
           named_indices_t indices{Index{L"i_17"}};
           tn.canonicalize(TensorCanonicalizer::cardinal_tensor_labels(), false,
                           &indices);
@@ -474,7 +476,7 @@ TEST_CASE("tensor_network", "[elements]") {
     // mbpt::sr::make_op
     canonicalize(tmp);
     // std::wcout << "A2*H2*T2*T2*T2 = " << to_latex(tmp) << std::endl;
-    TensorNetwork tn(tmp->as<Product>().factors());
+    TN tn(tmp->as<Product>().factors());
 
     // make graph, with all labels
     REQUIRE_NOTHROW(
@@ -720,11 +722,11 @@ L"}\n";
 
       auto tmp = g * ta * tb;
       // std::wcout << "TN1 = " << to_latex(tmp) << std::endl;
-      TensorNetwork tn(tmp->as<Product>().factors());
+      TN tn(tmp->as<Product>().factors());
 
       // make graph
       // N.B. treat all indices as dummy so that the automorphism ignores the
-      using named_indices_t = TensorNetwork::named_indices_t;
+      using named_indices_t = TN::named_indices_t;
       named_indices_t indices{};
       REQUIRE_NOTHROW(tn.make_bliss_graph({.named_indices = &indices}));
       auto [graph, vlabels, vtexlabels, vcolors, vtypes] =
@@ -1318,6 +1320,631 @@ TEST_CASE("tensor_network_v2", "[elements]") {
       REQUIRE_NOTHROW(tn.create_graph({.named_indices = &indices}));
       TensorNetworkV2::Graph graph =
           tn.create_graph({.named_indices = &indices});
+
+      // can disable label production
+      {
+        // make sure can generate without labels also
+        REQUIRE_NOTHROW(
+            tn.create_graph({.make_labels = true, .make_texlabels = false})
+                .vertex_texlabels.size() == 0);
+        REQUIRE_NOTHROW(
+            tn.create_graph({.make_labels = false, .make_texlabels = true})
+                .vertex_labels.size() == 0);
+        {
+          auto g =
+              tn.create_graph({.make_labels = false, .make_texlabels = false});
+          REQUIRE_NOTHROW(g.vertex_labels.size() == 0 &&
+                          g.vertex_texlabels.size() == 0);
+        }
+      }
+
+      // create dot
+      {
+        std::basic_ostringstream<wchar_t> oss;
+        REQUIRE_NOTHROW(graph.bliss_graph->write_dot(oss, graph.vertex_labels));
+        // std::wcout << "oss.str() = " << std::endl << oss.str() <<
+        // std::endl;
+      }
+
+      bliss::Stats stats;
+      graph.bliss_graph->set_splitting_heuristic(bliss::Graph::shs_fsm);
+
+      std::vector<std::vector<unsigned int>> aut_generators;
+      auto save_aut = [&aut_generators](const unsigned int n,
+                                        const unsigned int* aut) {
+        aut_generators.emplace_back(aut, aut + n);
+      };
+      graph.bliss_graph->find_automorphisms(
+          stats, &bliss::aut_hook<decltype(save_aut)>, &save_aut);
+      CHECK(aut_generators.size() ==
+            2);  // there are 2 generators, i1<->i2, i3<->i4
+
+      std::basic_ostringstream<wchar_t> oss;
+      bliss::print_auts(aut_generators, oss, graph.vertex_labels);
+      CHECK(oss.str() == L"({i_3},{i_4})\n({i_1},{i_2})\n");
+      // std::wcout << oss.str() << std::endl;
+    }
+  }
+}
+
+namespace sequant {
+class TensorNetworkV3Accessor {
+ public:
+  auto get_canonical_bliss_graph(
+      sequant::TensorNetworkV3 tn,
+      const sequant::TensorNetwork::named_indices_t* named_indices = nullptr) {
+    tn.canonicalize_graph(named_indices ? *named_indices : tn.ext_indices_);
+    tn.init_edges();
+    auto graph = tn.create_graph(
+        {.named_indices = named_indices,
+         .make_labels = Logger::instance().canonicalize_dot,
+         .make_texlabels = Logger::instance().canonicalize_dot});
+    return std::make_pair(std::move(graph.bliss_graph), graph.vertex_labels);
+  }
+};
+}  // namespace sequant
+
+TEST_CASE("tensor_network_v3", "[elements]") {
+  using namespace sequant;
+  using namespace sequant::mbpt;
+  using sequant::Context;
+  namespace t = sequant::mbpt::tensor;
+  namespace o = sequant::mbpt::op;
+  using TN = TensorNetworkV3;
+
+  auto ctx_resetter = sequant::set_scoped_default_context(Context(
+      mbpt::make_sr_spaces(), Vacuum::SingleProduct, IndexSpaceMetric::Unit,
+      BraKetSymmetry::conjugate, SPBasis::spinorbital));
+
+  SECTION("Edges") {
+    using Vertex = TN::Vertex;
+    using Edge = TN::Edge;
+    using Origin = TN::Origin;
+
+    Vertex v1(Origin::Bra, 0, 1, Symmetry::antisymm);
+    Vertex v2(Origin::Bra, 0, 0, Symmetry::antisymm);
+    Vertex v3(Origin::Ket, 1, 0, Symmetry::symm);
+    Vertex v4(Origin::Ket, 1, 3, Symmetry::symm);
+    Vertex v5(Origin::Bra, 3, 0, Symmetry::nonsymm);
+    Vertex v6(Origin::Bra, 3, 2, Symmetry::nonsymm);
+    Vertex v7(Origin::Ket, 3, 1, Symmetry::nonsymm);
+    Vertex v8(Origin::Ket, 5, 0, Symmetry::symm);
+
+    const Index dummy(L"a_1");
+
+    REQUIRE_NOTHROW(Edge(v1, &dummy));
+    Edge e1(v1, &dummy);
+    e1.connect_to(v4);
+    // cleaner: give all vertices at once
+    REQUIRE_NOTHROW(Edge({v2, v3}, &dummy));
+    Edge e2({v2, v3}, &dummy);
+    Edge e3({v3, v5}, &dummy);
+    Edge e4({v4, v6}, &dummy);
+
+    // can't connect same vertex more than once
+    REQUIRE_THROWS_AS(Edge({v4, v6, v6}), std::invalid_argument);
+    REQUIRE_THROWS_AS(e4.connect_to(v6), std::invalid_argument);
+
+    Edge e5(v8, &dummy);
+    e5.connect_to(v6);
+    Edge e6(v8, &dummy);
+    // ket cannot connect to ket
+    REQUIRE_THROWS_AS(e6.connect_to(v7), std::invalid_argument);
+
+    // Due to tensor symmetries, these edges are considered equal
+    REQUIRE(e1 == e2);
+    REQUIRE(!(e1 < e2));
+    REQUIRE(!(e2 < e1));
+
+    // Smallest terminal index wins
+    REQUIRE(!(e1 == e3));
+    REQUIRE(e1 < e3);
+    REQUIRE(!(e3 < e1));
+
+    // For non-symmetric tensors the connection slot is taken into account
+    REQUIRE(!(e3 == e4));
+    REQUIRE(e3 < e4);
+    REQUIRE(!(e4 < e3));
+
+    // Unconnected edges always come before fully connected ones
+    REQUIRE(!(e6 == e1));
+    REQUIRE(e6 < e1);
+    REQUIRE(!(e1 < e6));
+
+    // aux edges, including hyperedges
+    {
+      Vertex v9(Origin::Aux, 3, 1, Symmetry::nonsymm);
+      Vertex v10(Origin::Aux, 5, 0, Symmetry::nonsymm);
+      Vertex v11(Origin::Aux, 6, 0, Symmetry::nonsymm);
+
+      REQUIRE_NOTHROW(Edge({v9, v10}, &dummy));
+      Edge e1({v9, v10}, &dummy);
+      REQUIRE_NOTHROW(Edge({v9, v10, v11}, &dummy));
+      Edge e2({v9, v10, v11}, &dummy);
+      // order of input vertices does not matter
+      Edge e2_copy({v11, v10, v9}, &dummy);
+      REQUIRE(e2 == e2_copy);
+
+      // can't connect aux to bra
+      REQUIRE_THROWS_AS(Edge({v9, v1}, &dummy), std::invalid_argument);
+      // can't connect aux to ket
+      REQUIRE_THROWS_AS(Edge({v9, v3}, &dummy), std::invalid_argument);
+
+      // edge < hyperedge
+      REQUIRE(!(e1 == e2));
+      REQUIRE(e1 < e2);
+    }
+  }
+
+  SECTION("constructors") {
+    {  // with Tensors
+      auto t1 = ex<Tensor>(L"F", bra{L"i_1"}, ket{L"i_2"});
+      auto t2 = ex<Tensor>(L"t", bra{L"i_2"}, ket{L"i_1"});
+      auto t1_x_t2 = t1 * t2;
+      REQUIRE_NOTHROW(TN(*t1_x_t2));
+
+      auto t1_x_t2_p_t2 = t1 * (t2 + t2);  // can only use a flat tensor product
+      REQUIRE_THROWS_AS(TN(*t1_x_t2_p_t2), std::invalid_argument);
+
+      // must be covariant: no bra to bra or ket to ket
+      t2->adjoint();
+      auto t1_x_t2_adjoint = t1 * t2;
+      REQUIRE_THROWS_AS(TN(t1_x_t2_adjoint), std::invalid_argument);
+
+      // can use hyperedges with aux indices
+      {
+        auto u1 = ex<Tensor>(L"u1", bra{L"i_1"}, ket{}, aux{L"p"});
+        auto u2 = ex<Tensor>(L"u2", bra{L"i_2"}, ket{}, aux{L"p"});
+        auto u3 = ex<Tensor>(L"u3", bra{L"i_3"}, ket{}, aux{L"p"});
+        REQUIRE_NOTHROW(TN(u1 * u2 * u3));
+        TN tn(u1 * u2 * u3);
+      }
+    }
+
+    {  // with NormalOperators
+      constexpr const auto V = Vacuum::SingleProduct;
+      auto t1 = ex<FNOperator>(cre({L"i_1"}), ann({L"i_2"}), V);
+      auto t2 = ex<FNOperator>(cre({L"i_2"}), ann({L"i_1"}), V);
+      auto t1_x_t2 = t1 * t2;
+      REQUIRE_NOTHROW(TN(*t1_x_t2));
+    }
+
+    {  // with Tensors and NormalOperators
+      auto tmp = t::A(nₚ(-2)) * t::H_(2) * t::T_(2) * t::T_(2);
+      REQUIRE_NOTHROW(TN(tmp->as<Product>().factors()));
+    }
+
+  }  // SECTION("constructors")
+
+  SECTION("accessors") {
+    {
+      constexpr const auto V = Vacuum::SingleProduct;
+      auto t1 = ex<Tensor>(L"F", bra{L"i_1"}, ket{L"i_2"});
+      auto t2 = ex<FNOperator>(cre({L"i_1"}), ann({L"i_3"}), V);
+      auto t1_x_t2 = t1 * t2;
+      REQUIRE_NOTHROW(TN(*t1_x_t2));
+      TN tn(*t1_x_t2);
+
+      // edges
+      auto edges = tn.edges();
+      REQUIRE(edges.size() == 3);
+
+      // ext indices
+      auto ext_indices = tn.ext_indices();
+      REQUIRE(ext_indices.size() == 2);
+
+      // tensors
+      auto tensors = tn.tensors();
+      REQUIRE(size(tensors) == 2);
+      REQUIRE(std::dynamic_pointer_cast<Expr>(tensors[0]));
+      REQUIRE(std::dynamic_pointer_cast<Expr>(tensors[1]));
+      REQUIRE(*std::dynamic_pointer_cast<Expr>(tensors[0]) == *t1);
+      REQUIRE(*std::dynamic_pointer_cast<Expr>(tensors[1]) == *t2);
+    }
+  }  // SECTION("accessors")
+
+  SECTION("canonicalizer") {
+    {  // with no external indices, hence no named indices whatsoever
+      Index::reset_tmp_index();
+      constexpr const auto V = Vacuum::SingleProduct;
+      auto t1 = ex<Tensor>(L"F", bra{L"i_1"}, ket{L"i_2"});
+      auto t2 = ex<FNOperator>(cre({L"i_1"}), ann({L"i_2"}), V);
+      auto t1_x_t2 = t1 * t2;
+      TN tn(*t1_x_t2);
+      tn.canonicalize(TensorCanonicalizer::cardinal_tensor_labels(), false);
+
+      REQUIRE(size(tn.tensors()) == 2);
+      REQUIRE(std::dynamic_pointer_cast<Expr>(tn.tensors()[0]));
+      REQUIRE(std::dynamic_pointer_cast<Expr>(tn.tensors()[1]));
+      //        std::wcout <<
+      //        to_latex(std::dynamic_pointer_cast<Expr>(tn.tensors()[0])) <<
+      //        std::endl; std::wcout <<
+      //        to_latex(std::dynamic_pointer_cast<Expr>(tn.tensors()[1])) <<
+      //        std::endl;
+      REQUIRE(to_latex(std::dynamic_pointer_cast<Expr>(tn.tensors()[0])) ==
+              L"{F^{{i_2}}_{{i_1}}}");
+      REQUIRE(to_latex(std::dynamic_pointer_cast<Expr>(tn.tensors()[1])) ==
+              L"{\\tilde{a}^{{i_1}}_{{i_2}}}");
+    }
+
+    {
+      Index::reset_tmp_index();
+      constexpr const auto V = Vacuum::SingleProduct;
+      auto t1 = ex<Tensor>(L"F", bra{L"i_2"}, ket{L"i_17"});
+      auto t2 = ex<FNOperator>(cre({L"i_2"}), ann({L"i_3"}), V);
+      auto t1_x_t2 = t1 * t2;
+
+      // with all external named indices
+      SECTION("implicit") {
+        TN tn(*t1_x_t2);
+        tn.canonicalize(TensorCanonicalizer::cardinal_tensor_labels(), false);
+
+        REQUIRE(size(tn.tensors()) == 2);
+        REQUIRE(std::dynamic_pointer_cast<Expr>(tn.tensors()[0]));
+        REQUIRE(std::dynamic_pointer_cast<Expr>(tn.tensors()[1]));
+        // std::wcout <<
+        // to_latex(std::dynamic_pointer_cast<Expr>(tn.tensors()[0])) <<
+        // std::endl; std::wcout <<
+        // to_latex(std::dynamic_pointer_cast<Expr>(tn.tensors()[1])) <<
+        // std::endl;
+        REQUIRE(to_latex(std::dynamic_pointer_cast<Expr>(tn.tensors()[1])) ==
+                L"{\\tilde{a}^{{i_1}}_{{i_3}}}");
+        REQUIRE(to_latex(std::dynamic_pointer_cast<Expr>(tn.tensors()[0])) ==
+                L"{F^{{i_{17}}}_{{i_1}}}");
+      }
+
+      // with explicit named indices
+      SECTION("explicit") {
+        Index::reset_tmp_index();
+        TN tn(*t1_x_t2);
+
+        using named_indices_t = TN::NamedIndexSet;
+        named_indices_t indices{Index{L"i_17"}};
+        tn.canonicalize(TensorCanonicalizer::cardinal_tensor_labels(), false,
+                        &indices);
+
+        REQUIRE(size(tn.tensors()) == 2);
+        REQUIRE(std::dynamic_pointer_cast<Expr>(tn.tensors()[0]));
+        REQUIRE(std::dynamic_pointer_cast<Expr>(tn.tensors()[1]));
+        //        std::wcout <<
+        //        to_latex(std::dynamic_pointer_cast<Expr>(tn.tensors()[0]))
+        //        << std::endl; std::wcout <<
+        //        to_latex(std::dynamic_pointer_cast<Expr>(tn.tensors()[1]))
+        //        << std::endl;
+        REQUIRE(to_latex(std::dynamic_pointer_cast<Expr>(tn.tensors()[1])) ==
+                L"{\\tilde{a}^{{i_2}}_{{i_1}}}");
+        REQUIRE(to_latex(std::dynamic_pointer_cast<Expr>(tn.tensors()[0])) ==
+                L"{F^{{i_{17}}}_{{i_2}}}");
+      }
+    }
+
+    SECTION("particle non-conserving") {
+      const auto input1 = parse_expr(L"P{;a1,a3}");
+      const auto input2 = parse_expr(L"P{a1,a3;}");
+      const std::wstring expected1 = L"{{P^{{a_1}{a_3}}_{}}}";
+      const std::wstring expected2 = L"{{P^{}_{{a_1}{a_3}}}}";
+
+      for (int variant : {1, 2}) {
+        for (bool fast : {true, false}) {
+          TN tn(std::vector<ExprPtr>{variant == 1 ? input1 : input2});
+          tn.canonicalize(TensorCanonicalizer::cardinal_tensor_labels(), fast);
+          REQUIRE(tn.tensors().size() == 1);
+          auto result = ex<Product>(to_tensors(tn.tensors()));
+          REQUIRE(to_latex(result) == (variant == 1 ? expected1 : expected2));
+        }
+      }
+    }
+
+    SECTION("non-symmetric") {
+      const auto input =
+          parse_expr(L"A{i9,i12;i7,i3}:A I1{i7,i3;;x5}:N I2{;i9,i12;x5}:N")
+              .as<Product>()
+              .factors();
+      const std::wstring expected =
+          L"A{i_1,i_2;i_3,i_4}:A * I1{i_3,i_4;;x_1}:N * I2{;i_1,i_2;x_1}:N";
+
+      for (bool fast : {true, false}) {
+        TN tn(input);
+        tn.canonicalize(TensorCanonicalizer::cardinal_tensor_labels(), fast);
+        const auto result = ex<Product>(to_tensors(tn.tensors()));
+        REQUIRE_THAT(result, SimplifiesTo(expected));
+      }
+    }
+
+    SECTION("particle-1,2-symmetry") {
+      const std::vector<std::pair<std::wstring, std::wstring>> pairs = {
+          {L"S{i_1,i_2,i_3;a_1,a_2,a_3}:N * f{i_4;i_2}:N * "
+           L"t{a_1,a_2,a_3;i_4,i_3,i_1}:N",
+           L"S{i_1,i_2,i_3;a_1,a_2,a_3}:N * f{i_4;i_1}:N * "
+           L"t{a_1,a_2,a_3;i_2,i_3,i_4}:N"},
+          {L"Γ{o_2,o_4;o_1,o_3}:N * g{i_1,o_1;o_2,e_1}:N * "
+           L"t{o_3,e_1;o_4,i_1}:N",
+           L"Γ{o_2,o_4;o_1,o_3}:N * g{i_1,o_3;o_4,e_1}:N * "
+           L"t{o_1,e_1;o_2,i_1}:N"}};
+      for (const auto& pair : pairs) {
+        const auto first = parse_expr(pair.first).as<Product>().factors();
+        const auto second = parse_expr(pair.second).as<Product>().factors();
+
+        TensorNetworkV3Accessor accessor;
+        auto [first_graph, first_labels] =
+            accessor.get_canonical_bliss_graph(TN(first));
+        auto [second_graph, second_labels] =
+            accessor.get_canonical_bliss_graph(TN(second));
+        if (first_graph->cmp(*second_graph) != 0) {
+          std::wstringstream stream;
+          stream << "First graph:\n";
+          first_graph->write_dot(stream, first_labels, {},
+                                 {.display_colors = true});
+          stream << "Second graph:\n";
+          second_graph->write_dot(stream, second_labels, {},
+                                  {.display_colors = true});
+          stream << "TN graph:\n";
+          auto [wick_graph, labels, texlabels, d1, d2] =
+              TensorNetwork(first).make_bliss_graph();
+          wick_graph->write_dot(stream, labels, texlabels,
+                                {.display_colors = true});
+
+          FAIL(to_string(stream.str()));
+        }
+
+        TN tn1(first);
+        TN tn2(second);
+
+        tn1.canonicalize(TensorCanonicalizer::cardinal_tensor_labels(), false);
+        tn2.canonicalize(TensorCanonicalizer::cardinal_tensor_labels(), false);
+
+        REQUIRE(tn1.tensors().size() == tn2.tensors().size());
+        for (std::size_t i = 0; i < tn1.tensors().size(); ++i) {
+          auto t1 = std::dynamic_pointer_cast<Expr>(tn1.tensors()[i]);
+          auto t2 = std::dynamic_pointer_cast<Expr>(tn2.tensors()[i]);
+          REQUIRE(t1);
+          REQUIRE(t2);
+          REQUIRE(to_latex(t1) == to_latex(t2));
+        }
+      }
+    }
+
+    SECTION("miscellaneous") {
+      const std::vector<std::pair<std::wstring, std::wstring>> inputs = {
+          {L"g{i_1,a_1;i_2,i_3}:A * I{i_2,i_3;i_1,a_1}:A",
+           L"g{i_1,a_1;i_2,i_3}:A * I{i_2,i_3;i_1,a_1}:A"},
+          {L"g{a_1,i_1;i_2,i_3}:A * I{i_2,i_3;i_1,a_1}:A",
+           L"-1 g{i_1,a_1;i_2,i_3}:A * I{i_2,i_3;i_1,a_1}:A"},
+
+          {L"g{i_1,a_1;i_2,i_3}:N * I{i_2,i_3;i_1,a_1}:N",
+           L"g{i_1,a_1;i_2,i_3}:N * I{i_2,i_3;i_1,a_1}:N"},
+          {L"g{a_1,i_1;i_2,i_3}:N * I{i_2,i_3;i_1,a_1}:N",
+           L"g{i_1,a_1;i_2,i_3}:N * I{i_3,i_2;i_1,a_1}:N"},
+      };
+
+      for (const auto& [input, expected] : inputs) {
+        const auto input_tensors = parse_expr(input).as<Product>().factors();
+
+        TN tn(input_tensors);
+        ExprPtr factor = tn.canonicalize(
+            TensorCanonicalizer::cardinal_tensor_labels(), true);
+
+        ExprPtr prod = to_product(tn.tensors());
+        if (factor) {
+          prod = ex<Product>(
+              prod.as<Product>().scale(factor.as<Constant>().value()));
+        }
+
+        REQUIRE_THAT(prod, SimplifiesTo(expected));
+      }
+    }
+
+    SECTION("special") {
+      auto factors =
+          parse_expr(
+              L"S{i_1;a_1<i_1>}:N-C-S g{i_2,a_1<i_1>;a_2<i_2>,i_1}:N-C-S "
+              L"t{a_2<i_2>;i_2}:N-C-S")
+              ->as<Product>()
+              .factors();
+
+      TN tn(factors);
+
+      ExprPtr factor =
+          tn.canonicalize(TensorCanonicalizer::cardinal_tensor_labels(), false);
+      ExprPtr result = to_product(tn.tensors());
+      if (factor) {
+        result *= factor;
+      }
+
+      REQUIRE(result);
+    }
+
+#ifndef SEQUANT_SKIP_LONG_TESTS
+    SECTION("Exhaustive SRCC example") {
+      // Note: the exact canonical form written here is implementation-defined
+      // and doesn't actually matter What does, is that all equivalent ways of
+      // writing it down, canonicalizes to the same exact form
+      const Product expectedExpr =
+          parse_expr(
+              L"A{i1,i2;a1,a2} g{i3,i4;a3,a4} t{a1,a3;i3,i4} t{a2,a4;i1,i2}",
+              Symmetry::antisymm)
+              .as<Product>();
+
+      const auto expected = expectedExpr.factors();
+
+      TensorNetworkV3Accessor accessor;
+      const auto [canonical_graph, canonical_graph_labels] =
+          accessor.get_canonical_bliss_graph(TN(expected));
+
+      //      std::wcout << "Canonical graph:\n";
+      //      canonical_graph->write_dot(std::wcout, canonical_graph_labels);
+      //      std::wcout << std::endl;
+
+      std::vector<Index> indices;
+      for (std::size_t i = 0; i < expected.size(); ++i) {
+        const Tensor& tensor = expected[i].as<Tensor>();
+        for (const Index& idx : tensor.indices()) {
+          if (std::find(indices.begin(), indices.end(), idx) == indices.end()) {
+            indices.push_back(idx);
+          }
+        }
+      }
+      std::sort(indices.begin(), indices.end());
+
+      const auto original_indices = indices;
+
+      // Make sure to clone all expressions in order to not accidentally
+      // modify the ones in expected (even though they are const... the
+      // pointer-like semantics of expressions messes with const semantics)
+      std::remove_const_t<decltype(expected)> factors;
+      for (const auto& factor : expected) {
+        factors.push_back(factor.clone());
+      }
+      std::sort(factors.begin(), factors.end());
+
+      const auto is_occ = [](const Index& idx) {
+        return idx.space() == Index(L"i_1").space();
+      };
+
+      // Iterate over all tensor permutations and all permutations of possible
+      // index name swaps
+      REQUIRE(std::is_sorted(factors.begin(), factors.end()));
+      REQUIRE(std::is_sorted(indices.begin(), indices.end()));
+      REQUIRE(std::is_partitioned(indices.begin(), indices.end(), is_occ));
+      REQUIRE(std::partition_point(indices.begin(), indices.end(), is_occ) ==
+              indices.begin() + 4);
+      std::size_t total_variations = 0;
+      do {
+        do {
+          do {
+            total_variations++;
+
+            // Compute index replacements
+            container::map<Index, Index> idxrepl;
+            for (std::size_t i = 0; i < indices.size(); ++i) {
+              REQUIRE(original_indices[i].space() == indices[i].space());
+
+              idxrepl.insert(
+                  std::make_pair(original_indices.at(i), indices.at(i)));
+            }
+
+            // Apply index replacements to a copy of the current tensor
+            // permutation
+            auto copy = factors;
+            for (ExprPtr& expr : copy) {
+              expr.as<Tensor>().transform_indices(idxrepl);
+              reset_tags(expr.as<Tensor>());
+            }
+
+            TN tn(copy);
+
+            // At the heart of our canonicalization lies the fact that we can
+            // always create the uniquely defined canonical graph for a given
+            // network
+            const auto [current_graph, current_graph_labels] =
+                accessor.get_canonical_bliss_graph(tn);
+            if (current_graph->cmp(*canonical_graph) != 0) {
+              std::wcout << "Canonical graph for " << deparse(ex<Product>(copy))
+                         << ":\n";
+              current_graph->write_dot(std::wcout, current_graph_labels);
+              std::wcout << std::endl;
+            }
+            REQUIRE(current_graph->cmp(*canonical_graph) == 0);
+
+            tn.canonicalize(TensorCanonicalizer::cardinal_tensor_labels(),
+                            false);
+
+            std::vector<ExprPtr> actual;
+            std::transform(tn.tensors().begin(), tn.tensors().end(),
+                           std::back_inserter(actual), [](const auto& t) {
+                             assert(std::dynamic_pointer_cast<Expr>(t));
+                             return std::dynamic_pointer_cast<Expr>(t);
+                           });
+
+            // The canonical graph must not change due to the other
+            // canonicalization steps we perform
+            REQUIRE(accessor.get_canonical_bliss_graph(TN(actual))
+                        .first->cmp(*canonical_graph) == 0);
+
+            REQUIRE(actual.size() == expected.size());
+
+            if (!std::equal(expected.begin(), expected.end(), actual.begin())) {
+              std::wostringstream sstream;
+              sstream
+                  << "Expected all tensors to be equal (actual == expected), "
+                     "but got:\n";
+              for (std::size_t i = 0; i < expected.size(); ++i) {
+                std::wstring equality =
+                    actual[i] == expected[i] ? L" == " : L" != ";
+
+                sstream << deparse(actual[i]) << equality
+                        << deparse(expected[i]) << "\n";
+              }
+              sstream << "\nInput was " << deparse(ex<Product>(factors))
+                      << "\n";
+              FAIL(to_string(sstream.str()));
+            }
+          } while (std::next_permutation(indices.begin() + 4, indices.end()));
+        } while (std::next_permutation(indices.begin(), indices.begin() + 4));
+      } while (std::next_permutation(factors.begin(), factors.end()));
+
+      // 4! (tensors) * 4! (internal indices) * 4! (external indices)
+      REQUIRE(total_variations == 24 * 24 * 24);
+    }
+#endif
+
+    SECTION("idempotency") {
+      const std::vector<std::wstring> inputs = {
+          L"F{i1;i8} g{i8,i9;i1,i7}",
+          L"A{i9,i12;i7,i3}:A I1{i7,i3;;x5}:N I2{;i9,i12;x5}:N",
+          L"f{i4;i1}:N t{a1,a2,a3;i2,i3,i4}:N S{i1,i2,i3;a1,a2,a3}:N",
+          L"P{a1,a3;} k{i8;i2}",
+          L"L{x6;;x2} P{;a1,a3}",
+      };
+
+      for (const std::wstring& current : inputs) {
+        auto factors1 = parse_expr(current).as<Product>().factors();
+        auto factors2 = parse_expr(current).as<Product>().factors();
+
+        TN reference_tn(factors1);
+        reference_tn.canonicalize(TensorCanonicalizer::cardinal_tensor_labels(),
+                                  false);
+
+        TN check_tn(factors2);
+        check_tn.canonicalize(TensorCanonicalizer::cardinal_tensor_labels(),
+                              false);
+
+        REQUIRE(to_latex(to_product(reference_tn.tensors())) ==
+                to_latex(to_product(check_tn.tensors())));
+
+        for (bool fast : {true, false, true, true, false, false, true}) {
+          reference_tn.canonicalize(
+              TensorCanonicalizer::cardinal_tensor_labels(), fast);
+
+          REQUIRE(to_latex(to_product(reference_tn.tensors())) ==
+                  to_latex(to_product(check_tn.tensors())));
+        }
+      }
+    }  // SECTION("idempotency")
+
+  }  // SECTION("canonicalizer")
+
+  SECTION("misc1") {
+    if (false) {
+      Index::reset_tmp_index();
+      // TN1 from manuscript
+      auto g = ex<Tensor>(L"g", bra{L"i_3", L"i_4"}, ket{L"a_3", L"a_4"},
+                          Symmetry::antisymm);
+      auto ta = ex<Tensor>(L"t", bra{L"a_1", L"a_3"}, ket{L"i_1", L"i_2"},
+                           Symmetry::antisymm);
+      auto tb = ex<Tensor>(L"t", bra{L"a_2", L"a_4"}, ket{L"i_3", L"i_4"},
+                           Symmetry::antisymm);
+
+      auto tmp = g * ta * tb;
+      // std::wcout << "TN1 = " << to_latex(tmp) << std::endl;
+      TN tn(tmp->as<Product>().factors());
+
+      // make graph
+      // N.B. treat all indices as dummy so that the automorphism ignores the
+      using named_indices_t = TN::NamedIndexSet;
+      named_indices_t indices{};
+      REQUIRE_NOTHROW(tn.create_graph({.named_indices = &indices}));
+      TN::Graph graph = tn.create_graph({.named_indices = &indices});
 
       // can disable label production
       {

--- a/tests/unit/test_tensor_network.cpp
+++ b/tests/unit/test_tensor_network.cpp
@@ -1925,7 +1925,7 @@ TEST_CASE("tensor_network_v3", "[elements]") {
   }  // SECTION("canonicalizer")
 
   SECTION("misc1") {
-    if (false) {
+    if (true) {
       Index::reset_tmp_index();
       // TN1 from manuscript
       auto g = ex<Tensor>(L"g", bra{L"i_3", L"i_4"}, ket{L"a_3", L"a_4"},
@@ -1986,8 +1986,13 @@ TEST_CASE("tensor_network_v3", "[elements]") {
 
       std::basic_ostringstream<wchar_t> oss;
       bliss::print_auts(aut_generators, oss, graph.vertex_labels);
-      CHECK(oss.str() == L"({i_3},{i_4})\n({i_1},{i_2})\n");
-      // std::wcout << oss.str() << std::endl;
+      auto split_into_lines = [](const std::wstring& str) {
+        return str | ranges::views::split(L'\n') |
+               ranges::to<container::set<std::wstring>>();
+      };
+      CHECK(split_into_lines(oss.str()) ==
+            split_into_lines(L"(ket_1,ket_2)(i_1,i_2)\n(bra_1,bra_2)(ket_1,ket_"
+                             L"2)(i_3,i_4)\n"));
     }
   }
 }

--- a/tests/unit/test_tensor_network.cpp
+++ b/tests/unit/test_tensor_network.cpp
@@ -72,7 +72,7 @@ TEMPLATE_TEST_CASE("tensor_network_shared", "[elements]", TensorNetwork,
 
       // Case 7: with protoindices
 
-      auto& l = Logger::instance();
+      [[maybe_unused]] auto& l = Logger::instance();
       //      l.tensor_network = l.canonicalize = l.canonicalize_dot =
       //          l.canonicalize_input_graph = true;
 
@@ -238,7 +238,7 @@ TEMPLATE_TEST_CASE("tensor_network_shared", "[elements]", TensorNetwork,
     SECTION("Named index ordering") {
       REQUIRE(IndexSpace("i") < IndexSpace("a"));
 
-      for (const auto [input, str_indices] :
+      for (const auto& [input, str_indices] :
            std::vector<std::pair<std::wstring, std::vector<std::wstring>>>{
                {L"G{;;a1,a2,a3,a4} T{;;i3,i2,a3,a4}",
                 {L"i_2", L"i_3", L"a_1", L"a_2"}},

--- a/tests/unit/test_wick.cpp
+++ b/tests/unit/test_wick.cpp
@@ -972,7 +972,7 @@ TEST_CASE("wick", "[algorithms][wick]") {
       }    // use_nop_partitions
     });
 
-    // 2=body ^ 1-body ^ 2-body with dependent (PNO) indices
+    // 2-body ^ 1-body ^ 2-body with dependent (PNO) indices
     SEQUANT_PROFILE_SINGLE("wick(P2*H1*T2)", {
       auto opseq =
           ex<FNOperatorSeq>(FNOperator(cre({L"i_1", L"i_2"}),
@@ -1007,21 +1007,6 @@ TEST_CASE("wick", "[algorithms][wick]") {
           std::make_shared<DefaultTensorCanonicalizer>());
       canonicalize(wick_result_2);
       rapid_simplify(wick_result_2);
-
-      //    std::wcout << L"P2*H1*T2(PNO) = " << to_latex_align(wick_result_2)
-      //               << std::endl;
-      // it appears that the two terms are swapped when using gcc 8 on linux
-      // TODO investigate why sum canonicalization seems to produce
-      // platform-dependent results.
-      //      REQUIRE(to_latex(wick_result_2) ==
-      //              L"{ \\bigl( - {{{8}}"
-      //              L"{A^{{a_1^{{i_1}{i_2}}}{a_2^{{i_1}{i_2}}}}_{{i_1}{i_2}}}{f^{{a_"
-      //              L"3^{{i_1}{i_2}}}}_{{a_1^{{i_1}{i_2}}}}}{t^{{i_1}{i_2}}_{{a_2^{{"
-      //              L"i_1}{i_2}}}{a_3^{{i_1}{i_2}}}}}} + {{{8}}"
-      //              L"{A^{{a_1^{{i_1}{i_2}}}{a_2^{{i_1}{i_2}}}}_{{i_1}{i_2}}}{f^{{i_"
-      //              L"1}}_{{i_3}}}{t^{{i_2}{i_3}}_{{a_3^{{i_2}{i_3}}}{a_4^{{i_2}{i_3}"
-      //              L"}}}}{s^{{a_3^{{i_2}{i_3}}}}_{{a_1^{{i_1}{i_2}}}}}{s^{{a_4^{{i_"
-      //              L"2}{i_3}}}}_{{a_2^{{i_1}{i_2}}}}}}\\bigr) }");
     });
 
     // 2=body ^ 2-body ^ 2-body ^ 2-body with dependent (PNO) indices

--- a/utilities/tensor_network_graphs.cpp
+++ b/utilities/tensor_network_graphs.cpp
@@ -4,6 +4,7 @@
 #include <SeQuant/core/tensor.hpp>
 #include <SeQuant/core/tensor_network.hpp>
 #include <SeQuant/core/tensor_network_v2.hpp>
+#include <SeQuant/core/tensor_network_v3.hpp>
 #include <SeQuant/domain/mbpt/context.hpp>
 #include <SeQuant/domain/mbpt/convention.hpp>
 
@@ -21,9 +22,10 @@ std::wstring from_utf8(std::string_view str) {
   return converter.from_bytes(std::string(str));
 }
 
-std::optional<TensorNetwork> to_network(const ExprPtr &expr) {
+template <typename TN>
+std::optional<TN> make_tn(const ExprPtr &expr) {
   if (expr.is<Tensor>()) {
-    return TensorNetwork({expr});
+    return TN({expr});
   } else if (expr.is<Product>()) {
     for (const ExprPtr &factor : expr.as<Product>().factors()) {
       if (!factor.is<Tensor>()) {
@@ -31,23 +33,7 @@ std::optional<TensorNetwork> to_network(const ExprPtr &expr) {
       }
     }
 
-    return TensorNetwork(expr.as<Product>().factors());
-  } else {
-    return {};
-  }
-}
-
-std::optional<TensorNetworkV2> to_network_v2(const ExprPtr &expr) {
-  if (expr.is<Tensor>()) {
-    return TensorNetworkV2({expr});
-  } else if (expr.is<Product>()) {
-    for (const ExprPtr &factor : expr.as<Product>().factors()) {
-      if (!factor.is<Tensor>()) {
-        return {};
-      }
-    }
-
-    return TensorNetworkV2(expr.as<Product>().factors());
+    return TN(expr.as<Product>().factors());
   } else {
     return {};
   }
@@ -62,6 +48,7 @@ void print_help() {
   std::wcout << "Options:\n";
   std::wcout << "  --help     Shows this help message\n";
   std::wcout << "  --v2       Use TensorNetworkV2\n";
+  std::wcout << "  --v3       Use TensorNetworkV3\n";
   std::wcout << "  --no-named Treat all indices as unnamed (even if they are "
                 "external)\n";
 }
@@ -73,7 +60,7 @@ int main(int argc, char **argv) {
       BraKetSymmetry::conjugate, SPBasis::spinorbital));
 
   bool use_named_indices = true;
-  bool use_tnv2 = false;
+  int version = 1;
   const TensorNetwork::named_indices_t empty_named_indices;
 
   if (argc <= 1) {
@@ -90,7 +77,10 @@ int main(int argc, char **argv) {
       use_named_indices = false;
       continue;
     } else if (current == L"--v2") {
-      use_tnv2 = true;
+      version = 2;
+      continue;
+    } else if (current == L"--v3") {
+      version = 3;
       continue;
     }
 
@@ -104,8 +94,8 @@ int main(int argc, char **argv) {
     }
     assert(expr);
 
-    if (!use_tnv2) {
-      std::optional<TensorNetwork> network = to_network(expr);
+    if (version == 1) {
+      std::optional<TensorNetwork> network = make_tn<TensorNetwork>(expr);
       if (!network.has_value()) {
         std::wcout << "Failed to construct tensor network for input '"
                    << to_latex(expr) << "'" << std::endl;
@@ -119,18 +109,27 @@ int main(int argc, char **argv) {
       std::wcout << "Graph for '" << to_latex(expr) << "'\n";
       graph->write_dot(std::wcout, vlabels);
     } else {
-      std::optional<TensorNetworkV2> network = to_network_v2(expr);
-      if (!network.has_value()) {
-        std::wcout << "Failed to construct tensor network for input '"
-                   << to_latex(expr) << "'" << std::endl;
-        return 2;
-      }
+      auto make_graph = [&](auto *tn_ptr) {
+        using TN = std::decay_t<decltype(*tn_ptr)>;
+        std::optional<TN> network = make_tn<TN>(expr);
+        if (!network.has_value()) {
+          std::wcout << "Failed to construct tensor network for input '"
+                     << to_latex(expr) << "'" << std::endl;
+          return 2;
+        }
 
-      TensorNetworkV2::Graph graph = network->create_graph(
-          {.named_indices =
-               use_named_indices ? nullptr : &empty_named_indices});
-      std::wcout << "Graph for '" << to_latex(expr) << "'\n";
-      graph.bliss_graph->write_dot(std::wcout, graph.vertex_labels);
+        auto graph = network->create_graph(
+            {.named_indices =
+                 use_named_indices ? nullptr : &empty_named_indices});
+        std::wcout << "Graph for '" << to_latex(expr) << "'\n";
+        graph.bliss_graph->write_dot(std::wcout, graph.vertex_labels);
+      };
+      if (version == 2)
+        make_graph(static_cast<TensorNetworkV2 *>(nullptr));
+      else if (version == 3)
+        make_graph(static_cast<TensorNetworkV3 *>(nullptr));
+      else
+        abort();
     }
   }
 }


### PR DESCRIPTION
TN versions 1 and 2 cannot ensure that the canonical order is independent of arbitrary reorderings and renamings of input slots and tensors. For example, TNV1 did not reorder slots (i.e. places where indices can be placed, such as bra slots, ket slots, aux slots) or slot bundles (braket slot pairs, etc.) as part of the canonical reorder, and only required local (fast) recanonicalization. TNV2 tried to fix this partially (for nonsymmetric tensors), but did not do this correctly.

Version 3 of TensorNetwork tries to fix most of these issues.

P.S. It is still possible for index coloring to produce color collisions which will make colors, hence canonical order dependent on the input order.