### PR TITLE
amends #354

### DIFF
--- a/SeQuant/core/abstract_tensor.hpp
+++ b/SeQuant/core/abstract_tensor.hpp
@@ -222,8 +222,8 @@ class AbstractTensor {
   }
   /// permutes braket slot groups according to @p perm
   /// @param perm from-permutation, i.e. Index pair in slot `permutation[i]`
-  /// will be in slot `i`
-  virtual void _permute_braket(std::span<const std::size_t> perm) {
+  /// will end up in slot `i`
+  virtual void _permute_braket(std::span<std::size_t> perm) {
     permute_braket_impl(_bra_mutable(), _ket_mutable(), perm);
   }
 
@@ -264,7 +264,7 @@ class AbstractTensor {
 
   static void permute_braket_impl(AbstractTensor::any_view_randsz bra_indices,
                                   any_view_randsz ket_indices,
-                                  std::span<const std::size_t> perm) {
+                                  std::span<std::size_t> perm_from) {
     const auto n = std::max(bra_indices.size(), ket_indices.size());
     assert(n == perm.size());
 
@@ -519,8 +519,7 @@ inline void permute_ket(AbstractTensor& t, std::span<const std::size_t> perm) {
 /// @param t reference to an AbstractTensor object
 /// @param perm from-permutation, i.e. Index pair in input slot `permutation[i]`
 /// will be in slot `i`
-inline void permute_braket(AbstractTensor& t,
-                           std::span<const std::size_t> perm) {
+inline void permute_braket(AbstractTensor& t, std::span<std::size_t> perm) {
   return t._permute_braket(perm);
 }
 

--- a/SeQuant/core/abstract_tensor.hpp
+++ b/SeQuant/core/abstract_tensor.hpp
@@ -126,8 +126,8 @@ class AbstractTensor {
   }
   /// accesses bra, ket, and aux indices
   /// @return view of a not necessarily contiguous range of Index objects
-  virtual const_any_view_rand _indices() const {
-    throw missing_instantiation_for("_indices");
+  virtual const_any_view_rand _braketaux() const {
+    throw missing_instantiation_for("_braketaux");
   }
   /// @return the number of bra indices (some may be null, hence this is the
   /// gross rank)
@@ -296,7 +296,7 @@ class AbstractTensor {
 /// objects.
 /// @{
 inline auto braket(const AbstractTensor& t) { return t._braket(); }
-inline auto indices(const AbstractTensor& t) { return t._indices(); }
+inline auto indices(const AbstractTensor& t) { return t._braketaux(); }
 inline auto bra_rank(const AbstractTensor& t) { return t._bra_rank(); }
 inline auto bra_net_rank(const AbstractTensor& t) { return t._bra_net_rank(); }
 inline auto ket_rank(const AbstractTensor& t) { return t._ket_rank(); }

--- a/SeQuant/core/abstract_tensor.hpp
+++ b/SeQuant/core/abstract_tensor.hpp
@@ -54,9 +54,10 @@ class TensorCanonicalizer;
 ///
 /// Tensors can have the following symmetries:
 /// - Tensors can be symmetric or nonsymmetric with respect to the transposition
-///   of corresponding (first, second, etc.) modes in bra/ket mode ranges. This
-///   symmetry is used to treat particle as indistinguishable or distinguishable
-///   in many-particle quantum mechanics context.
+///   of corresponding {bra,ket} modes in bra/ket mode ranges. This
+///   symmetry is used to treat particles as indistinguishable or
+///   distinguishable in physical simulation. See more below on how such mode
+///   _bundles_ are handled.
 /// - Tensors can be symmetric, antisymmetric, and nonsymmetric
 ///   with respect to the transposition of modes within the bra or ket sets.
 ///   This symmetry is used to model the
@@ -67,8 +68,26 @@ class TensorCanonicalizer;
 ///   swap of bra with ket. This symmetry corresponds to time reversal in
 ///   physical simulation.
 ///
-/// Lastly, the supporting rings are not assumed to be scalars, hence tensor
+/// The supporting rings are not assumed to be scalars, hence tensor
 /// product supporting the concept of tensor is not necessarily commutative.
+///
+/// For some applications the pairing of bra and ket modes is important, hence
+/// it is necessary to support not only tensors where first bra mode is paired
+/// with the first ket, but it is then necessary to support bra and ket
+/// modes that are unpaired. This introduces notion of bra/ket _slots_.
+/// A slot is either occupied by a non-null Index (hence corresponds to a bra
+/// or ket mode), or empty (i.e., occupied by a null Index).
+/// Tensors with non-symmetric bras and kets can have empty slots in arbitrary
+/// positions in bra and ket slot bundles. Such tensors symmetric with
+/// respect to reordering of braket bundles (`_particle_symmetry()`)
+/// assume the canonical order of slots, defined as follows:
+/// - paired braket slot bundles (both bra and ket slots are nonempty) appear
+///    first
+/// - unpaired bra slots appear next (with ket slots empty, or without
+///   altogether is there are no unpaired ket slots)
+/// - unpaired ket slots appear next (without matching bra slots).
+///
+/// Empty aux slots are not permitted.
 ///
 /// \note This interface class defines a Tensor _concept_. All Tensor objects
 /// must fulfill the is_tensor trait (see below). To adapt an existing class
@@ -103,13 +122,15 @@ class AbstractTensor {
       ranges::any_view<Index&, ranges::category::random_access |
                                    ranges::category::sized>;
 
-  /// accessor bra indices
-  /// @return view of a contiguous range of bra Index objects
+  /// accessor for bra slots
+  /// @return view of a contiguous range of bra Index objects; empty slots
+  /// may be empty (i.e., occupied by null indices).
   virtual const_any_view_randsz _bra() const {
     throw missing_instantiation_for("_bra");
   }
-  /// accesses ket indices
-  /// @return view of a contiguous range of ket Index objects
+  /// accesses ket slots
+  /// @return view of a contiguous range of ket Index objects; empty slots
+  /// may be empty (i.e., occupied by null indices).
   virtual const_any_view_randsz _ket() const {
     throw missing_instantiation_for("_ket");
   }
@@ -118,9 +139,8 @@ class AbstractTensor {
   virtual const_any_view_randsz _aux() const {
     throw missing_instantiation_for("_aux");
   }
-  /// accesses bra and ket indices
-  /// @return concatenated (hence, non contiguous) view of bra and ket Index
-  /// objects
+  /// accesses bra and ket slots
+  /// @return concatenated (hence, non contiguous) view of bra and ket slots
   virtual const_any_view_rand _braket() const {
     throw missing_instantiation_for("_braket");
   }
@@ -129,25 +149,25 @@ class AbstractTensor {
   virtual const_any_view_rand _braketaux() const {
     throw missing_instantiation_for("_braketaux");
   }
-  /// @return the number of bra indices (some may be null, hence this is the
+  /// @return the number of bra slots (some may be empty, hence this is the
   /// gross rank)
   virtual std::size_t _bra_rank() const {
     throw missing_instantiation_for("_bra_rank");
   }
-  /// @return the number of nonnull bra indices
+  /// @return the number of nonempty bra slots (i.e., nonnull bra indices)
   virtual std::size_t _bra_net_rank() const {
     throw missing_instantiation_for("_bra_net_rank");
   }
-  /// @return the number of ket indices (some may be null, hence this is the
+  /// @return the number of bra slots (some may be empty, hence this is the
   /// gross rank)
   virtual std::size_t _ket_rank() const {
     throw missing_instantiation_for("_ket_rank");
   }
-  /// @return the number of nonnull ket indices
+  /// @return the number of nonempty ket slots (i.e., nonnull bra indices)
   virtual std::size_t _ket_net_rank() const {
     throw missing_instantiation_for("_ket_net_rank");
   }
-  /// @return the number of aux indices
+  /// @return the number of aux slots
   virtual std::size_t _aux_rank() const {
     throw missing_instantiation_for("_aux_rank");
   }
@@ -266,22 +286,55 @@ class AbstractTensor {
                                   any_view_randsz ket_indices,
                                   std::span<std::size_t> perm_from) {
     const auto n = std::max(bra_indices.size(), ket_indices.size());
-    assert(n == perm.size());
+    assert(n == perm_from.size());
 
-    // N.B. currently bra/ket are left aligned, i.e. there are no empty slots in
-    // the middle of bra/ket this means permutations should not mix braket slots
-    // with 2 and 1 indices
+    // N.B. braket slot bundles are kept in canonical order, see AbstractTensor
+    // class dox: paired bundles first, then bra (paired with null ket) and
+    // ket (unpaired).
+
+    // 1. count each type of bundles
+    std::size_t npaired = 0;
+    std::size_t nunpaired_bra = 0;
+    for (const auto& [bra_idx, ket_idx] :
+         ranges::views::zip(bra_indices, ket_indices)) {
+      if (bra_idx.nonnull()) {
+        if (ket_idx.nonnull())
+          ++npaired;
+        else
+          ++nunpaired_bra;
+      }
+    }
+    // corner case: there are only unpaired bra slots, no unpaired ket slots
+    if (bra_indices.size() > ket_indices.size()) {
+      assert(ket_indices.size() == npaired);
+      nunpaired_bra += bra_indices.size() - ket_indices.size();
+    }
+
+    // adjust perm to ensure that different types of bundles do not mix
+    // this ends up just a simple stable sort according to the bundle type
+    // i.e. bring elements of perm_from with values [0,npaired) to the front,
+    // etc.
+    ranges::stable_sort(perm_from, [&](const auto& i, const auto j) {
+      enum { paired = 0, bra_unpaired = 1, ket_unpaired = 2 };
+      auto to_type = [&](const auto& i) {
+        if (i < npaired)
+          return paired;
+        else if (i < npaired + nunpaired_bra)
+          return bra_unpaired;
+        else
+          return ket_unpaired;
+      };
+      return to_type(i) < to_type(j);
+    });
 
     container::svector<std::pair<Index, Index>> sorted_indices(n);
     for (std::size_t i = 0; i != bra_indices.size(); ++i) {
-      assert(perm[i] < bra_indices.size());  // this asserts that 2-index slots
-                                             // do not mix with 1-index slots
-      sorted_indices[i].first = std::move(bra_indices[perm[i]]);
+      assert(perm_from[i] < bra_indices.size());
+      sorted_indices[i].first = std::move(bra_indices[perm_from[i]]);
     }
     for (std::size_t i = 0; i != ket_indices.size(); ++i) {
-      assert(perm[i] < ket_indices.size());  // this asserts that 2-index slots
-                                             // do not mix with 1-index slots
-      sorted_indices[i].second = std::move(ket_indices[perm[i]]);
+      assert(perm_from[i] < ket_indices.size());
+      sorted_indices[i].second = std::move(ket_indices[perm_from[i]]);
     }
     for (std::size_t i = 0; i != bra_indices.size(); ++i) {
       bra_indices[i] = std::move(sorted_indices[i].first);

--- a/SeQuant/core/eval_expr.cpp
+++ b/SeQuant/core/eval_expr.cpp
@@ -39,7 +39,7 @@ namespace {
 size_t hash_terminal_tensor(Tensor const&) noexcept;
 
 bool is_tot(Tensor const& t) noexcept {
-  return ranges::any_of(t.const_indices(), &Index::has_proto_indices);
+  return ranges::any_of(t.const_braketaux_indices(), &Index::has_proto_indices);
 }
 
 }  // namespace
@@ -88,7 +88,7 @@ EvalExpr::EvalExpr(Tensor const& tnsr)
   } else {
     hash_value_ = hash_terminal_tensor(tnsr);
     canon_phase_ = 1;
-    canon_indices_ = tnsr.indices() | ranges::to<index_vector>;
+    canon_indices_ = tnsr.braketaux_indices() | ranges::to<index_vector>;
   }
 }
 
@@ -197,7 +197,7 @@ size_t hash_indices(T const& indices) noexcept {
 size_t hash_terminal_tensor(Tensor const& tnsr) noexcept {
   size_t h = 0;
   hash::combine(h, hash::value(tnsr.label()));
-  hash::combine(h, hash_indices(tnsr.const_indices()));
+  hash::combine(h, hash_indices(tnsr.const_braketaux()));
   return h;
 }
 

--- a/SeQuant/core/eval_expr.hpp
+++ b/SeQuant/core/eval_expr.hpp
@@ -245,18 +245,19 @@ class EvalExprBTAS final : public EvalExpr {
   ///         of the labels of indices in \c bk
   ///
   template <typename Iterable>
-  static auto index_hash(Iterable const& bk) {
-    return ranges::views::transform(bk, [](auto const& idx) {
-      //
-      // WARNING!
-      // The BTAS uses long for scalar indexing by default.
-      // Hence, here we explicitly cast the size_t values to long
-      // Which is a potentially narrowing conversion leading to
-      // integral overflow. Hence, the values in the returned
-      // container are mixed negative and positive integers (long type)
-      //
-      return static_cast<long>(sequant::hash::value(Index{idx}.label()));
-    });
+  static auto index_hash(Iterable&& bk) {
+    return ranges::views::transform(
+        std::forward<Iterable>(bk), [](auto const& idx) {
+          //
+          // WARNING!
+          // The BTAS uses long for scalar indexing by default.
+          // Hence, here we explicitly cast the size_t values to long
+          // Which is a potentially narrowing conversion leading to
+          // integral overflow. Hence, the values in the returned
+          // container are mixed negative and positive integers (long type)
+          //
+          return static_cast<long>(sequant::hash::value(Index{idx}.label()));
+        });
   }
 
   template <typename... Args, typename = std::enable_if_t<

--- a/SeQuant/core/eval_node.hpp
+++ b/SeQuant/core/eval_node.hpp
@@ -34,8 +34,8 @@ namespace {
 enum NodePos { Left = 0, Right, This };
 
 [[maybe_unused]] std::pair<size_t, size_t> occ_virt(Tensor const& t) {
-  auto bk_rank = t.bra_rank() + t.ket_rank();
-  auto nocc = ranges::count_if(t.const_braket(), [](Index const& idx) {
+  auto bk_rank = t.bra_net_rank() + t.ket_net_rank();
+  auto nocc = ranges::count_if(t.const_braket_indices(), [](Index const& idx) {
     return idx.space() ==
            get_default_context().index_space_registry()->hole_space(
                idx.space().qns());

--- a/SeQuant/core/export/itf.cpp
+++ b/SeQuant/core/export/itf.cpp
@@ -566,7 +566,7 @@ std::wstring ITFGenerator::generate() const {
 
   // Tensor declarations
   for (const Tensor &current : m_importedTensors) {
-    if (current.indices().size() == 0 && current.label() == L"One") {
+    if (current.braketaux().size() == 0 && current.label() == L"One") {
       // The One[] tensor exists implicitly
       continue;
     }
@@ -576,13 +576,13 @@ std::wstring ITFGenerator::generate() const {
   }
   itf += L"\n";
   for (const Tensor &current : m_createdTensors) {
-    if (current.indices().size() == 0 && current.label() == L"One") {
+    if (current.braketaux().size() == 0 && current.label() == L"One") {
       // The One[] tensor exists implicitly
       continue;
     }
 
     itf += L"tensor: " + to_itf(current, *m_ctx);
-    if (current.indices().size() > 0) {
+    if (current.braketaux().size() > 0) {
       itf += +L", !Create{type:disk}\n";
     } else {
       itf += +L", !Create{type:scalar}\n";

--- a/SeQuant/core/op.hpp
+++ b/SeQuant/core/op.hpp
@@ -836,7 +836,7 @@ class NormalOperator : public Operator<S>,
            ranges::views::transform(
                [](auto &&op) -> const Index & { return op.index(); });
   }
-  AbstractTensor::const_any_view_rand _indices() const override final {
+  AbstractTensor::const_any_view_rand _braketaux() const override final {
     return _braket();
   }
   std::size_t _bra_rank() const override final { return nannihilators(); }

--- a/SeQuant/core/space.hpp
+++ b/SeQuant/core/space.hpp
@@ -448,9 +448,26 @@ class IndexSpace {
   explicit IndexSpace(std::wstring_view label);
 
   IndexSpace(const IndexSpace &other) = default;
-  IndexSpace(IndexSpace &&other) = default;
+  /// move constructor
+  /// @param other[in,out] on output is null
+  /// @post state of this object is identical to the input state of @p other
+  IndexSpace(IndexSpace &&other) noexcept
+      : attr_(std::move(other.attr_)),
+        base_key_(std::move(other.base_key_)),
+        approximate_size_(std::move(other.approximate_size_)) {
+    other = null;
+  }
   IndexSpace &operator=(const IndexSpace &other) = default;
-  IndexSpace &operator=(IndexSpace &&other) = default;
+  /// move constructor
+  /// @param other[in,out] on output is null
+  /// @post state of this object is identical to the input state of @p other
+  IndexSpace &operator=(IndexSpace &&other) {
+    attr_ = std::move(other.attr_);
+    base_key_ = std::move(other.base_key_);
+    approximate_size_ = std::move(other.approximate_size_);
+    other = null;
+    return *this;
+  }
 
   const std::wstring &base_key() const { return base_key_; }
   static std::wstring_view reduce_key(std::wstring_view key) {

--- a/SeQuant/core/tensor.hpp
+++ b/SeQuant/core/tensor.hpp
@@ -648,7 +648,7 @@ class Tensor : public Expr, public AbstractTensor, public Labeled {
   AbstractTensor::const_any_view_rand _braket() const override final {
     return braket();
   }
-  AbstractTensor::const_any_view_rand _indices() const override final {
+  AbstractTensor::const_any_view_rand _braketaux() const override final {
     return braketaux();
   }
   std::size_t _bra_rank() const override final { return bra_rank(); }

--- a/SeQuant/core/tensor_network_v2.cpp
+++ b/SeQuant/core/tensor_network_v2.cpp
@@ -1074,6 +1074,8 @@ void TensorNetworkV2::init_edges() {
   pure_proto_indices_.clear();
 
   auto idx_insert = [this](const Index &idx, Vertex vertex) {
+    if (idx.nonnull() == false) return;
+
     if (Logger::instance().tensor_network) {
       std::wcout << "TensorNetworkV2::init_edges: idx=" << to_latex(idx)
                  << " attached to tensor " << vertex.getTerminalIndex() << " ("

--- a/SeQuant/core/utility/expr.cpp
+++ b/SeQuant/core/utility/expr.cpp
@@ -168,9 +168,9 @@ std::string toplevel_diff(const Tensor &lhs, const Tensor &rhs) {
            to_string(rhs.label());
   }
 
-  if (lhs.indices().size() != rhs.indices().size()) {
-    return std::to_string(lhs.indices().size()) + " indices vs. " +
-           std::to_string(rhs.indices().size()) + " indices";
+  if (lhs.braketaux().size() != rhs.braketaux().size()) {
+    return std::to_string(lhs.braketaux().size()) + " indices vs. " +
+           std::to_string(rhs.braketaux().size()) + " indices";
   }
 
   if (lhs.symmetry() != rhs.symmetry()) {

--- a/SeQuant/core/utility/strong.hpp
+++ b/SeQuant/core/utility/strong.hpp
@@ -303,6 +303,7 @@ class strong_type_base {
 #define DEFINE_STRONG_TYPE_FOR_RANGE(ID)                                       \
   template <typename T>                                                        \
   struct ID : detail::strong_type_base<T, ID<T>> {                             \
+    using value_type = T;                                                      \
     using base_type = detail::strong_type_base<T, ID<T>>;                      \
     using base_type::base_type;                                                \
     using base_type::operator=;                                                \
@@ -336,6 +337,7 @@ class strong_type_base {
 #ifndef DEFINE_STRONG_TYPE_FOR_INTEGER
 #define DEFINE_STRONG_TYPE_FOR_INTEGER(ID, IntType)          \
   struct ID : detail::strong_type_base<IntType, ID> {        \
+    using value_type = IntType;                              \
     using base_type = detail::strong_type_base<IntType, ID>; \
     using base_type::base_type;                              \
     using base_type::operator=;                              \

--- a/SeQuant/core/wick.impl.hpp
+++ b/SeQuant/core/wick.impl.hpp
@@ -246,7 +246,7 @@ inline bool apply_index_replacement_rules(
       const auto &factor = *it;
       if (factor->is<Tensor>()) {
         auto &tensor = factor->as<Tensor>();
-        assert(ranges::none_of(tensor.const_indices(), [](const Index &idx) {
+        assert(ranges::none_of(tensor.const_braketaux(), [](const Index &idx) {
           return idx.tag().has_value();
         }));
       }
@@ -372,11 +372,11 @@ void reduce_wick_impl(std::shared_ptr<Product> &expr,
       std::set<Index, Index::LabelCompare> all_indices;
       ranges::for_each(*expr, [&all_indices](const auto &factor) {
         if (factor->template is<Tensor>()) {
-          ranges::for_each(factor->template as<const Tensor>().indices(),
-                           [&all_indices](const Index &idx) {
-                             [[maybe_unused]] auto result =
-                                 all_indices.insert(idx);
-                           });
+          ranges::for_each(
+              factor->template as<const Tensor>().braketaux_indices(),
+              [&all_indices](const Index &idx) {
+                [[maybe_unused]] auto result = all_indices.insert(idx);
+              });
         }
       });
 

--- a/SeQuant/domain/mbpt/rules/csv.cpp
+++ b/SeQuant/domain/mbpt/rules/csv.cpp
@@ -19,7 +19,7 @@ ExprPtr csv_transform_impl(Tensor const& tnsr, const IndexSpace& csv_basis,
                            std::wstring_view coeff_tensor_label) {
   using ranges::views::transform;
 
-  if (ranges::none_of(tnsr.const_braket(), &Index::has_proto_indices))
+  if (ranges::none_of(tnsr.const_braket_indices(), &Index::has_proto_indices))
     return nullptr;
 
   assert(ranges::none_of(tnsr.aux(), &Index::has_proto_indices));
@@ -100,7 +100,8 @@ ExprPtr csv_transform(ExprPtr const& expr, const IndexSpace& csv_basis,
   else if (expr->is<Tensor>()) {
     auto const& tnsr = expr->as<Tensor>();
     if (!ranges::contains(tensor_labels, tnsr.label())) return expr;
-    if (ranges::none_of(tnsr.indices(), &Index::has_proto_indices)) return expr;
+    if (ranges::none_of(tnsr.braketaux_indices(), &Index::has_proto_indices))
+      return expr;
     return csv_transform_impl(tnsr, csv_basis, coeff_tensor_label);
   } else if (expr->is<Product>()) {
     auto const& prod = expr->as<Product>();

--- a/SeQuant/domain/mbpt/spin.cpp
+++ b/SeQuant/domain/mbpt/spin.cpp
@@ -775,8 +775,7 @@ container::svector<container::map<Index, Index>> P_maps(const Tensor& P) {
   // P_ij -> {{i,j},{j,i}}
   // P_ijkl \equiv P_ij P_kl -> {{i,j},{j,i},{k,l},{l,k}}
   // P_ij^ab \equiv P_ij P^ab -> {{i,j},{j,i},{a,b},{b,a}}
-  assert(P.bra_rank() > 0 && P.bra_rank() % 2 == 0 && P.ket_rank() > 0 &&
-         P.ket_rank() % 2 == 0);
+  assert(P.bra_rank() % 2 == 0 && P.ket_rank() % 2 == 0);
   container::map<Index, Index> idx_rep;
   auto indices = P.const_braket_indices();
   for (auto it = indices.begin(); it != indices.end(); ranges::advance(it, 2)) {

--- a/SeQuant/domain/mbpt/spin.cpp
+++ b/SeQuant/domain/mbpt/spin.cpp
@@ -776,11 +776,16 @@ container::svector<container::map<Index, Index>> P_maps(const Tensor& P) {
   assert(P.bra_rank() % 2 == 0 && P.ket_rank() % 2 == 0);
   container::map<Index, Index> idx_rep;
   for (std::size_t i = 0; i != P.const_braket().size(); i += 2) {
-    idx_rep.emplace(P.const_braket().at(i), P.const_braket().at(i + 1));
-    idx_rep.emplace(P.const_braket().at(i + 1), P.const_braket().at(i));
+    auto& idx1 = P.const_braket().at(i);
+    auto& idx2 = P.const_braket().at(i + 1);
+    if (idx1.nonnull()) {
+      assert(idx2.nonnull());
+      idx_rep.emplace(P.const_braket().at(i), P.const_braket().at(i + 1));
+      idx_rep.emplace(P.const_braket().at(i + 1), P.const_braket().at(i));
+    }
   }
 
-  assert(idx_rep.size() == (P.bra_rank() + P.ket_rank()));
+  assert(idx_rep.size() == (P.bra_net_rank() + P.ket_net_rank()));
   return container::svector<container::map<Index, Index>>{idx_rep};
 }
 
@@ -1266,11 +1271,9 @@ std::vector<ExprPtr> open_shell_P_op_vector(const Tensor& A) {
       for (auto& k : beta_spin) {
         if (!alpha_spin.empty() && !beta_spin.empty()) {
           P_bra_list.emplace_back(Tensor(
-              L"P", bra{A.bra().at(j), A.bra().at(k)}, ket{}, Symmetry::nonsymm,
-              BraKetSymmetry::nonsymm, ParticleSymmetry::nonsymm));
+              L"P", bra{A.bra().at(j), A.bra().at(k)}, ket{}, Symmetry::symm));
           P_ket_list.emplace_back(Tensor(
-              L"P", bra{}, ket{A.ket().at(j), A.ket().at(k)}, Symmetry::nonsymm,
-              BraKetSymmetry::nonsymm, ParticleSymmetry::nonsymm));
+              L"P", bra{}, ket{A.ket().at(j), A.ket().at(k)}, Symmetry::symm));
         }
       }
     }
@@ -1289,14 +1292,12 @@ std::vector<ExprPtr> open_shell_P_op_vector(const Tensor& A) {
                   Tensor(L"P",
                          bra{A.bra().at(i1), A.bra().at(i3), A.bra().at(i2),
                              A.bra().at(i4)},
-                         ket{}, Symmetry::nonsymm, BraKetSymmetry::nonsymm,
-                         ParticleSymmetry::nonsymm));
+                         ket{}, Symmetry::symm));
               P_ket_list.emplace_back(
                   Tensor(L"P", bra{},
                          ket{A.ket().at(i1), A.ket().at(i3), A.ket().at(i2),
                              A.ket().at(i4)},
-                         Symmetry::nonsymm, BraKetSymmetry::nonsymm,
-                         ParticleSymmetry::nonsymm));
+                         Symmetry::symm));
             }
           }
         }

--- a/python/src/sequant/_sequant.cc
+++ b/python/src/sequant/_sequant.cc
@@ -139,9 +139,9 @@ PYBIND11_MODULE(_sequant, m) {
                                return std::vector<Index>(braket.begin(),
                                                          braket.end());
                              })
-      .def_property_readonly("indices", [](const Tensor &t) {
-        auto indices = t.indices();
-        return std::vector<Index>(indices.begin(), indices.end());
+      .def_property_readonly("braketaux", [](const Tensor &t) {
+        auto slots = t.braketaux();
+        return std::vector<Index>(slots.begin(), slots.end());
       });
 
   py::class_<Complex<rational>>(m, "zRational")

--- a/tests/integration/eval/btas/data_world_btas.hpp
+++ b/tests/integration/eval/btas/data_world_btas.hpp
@@ -112,7 +112,7 @@ class DataWorldBTAS {
 
     assert(tensor.label() != L"t");
 
-    auto const r1_limits = range1_limits(tensor, nocc, nvirt);
+    auto r1_limits = range1_limits(tensor, nocc, nvirt);
     assert(r1_limits.size() == DataInfo::fock_rank ||
            r1_limits.size() == DataInfo::eri_rank);
 

--- a/tests/integration/eval/eval_utils.hpp
+++ b/tests/integration/eval/eval_utils.hpp
@@ -55,13 +55,13 @@ auto range1_limits(sequant::Tensor const& tensor, size_t nocc, size_t nvirt) {
   auto isr = get_default_context().index_space_registry();
   static auto const ao = isr->retrieve(L"i");
   static auto const au = isr->retrieve(L"a");
-  return tensor.const_braket_indices() |
-         ranges::views::transform([nocc, nvirt](auto const& idx) {
-           const auto& sp = idx.space();
-           assert(sp == ao || sp == au);
+  return ranges::views::transform(tensor.const_braket(),
+                                  [nocc, nvirt](auto const& idx) {
+                                    const auto& sp = idx.space();
+                                    assert(sp == ao || sp == au);
 
-           return sp == ao ? nocc : nvirt;
-         });
+                                    return sp == ao ? nocc : nvirt;
+                                  });
 }
 
 template <typename Tensor_t>

--- a/tests/integration/eval/eval_utils.hpp
+++ b/tests/integration/eval/eval_utils.hpp
@@ -55,7 +55,7 @@ auto range1_limits(sequant::Tensor const& tensor, size_t nocc, size_t nvirt) {
   auto isr = get_default_context().index_space_registry();
   static auto const ao = isr->retrieve(L"i");
   static auto const au = isr->retrieve(L"a");
-  return tensor.const_braket() |
+  return tensor.const_braket_indices() |
          ranges::views::transform([nocc, nvirt](auto const& idx) {
            const auto& sp = idx.space();
            assert(sp == ao || sp == au);

--- a/tests/integration/eval/ta/data_world_ta.hpp
+++ b/tests/integration/eval/ta/data_world_ta.hpp
@@ -148,7 +148,7 @@ class DataWorldTA {
 
     assert(tensor.label() != L"t");
 
-    auto const r1_limits = range1_limits(tensor, nocc, nvirt);
+    auto r1_limits = range1_limits(tensor, nocc, nvirt);
     assert(r1_limits.size() == DataInfo::fock_rank ||
            r1_limits.size() == DataInfo::eri_rank);
 

--- a/tests/unit/gwt.hpp
+++ b/tests/unit/gwt.hpp
@@ -9,7 +9,7 @@
 
 #include <range/v3/algorithm/equal_range.hpp>
 #include <range/v3/numeric/accumulate.hpp>
-#include <range/v3/to_container.hpp>
+#include <range/v3/range/conversion.hpp>
 #include <range/v3/view/filter.hpp>
 #include <range/v3/view/iota.hpp>
 #include <range/v3/view/transform.hpp>

--- a/tests/unit/test_abstract_tensor.cpp
+++ b/tests/unit/test_abstract_tensor.cpp
@@ -88,7 +88,7 @@ TEST_CASE("abstract_tensor", "[elements]") {
     SECTION("2-index") {
       for (auto& tptr : {tensor, nop}) {
         auto& t = *tptr;
-        const std::array<std::size_t, 3> pdata{1, 0, 2};
+        std::array<std::size_t, 3> pdata{1, 0, 2};
         std::span p{pdata.data(), 3};
         // permutation moves indices around, i.e. no reallocation, pointers are
         // stable

--- a/tests/unit/test_eval_btas.cpp
+++ b/tests/unit/test_eval_btas.cpp
@@ -22,10 +22,10 @@ auto eval_node(sequant::ExprPtr const& expr) {
   auto node = binarize(expr);
   return transform_node(node, [](auto&& val) {
     if (val.is_tensor()) {
-      return EvalExprBTAS(
-          *val.op_type(), val.result_type(), val.expr(),
-          val.as_tensor().indices() | ranges::to<EvalExpr::index_vector>(),
-          val.canon_phase(), val.hash_value());
+      return EvalExprBTAS(*val.op_type(), val.result_type(), val.expr(),
+                          val.as_tensor().braketaux_indices() |
+                              ranges::to<EvalExpr::index_vector>(),
+                          val.canon_phase(), val.hash_value());
     } else
       return EvalExprBTAS(val);
   });
@@ -63,7 +63,7 @@ class rand_tensor_yield {
     using sequant::IndexSpace;
     auto isr = sequant::get_default_context().index_space_registry();
 
-    assert(ranges::all_of(tnsr.const_braket(),
+    assert(ranges::all_of(tnsr.const_braket_indices(),
                           [&isr](auto const& idx) {
                             return idx.space() == isr->retrieve(L"i") ||
                                    idx.space() == isr->retrieve(L"a");
@@ -71,7 +71,7 @@ class rand_tensor_yield {
            "Unsupported IndexSpace type found while generating tensor.");
 
     auto rng = btas::Range{
-        tnsr.const_braket() | transform([this, &isr](auto const& idx) {
+        tnsr.const_braket_indices() | transform([this, &isr](auto const& idx) {
           return idx.space() == isr->retrieve(L"i") ? nocc_ : nvirt_;
         }) |
         ranges::to_vector};
@@ -149,7 +149,7 @@ container::svector<long> tidxs(Iterable const& indices) noexcept {
 }
 
 container::svector<long> tidxs(Tensor const& tnsr) noexcept {
-  return sequant::EvalExprBTAS::index_hash(tnsr.const_braket()) |
+  return sequant::EvalExprBTAS::index_hash(tnsr.const_braket_indices()) |
          ranges::to<container::svector<long>>;
 }
 

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -45,11 +45,12 @@ struct NestedTensorIndices {
       if (!ranges::contains(cont, el)) cont.emplace_back(el);
     };
 
-    for (Index const& ix : tnsr.const_braket())
+    for (Index const& ix : tnsr.const_braket_indices()) {
       append_unique(ix.has_proto_indices() ? inner : outer, ix);
+    }
 
     for (Index const& ix :
-         tnsr.const_braket() | transform(&Index::proto_indices) | join)
+         tnsr.const_braket_indices() | transform(&Index::proto_indices) | join)
       append_unique(outer, ix);
   }
 

--- a/tests/unit/test_index.cpp
+++ b/tests/unit/test_index.cpp
@@ -115,6 +115,19 @@ TEST_CASE("index", "[elements][index]") {
       REQUIRE(i7.proto_indices()[1] == i2);  // !!
       REQUIRE(i7.full_label() == L"i_7<i_1, i_2>");
 
+      // move-ctor should leave null in its wake
+      REQUIRE(i7.nonnull());
+      auto i7_copy = i7;
+      i7_copy.tag();  // make tag nonnull also
+      REQUIRE(i7_copy.nonnull() == true);
+      REQUIRE_NOTHROW(Index(std::move(i7_copy)));
+      REQUIRE(i7_copy.nonnull() == false);
+      i7_copy = i7;
+      i7_copy.tag();  // make tag nonnull also
+      REQUIRE(i7_copy.nonnull() == true);
+      REQUIRE_NOTHROW(Index{} = std::move(i7_copy));
+      REQUIRE(i7_copy.nonnull() == false);
+
 #ifndef NDEBUG
       REQUIRE_THROWS(Index(isr->retrieve(L"i"), 4, {i1, i1}));
       REQUIRE_THROWS(Index(L"i_5", {L"i_1", L"i_1"}));

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -51,8 +51,8 @@ TEST_CASE("optimize", "[optimize]") {
 
     auto single_term_opt = [](Product const& prod) {
       return opt::single_term_opt(prod, [](Index const& ix) {
-        auto lbl = to_string(ix.label());
-        auto sz = ix.space().approximate_size();
+        // null space contributes x1 to the size
+        auto sz = ix.nonnull() ? ix.space().approximate_size() : 1;
         return sz;
       });
     };

--- a/tests/unit/test_parse.cpp
+++ b/tests/unit/test_parse.cpp
@@ -163,8 +163,9 @@ TEST_CASE("parsing", "[parse]") {
       REQUIRE(expr->as<Tensor>().bra().size() == 2);
       REQUIRE(expr->as<Tensor>().bra().at(0).label() == L"i_1");
       REQUIRE(expr->as<Tensor>().bra().at(1).label() == L"i_2");
-      REQUIRE(expr->as<Tensor>().ket().size() == 1);
+      REQUIRE(expr->as<Tensor>().ket().size() == 2);
       REQUIRE(expr->as<Tensor>().ket().at(0).label() == L"a_1");
+      REQUIRE(expr->as<Tensor>().ket().at(1).nonnull() == false);
       REQUIRE(expr->as<Tensor>().aux().size() == 2);
       REQUIRE(expr->as<Tensor>().aux().at(0).label() == L"x_1");
       REQUIRE(expr->as<Tensor>().aux().at(1).label() == L"x_2");

--- a/tests/unit/test_parse.cpp
+++ b/tests/unit/test_parse.cpp
@@ -163,9 +163,8 @@ TEST_CASE("parsing", "[parse]") {
       REQUIRE(expr->as<Tensor>().bra().size() == 2);
       REQUIRE(expr->as<Tensor>().bra().at(0).label() == L"i_1");
       REQUIRE(expr->as<Tensor>().bra().at(1).label() == L"i_2");
-      REQUIRE(expr->as<Tensor>().ket().size() == 2);
+      REQUIRE(expr->as<Tensor>().ket().size() == 1);
       REQUIRE(expr->as<Tensor>().ket().at(0).label() == L"a_1");
-      REQUIRE(expr->as<Tensor>().ket().at(1).nonnull() == false);
       REQUIRE(expr->as<Tensor>().aux().size() == 2);
       REQUIRE(expr->as<Tensor>().aux().at(0).label() == L"x_1");
       REQUIRE(expr->as<Tensor>().aux().at(1).label() == L"x_2");

--- a/tests/unit/test_space.cpp
+++ b/tests/unit/test_space.cpp
@@ -14,6 +14,21 @@
 TEST_CASE("index_space", "[elements]") {
   using namespace sequant;
 
+  SECTION("constructor") {
+    REQUIRE_NOTHROW(IndexSpace{});
+    REQUIRE(IndexSpace{} == IndexSpace::null);
+
+    REQUIRE_NOTHROW(IndexSpace(L"i", 0b0010, 20));
+    IndexSpace active_occupied(L"i", 0b0010, 20);
+
+    // move leave null in its wake
+    REQUIRE_NOTHROW(IndexSpace(std::move(active_occupied)));
+    REQUIRE(active_occupied == IndexSpace::null);
+    active_occupied = IndexSpace(L"i", 0b0010, 20);
+    REQUIRE_NOTHROW(IndexSpace{} = std::move(active_occupied));
+    REQUIRE(active_occupied == IndexSpace::null);
+  }
+
   SECTION("registry synopsis") {
     auto sr_isr = sequant::mbpt::make_sr_spaces();
     REQUIRE_NOTHROW(sr_isr->retrieve(L"i"));

--- a/tests/unit/test_spin.cpp
+++ b/tests/unit/test_spin.cpp
@@ -948,14 +948,15 @@ SECTION("Closed-shell spintrace CCSDT terms") {
 }
 
 SECTION("Merge P operators") {
-  auto P1 = Tensor(L"P", bra{L"i_1", L"i_2"}, ket{});
-  auto P2 = Tensor(L"P", bra{}, ket{L"a_1", L"a_2"});
-  auto P3 = Tensor(L"P", bra{L"i_1", L"i_2"}, ket{L"a_1", L"a_2"});
-  auto P4 = Tensor(L"P", bra{}, ket{});
+  auto P1 = Tensor(L"P", bra{L"i_1", L"i_2"}, ket{}, Symmetry::symm);
+  auto P2 = Tensor(L"P", bra{}, ket{L"a_1", L"a_2"}, Symmetry::symm);
+  auto P3 =
+      Tensor(L"P", bra{L"i_1", L"i_2"}, ket{L"a_1", L"a_2"}, Symmetry::symm);
+  auto P4 = Tensor(L"P", bra{}, ket{}, Symmetry::symm);
   auto P12 = merge_tensors(P1, P2);
   auto P34 = merge_tensors(P3, P4);
-  REQUIRE_THAT(P12, EquivalentTo("P{i1,i2;a1,a2}"));
-  REQUIRE_THAT(P34, EquivalentTo("P{i1,i2;a1,a2}"));
+  REQUIRE_THAT(P12, EquivalentTo("P{i1,i2;a1,a2}:S"));
+  REQUIRE_THAT(P34, EquivalentTo("P{i1,i2;a1,a2}:S"));
 }
 
 SECTION("Permutation operators") {

--- a/tests/unit/test_spin.cpp
+++ b/tests/unit/test_spin.cpp
@@ -40,7 +40,7 @@ TEST_CASE("spin", "[spin]") {
 
   auto reset_idx_tags = [](ExprPtr& expr) {
     if (expr->is<Tensor>())
-      ranges::for_each(expr->as<Tensor>().const_braket(),
+      ranges::for_each(expr->as<Tensor>().const_braketaux(),
                        [](const Index& idx) { idx.reset_tag(); });
   };
 
@@ -191,7 +191,7 @@ TEST_CASE("spin", "[spin]") {
     REQUIRE_THAT(spin_swap_tensor, EquivalentTo("t{p↓1,p↑2;p↓3,p↑4}"));
 
     auto result = remove_spin(input);
-    for (auto& i : result->as<Tensor>().const_braket())
+    for (auto& i : result->as<Tensor>().const_braket_indices())
       REQUIRE(i.space().base_key() == L"p");
 
     input = ex<Tensor>(L"t", bra{p1, p3}, ket{p2, p4});

--- a/tests/unit/test_tensor.cpp
+++ b/tests/unit/test_tensor.cpp
@@ -51,7 +51,9 @@ TEST_CASE("tensor", "[elements]") {
     REQUIRE(t2.ket_rank() == 1);
     REQUIRE(t2.aux_rank() == 0);
     REQUIRE(t2.rank() == 1);
-    REQUIRE(t2.const_indices().size() == 2);
+    REQUIRE(t2.const_braketaux().size() == 2);
+    REQUIRE(ranges::distance(t2.const_braketaux_indices().begin(),
+                             t2.const_braketaux_indices().end()) == 2);
     REQUIRE(t2.symmetry() == Symmetry::nonsymm);
     REQUIRE(t2.braket_symmetry() == BraKetSymmetry::conjugate);
     REQUIRE(t2.particle_symmetry() == ParticleSymmetry::symm);
@@ -66,7 +68,9 @@ TEST_CASE("tensor", "[elements]") {
     REQUIRE(t3.bra_net_rank() == 1);
     REQUIRE(t3.ket_net_rank() == 0);
     REQUIRE(t3.rank() == 1);
-    REQUIRE(t3.const_indices().size() == 3);
+    REQUIRE(t3.const_braketaux().size() == 3);
+    REQUIRE(ranges::distance(t3.const_braketaux_indices().begin(),
+                             t3.const_braketaux_indices().end()) == 2);
     REQUIRE(t3.symmetry() == Symmetry::nonsymm);
     REQUIRE(t3.braket_symmetry() == BraKetSymmetry::conjugate);
     REQUIRE(t3.particle_symmetry() == ParticleSymmetry::symm);
@@ -85,7 +89,7 @@ TEST_CASE("tensor", "[elements]") {
     REQUIRE(t4.ket_rank() == 2);
     REQUIRE(t4.aux_rank() == 1);
     REQUIRE(t4.rank() == 2);
-    REQUIRE(t4.const_indices().size() == 5);
+    REQUIRE(ranges::size(t4.const_braketaux()) == 5);
     REQUIRE(t4.symmetry() == Symmetry::nonsymm);
     REQUIRE(t4.braket_symmetry() == BraKetSymmetry::symm);
     REQUIRE(t4.particle_symmetry() == ParticleSymmetry::nonsymm);

--- a/tests/unit/test_tensor_network.cpp
+++ b/tests/unit/test_tensor_network.cpp
@@ -1164,7 +1164,7 @@ TEST_CASE("tensor_network_v2", "[elements]") {
       std::vector<Index> indices;
       for (std::size_t i = 0; i < expected.size(); ++i) {
         const Tensor& tensor = expected[i].as<Tensor>();
-        for (const Index& idx : tensor.indices()) {
+        for (const Index& idx : tensor.braketaux_indices()) {
           if (std::find(indices.begin(), indices.end(), idx) == indices.end()) {
             indices.push_back(idx);
           }
@@ -1856,7 +1856,7 @@ TEST_CASE("tensor_network_v3", "[elements]") {
       std::vector<Index> indices;
       for (std::size_t i = 0; i < expected.size(); ++i) {
         const Tensor& tensor = expected[i].as<Tensor>();
-        for (const Index& idx : tensor.indices()) {
+        for (const Index& idx : tensor.braketaux_indices()) {
           if (std::find(indices.begin(), indices.end(), idx) == indices.end()) {
             indices.push_back(idx);
           }

--- a/tests/unit/test_tensor_network.cpp
+++ b/tests/unit/test_tensor_network.cpp
@@ -1004,8 +1004,10 @@ TEST_CASE("tensor_network_v2", "[elements]") {
     SECTION("particle non-conserving") {
       const auto input1 = parse_expr(L"P{;a1,a3}");
       const auto input2 = parse_expr(L"P{a1,a3;}");
-      const std::wstring expected1 = L"{{P^{{a_1}{a_3}}_{}}}";
-      const std::wstring expected2 = L"{{P^{}_{{a_1}{a_3}}}}";
+      const std::wstring expected1 =
+          L"{{P^{{a_1}{a_3}}_{\\textvisiblespace\\textvisiblespace}}}";
+      const std::wstring expected2 =
+          L"{{P^{\\textvisiblespace\\textvisiblespace}_{{a_1}{a_3}}}}";
 
       for (int variant : {1, 2}) {
         for (bool fast : {true, false}) {
@@ -1506,13 +1508,13 @@ TEST_CASE("tensor_network_v3", "[elements]") {
         TN tn(u1 * u2 * u3);
       }
 
-      // can have empty slots
+      // can have empty slots, but only in nonsymm bra/ket
       {
         auto u1 = ex<Tensor>(L"u1", bra{L"i_1", L""}, ket{L"", L"i_4"},
                              aux{L"p"}, Symmetry::nonsymm);
         auto u2 = ex<Tensor>(L"u2", bra{L"i_2", L"", L"i_4"}, ket{L"", L"i_1"},
                              aux{L"p"}, Symmetry::nonsymm);
-        auto u3 = ex<Tensor>(L"u3", bra{L"i_3", L"i_5"}, ket{L""}, aux{L"p"},
+        auto u3 = ex<Tensor>(L"u3", bra{L"i_3", L"i_5"}, ket{}, aux{L"p"},
                              Symmetry::symm);
         REQUIRE_NOTHROW(TN(u1 * u2 * u3));
         TN tn(u1 * u2 * u3);
@@ -1641,8 +1643,10 @@ TEST_CASE("tensor_network_v3", "[elements]") {
     SECTION("particle non-conserving") {
       const auto input1 = parse_expr(L"P{;a1,a3}");
       const auto input2 = parse_expr(L"P{a1,a3;}");
-      const std::wstring expected1 = L"{{P^{{a_1}{a_3}}_{}}}";
-      const std::wstring expected2 = L"{{P^{}_{{a_1}{a_3}}}}";
+      const std::wstring expected1 =
+          L"{{P^{{a_1}{a_3}}_{\\textvisiblespace\\textvisiblespace}}}";
+      const std::wstring expected2 =
+          L"{{P^{\\textvisiblespace\\textvisiblespace}_{{a_1}{a_3}}}}";
 
       for (int variant : {1, 2}) {
         for (bool fast : {true, false}) {

--- a/tests/unit/test_tensor_network.cpp
+++ b/tests/unit/test_tensor_network.cpp
@@ -1004,10 +1004,8 @@ TEST_CASE("tensor_network_v2", "[elements]") {
     SECTION("particle non-conserving") {
       const auto input1 = parse_expr(L"P{;a1,a3}");
       const auto input2 = parse_expr(L"P{a1,a3;}");
-      const std::wstring expected1 =
-          L"{{P^{{a_1}{a_3}}_{\\textvisiblespace\\textvisiblespace}}}";
-      const std::wstring expected2 =
-          L"{{P^{\\textvisiblespace\\textvisiblespace}_{{a_1}{a_3}}}}";
+      const std::wstring expected1 = L"{{P^{{a_1}{a_3}}_{}}}";
+      const std::wstring expected2 = L"{{P^{}_{{a_1}{a_3}}}}";
 
       for (int variant : {1, 2}) {
         for (bool fast : {true, false}) {
@@ -1643,10 +1641,8 @@ TEST_CASE("tensor_network_v3", "[elements]") {
     SECTION("particle non-conserving") {
       const auto input1 = parse_expr(L"P{;a1,a3}");
       const auto input2 = parse_expr(L"P{a1,a3;}");
-      const std::wstring expected1 =
-          L"{{P^{{a_1}{a_3}}_{\\textvisiblespace\\textvisiblespace}}}";
-      const std::wstring expected2 =
-          L"{{P^{\\textvisiblespace\\textvisiblespace}_{{a_1}{a_3}}}}";
+      const std::wstring expected1 = L"{{P^{{a_1}{a_3}}_{}}}";
+      const std::wstring expected2 = L"{{P^{}_{{a_1}{a_3}}}}";
 
       for (int variant : {1, 2}) {
         for (bool fast : {true, false}) {

--- a/tests/unit/test_utilities.cpp
+++ b/tests/unit/test_utilities.cpp
@@ -114,7 +114,8 @@ TEST_CASE("utilities", "[utilities]") {
 
       auto indices = get_unique_indices(expression);
 
-      REQUIRE_THAT(indices.bra, UnorderedEquals(std::vector<Index>{{L"i_1"}}));
+      REQUIRE_THAT(indices.bra,
+                   UnorderedEquals(std::vector<Index>{{L"i_1", L""}}));
       REQUIRE_THAT(indices.ket,
                    UnorderedEquals(std::vector<Index>{{L"a_1", L"a_2"}}));
       REQUIRE_THAT(indices.aux, UnorderedEquals(std::vector<Index>{{L"x_1"}}));
@@ -144,7 +145,8 @@ TEST_CASE("utilities", "[utilities]") {
 
       auto indices = get_unique_indices(expression);
 
-      REQUIRE_THAT(indices.bra, UnorderedEquals(std::vector<Index>{{L"i_1"}}));
+      REQUIRE_THAT(indices.bra,
+                   UnorderedEquals(std::vector<Index>{{L"i_1", L""}}));
       REQUIRE_THAT(indices.ket,
                    UnorderedEquals(std::vector<Index>{{L"a_1", L"i_2"}}));
       REQUIRE_THAT(indices.aux, UnorderedEquals(std::vector<Index>{{L"x_1"}}));

--- a/tests/unit/test_utilities.cpp
+++ b/tests/unit/test_utilities.cpp
@@ -114,8 +114,7 @@ TEST_CASE("utilities", "[utilities]") {
 
       auto indices = get_unique_indices(expression);
 
-      REQUIRE_THAT(indices.bra,
-                   UnorderedEquals(std::vector<Index>{{L"i_1", L""}}));
+      REQUIRE_THAT(indices.bra, UnorderedEquals(std::vector<Index>{{L"i_1"}}));
       REQUIRE_THAT(indices.ket,
                    UnorderedEquals(std::vector<Index>{{L"a_1", L"a_2"}}));
       REQUIRE_THAT(indices.aux, UnorderedEquals(std::vector<Index>{{L"x_1"}}));
@@ -145,8 +144,7 @@ TEST_CASE("utilities", "[utilities]") {
 
       auto indices = get_unique_indices(expression);
 
-      REQUIRE_THAT(indices.bra,
-                   UnorderedEquals(std::vector<Index>{{L"i_1", L""}}));
+      REQUIRE_THAT(indices.bra, UnorderedEquals(std::vector<Index>{{L"i_1"}}));
       REQUIRE_THAT(indices.ket,
                    UnorderedEquals(std::vector<Index>{{L"a_1", L"i_2"}}));
       REQUIRE_THAT(indices.aux, UnorderedEquals(std::vector<Index>{{L"x_1"}}));


### PR DESCRIPTION
#354 introduced support for empty slots (expressed as slots occupied by null indices). This refines the design of this feature. Namely:
- empty slots are not allowed in (anti)symmetric tensors
- empty slots are allowed in asymmetric tensors:
  - slots of particle-symmetric tensors are canonicalized in the constructor in the following canonical order:
    - paired braket slot bundles (i.e. pairs of matching nonempty bra and ket slots, `{bra[i],ket[i]}`) appear first
    - bra-only slots appear next (either paired with an empty ket slot, if there are ket-only slots to follow, or left unpaired)
    - ket-only slots appear last (unpaired)
    
    thus tensor `t(,b1,b2,;k1,,k2,k3)` is converted by its ctor to `t(b2,b1;k2,,k1,k3)`. Subsequent operations maintain this invariant.
  - slots of non-particle-symmetric tensors are kept in their input form, e.g. `t(,b1,b2,;k1,,k2,k3)` is kept as is.

N.B. The notion of empty slots requires refinement of the AbstractTensor API as well.