### PR TITLE
TNV3: support for `BraKetSymmetry`

### DIFF
--- a/SeQuant/core/abstract_tensor.hpp
+++ b/SeQuant/core/abstract_tensor.hpp
@@ -249,6 +249,10 @@ class AbstractTensor {
   virtual void _permute_braket(std::span<std::size_t> perm) {
     permute_braket_impl(_bra_mutable(), _ket_mutable(), perm);
   }
+  /// swaps bra and ket slots
+  virtual void _swap_bra_ket() {
+    throw missing_instantiation_for("_swap_bra_ket");
+  }
 
  private:
   /// @return mutable view of bra

--- a/SeQuant/core/abstract_tensor.hpp
+++ b/SeQuant/core/abstract_tensor.hpp
@@ -352,7 +352,7 @@ class AbstractTensor {
 /// objects.
 /// @{
 inline auto braket(const AbstractTensor& t) { return t._braket(); }
-inline auto indices(const AbstractTensor& t) { return t._braketaux(); }
+inline auto braketaux(const AbstractTensor& t) { return t._braketaux(); }
 inline auto bra_rank(const AbstractTensor& t) { return t._bra_rank(); }
 inline auto bra_net_rank(const AbstractTensor& t) { return t._bra_net_rank(); }
 inline auto ket_rank(const AbstractTensor& t) { return t._ket_rank(); }
@@ -511,7 +511,7 @@ template <typename T>
 struct is_tensor
     : std::bool_constant<
           std::is_invocable_v<decltype(braket), T> &&
-          std::is_invocable_v<decltype(indices), T> &&
+          std::is_invocable_v<decltype(braketaux), T> &&
           std::is_invocable_v<decltype(bra_rank), T> &&
           std::is_invocable_v<decltype(ket_rank), T> &&
           std::is_invocable_v<decltype(aux_rank), T> &&

--- a/SeQuant/core/abstract_tensor.hpp
+++ b/SeQuant/core/abstract_tensor.hpp
@@ -29,7 +29,10 @@
 
 namespace sequant {
 
-enum class SlotType { Bra, Ket, Aux, BraKet };
+/// index slot types
+///
+/// @note This does not include slot bundles, like braket, etc.
+enum class SlotType { Bra, Ket, Aux };
 
 class TensorCanonicalizer;
 

--- a/SeQuant/core/abstract_tensor.hpp
+++ b/SeQuant/core/abstract_tensor.hpp
@@ -357,6 +357,8 @@ class AbstractTensor {
 /// @{
 inline auto braket(const AbstractTensor& t) { return t._braket(); }
 inline auto braketaux(const AbstractTensor& t) { return t._braketaux(); }
+/// @return a view of all indices; currently equivalent to braketaux
+inline auto indices(const AbstractTensor& t) { return braketaux(t); }
 inline auto bra_rank(const AbstractTensor& t) { return t._bra_rank(); }
 inline auto bra_net_rank(const AbstractTensor& t) { return t._bra_net_rank(); }
 inline auto ket_rank(const AbstractTensor& t) { return t._ket_rank(); }

--- a/SeQuant/core/attr.hpp
+++ b/SeQuant/core/attr.hpp
@@ -31,7 +31,7 @@ enum class Symmetry { symm, antisymm, nonsymm, invalid };
 enum class BraKetSymmetry { symm, conjugate, nonsymm, invalid };
 
 /// describes type of single-particle basis
-enum class SPBasis { spinorbital, spinfree };
+enum class SPBasis { spinor, spinfree };
 
 inline std::wstring to_wolfram(const Symmetry& symmetry) {
   std::wstring result;

--- a/SeQuant/core/context.cpp
+++ b/SeQuant/core/context.cpp
@@ -102,6 +102,16 @@ set_scoped_default_context(Context&& ctx) {
           {Statistics::Arbitrary, std::move(ctx)}});
 }
 
+Context::Context(ContextOptions options)
+    : idx_space_reg_(std::move(options.index_space_registry_shared_ptr)),
+      vacuum_(options.vacuum),
+      metric_(options.metric),
+      braket_symmetry_(options.braket_symmetry),
+      spbasis_(options.spbasis),
+      first_dummy_index_ordinal_(options.first_dummy_index_ordinal),
+      braket_typesetting_(options.braket_typesetting),
+      braket_slot_typesetting_(options.braket_slot_typesetting) {}
+
 Context::Context(std::shared_ptr<IndexSpaceRegistry> isr, Vacuum vac,
                  IndexSpaceMetric m, BraKetSymmetry bks, SPBasis spb,
                  std::size_t fdio, BraKetTypesetting bkt,

--- a/SeQuant/core/context.hpp
+++ b/SeQuant/core/context.hpp
@@ -12,6 +12,9 @@ namespace sequant {
 /// spaces are orthonormal, sizes of index spaces, etc.
 ///
 /// SeQuant context contains the following information:
+/// - a IndexSpaceRegistry object: contains information about the known
+///   IndexSpace objects and their attributes; managed by shared_ptr and
+///   can be shared by multiple contexts.
 /// - `vacuum`: the vacuum state used to define normal ordering of
 /// `NormalOperator`s
 /// - `metric`: whether the plain basis of vector space (ket) modes are
@@ -53,6 +56,40 @@ class Context {
     constexpr static auto braket_slot_typesetting =
         BraKetSlotTypesetting::TensorPackage;
   };
+
+  /// helper for the named-parameter constructor of Context
+
+  /// see the Context documentation for detailed description
+  struct ContextOptions {
+      /// a shared_ptr to an IndexSpaceRegistry object
+      std::shared_ptr<IndexSpaceRegistry> index_space_registry_shared_ptr = nullptr;
+      /// the Vacuum object
+      Vacuum vacuum = Defaults::vacuum;
+      /// the IndexSpaceMetric object
+      IndexSpaceMetric metric = Defaults::metric;
+      /// the BraKetSymmetry object
+      BraKetSymmetry braket_symmetry = Defaults::braket_symmetry;
+      /// the SPBasis object
+      SPBasis spbasis = Defaults::spbasis;
+      /// the first dummy index ordinal
+      std::size_t first_dummy_index_ordinal = Defaults::first_dummy_index_ordinal;
+      /// the BraKetTypesetting object
+      BraKetTypesetting braket_typesetting = Defaults::braket_typesetting;
+      /// the BraKetSlotTypesetting object
+      BraKetSlotTypesetting braket_slot_typesetting =
+        Defaults::braket_slot_typesetting;
+  };
+
+  /// @brief standard named-parameter constructor
+  ///
+  /// @warning default constructor does not create an IndexSpaceRegistry, thus
+  /// `this->index_space_registry()` will return nullptr
+  /// Example:
+  /// ```cpp
+  ///   Context ctx({.vacuum = Vacuum::SingleReference, .spbasis = SPBasis::spinfree});
+  /// ```
+  Context(ContextOptions options = {.index_space_registry_shared_ptr = nullptr, .vacuum = Defaults::vacuum, .metric = Defaults::metric, .braket_symmetry =  Defaults::braket_symmetry, .spbasis = Defaults::spbasis, .first_dummy_index_ordinal = Defaults::first_dummy_index_ordinal, .braket_typesetting = Defaults::braket_typesetting, .braket_slot_typesetting =
+        Defaults::braket_slot_typesetting});
 
   /// standard full-form constructor
 
@@ -109,13 +146,6 @@ class Context {
       std::size_t fdio = Defaults::first_dummy_index_ordinal,
       BraKetTypesetting bkt = Defaults::braket_typesetting,
       BraKetSlotTypesetting bkst = Defaults::braket_slot_typesetting);
-
-  /// default constructor, equivalent to Context(Vacuum::Physical,
-  /// IndexSpaceMetric::Unit, BraKetSymmetry::conjugate,
-  /// sequant::SPBasis::spinor, 100)
-  /// @warning default constructor does not create an IndexSpaceRegistry, thus
-  /// `this->index_space_registry()` will return nullptr
-  Context() = default;
 
   ~Context() = default;
 
@@ -264,8 +294,7 @@ void reset_default_context();
 /// @brief changes default contexts
 /// @param ctx Context objects for one or more statistics
 /// @return a move-only ContextResetter object whose destruction will reset the
-/// default context to the previous value
-/// @example
+/// default context to the previous value. Example:
 /// ```cpp
 /// {
 ///   auto resetter = set_scoped_default_context({{Statistics::Arbitrary,

--- a/SeQuant/core/context.hpp
+++ b/SeQuant/core/context.hpp
@@ -7,8 +7,40 @@
 
 namespace sequant {
 
-/// Specifies SeQuant context, such as vacuum choice, whether index
+// clang-format
+/// @brief Specifies SeQuant context, such as vacuum choice, whether index
 /// spaces are orthonormal, sizes of index spaces, etc.
+///
+/// SeQuant context contains the following information:
+/// - `vacuum`: the vacuum state used to define normal ordering of
+/// `NormalOperator`s
+/// - `metric`: whether the plain basis of vector space (ket) modes are
+/// orthonormal to their dual (bra) counterparts
+///   (`IndexSpaceMetric::Unit`) or not (`IndexSpaceMetric::General`);
+///    this affects the value of Wick contractions.
+/// - `braket_symmetry`: whether the primal (ket) and dual (bra) vector space
+/// _bases_
+///    are "equivalent" (homogenous to each other; `BraKetSymmetry::symm`),
+///    "conjugate to each other" (<a
+///    href="https://en.wikipedia.org/wiki/Antilinear_map">conjugate-homogenous</a>
+///    to each other; `BraKetSymmetry::conjugate`) or are "nonequivalent" (not
+///    homogeneous; `BraKetSymmetry::nonsymm`)
+/// - `spbasis`: whether the bra/ket bases are spinor (`SPBasis::spinor`) or
+/// spin-free (`SPBasis::spinfree`).
+/// - `first_dummy_index_ordinal`: during its operation SeQuant will generate
+///    temporary indices with orbitals greater or equal to this; to avoid
+///    duplicates user Index objects should have ordinals smaller than this
+/// - `braket_typesetting`: whether `to_latex()` typesets tensor indices of ket
+///    (covariant, primal) modes as superscript (`BraKetTypesetting::KetSuper`,
+///    default)
+//     or as subscript (`BraKetTypesetting::KetSub`); the latter is the
+//     traditional tensor convention
+/// - `braket_slot_typesetting`: whether `to_latex()` typesets tensor indices
+/// using
+///   `tensor` LaTeX package (`BraKetSlotTypesetting::TensorPackage`, default)
+///   or native typesetting (`BraKetSlotTypesetting::Naive`); the former is
+///   preferred for alignment of superscript with subscript slots.
+// clang-format off
 class Context {
  public:
   struct Defaults {

--- a/SeQuant/core/context.hpp
+++ b/SeQuant/core/context.hpp
@@ -47,7 +47,7 @@ class Context {
     constexpr static auto vacuum = Vacuum::Physical;
     constexpr static auto metric = IndexSpaceMetric::Unit;
     constexpr static auto braket_symmetry = BraKetSymmetry::conjugate;
-    constexpr static auto spbasis = sequant::SPBasis::spinorbital;
+    constexpr static auto spbasis = sequant::SPBasis::spinor;
     constexpr static auto first_dummy_index_ordinal = 100;
     constexpr static auto braket_typesetting = BraKetTypesetting::ContraSub;
     constexpr static auto braket_slot_typesetting =
@@ -112,7 +112,7 @@ class Context {
 
   /// default constructor, equivalent to Context(Vacuum::Physical,
   /// IndexSpaceMetric::Unit, BraKetSymmetry::conjugate,
-  /// sequant::SPBasis::spinorbital, 100)
+  /// sequant::SPBasis::spinor, 100)
   /// @warning default constructor does not create an IndexSpaceRegistry, thus
   /// `this->index_space_registry()` will return nullptr
   Context() = default;

--- a/SeQuant/core/index.hpp
+++ b/SeQuant/core/index.hpp
@@ -67,7 +67,7 @@ using IndexList = std::initializer_list<Index>;
 /// recommendations to use narrow strings (bytestrings) everywhere. The
 /// rationale for such a choice is that this makes "character"-centric operations easy without
 /// the need to grok Unicode and to introduce extra dependencies such as
-/// [https://github.com/unicode-org/icu](ICU). Many functions accept
+/// <a href="https://github.com/unicode-org/icu">ICU</a>. Many functions accept
 /// bytestrings as input, but they are recoded to wide (but UTF-8 encoded)
 /// strings. For optimal efficiency and simplicity users are recommended to use
 /// wide strings until further notice.

--- a/SeQuant/core/op.hpp
+++ b/SeQuant/core/op.hpp
@@ -61,7 +61,7 @@ class Op {
   void adjoint() { action_ = sequant::adjoint(action_); }
 
   static std::wstring core_label() {
-    return get_default_context(S).spbasis() == SPBasis::spinorbital
+    return get_default_context(S).spbasis() == SPBasis::spinor
                ? (S == Statistics::FermiDirac ? L"a" : L"b")
                : L"E";
   }
@@ -852,7 +852,7 @@ class NormalOperator : public Operator<S>,
   std::size_t _aux_rank() const override final { return 0; }
   Symmetry _symmetry() const override final {
     return (S == Statistics::FermiDirac
-                ? (get_default_context(S).spbasis() == SPBasis::spinorbital
+                ? (get_default_context(S).spbasis() == SPBasis::spinor
                        ? Symmetry::antisymm
                        : Symmetry::nonsymm)
                 : (Symmetry::symm));

--- a/SeQuant/core/optimize.hpp
+++ b/SeQuant/core/optimize.hpp
@@ -192,7 +192,7 @@ EvalSequence single_term_opt(TensorNetworkV2 const& network,
 
     nth_tensor_indices.emplace_back();
     auto& ixs = nth_tensor_indices.back();
-    for (auto&& j : indices(tnsr)) ixs.emplace_back(j);
+    for (auto&& j : braketaux(tnsr)) ixs.emplace_back(j);
 
     ranges::sort(ixs, std::less<Index>{});
   }

--- a/SeQuant/core/tensor.hpp
+++ b/SeQuant/core/tensor.hpp
@@ -770,6 +770,16 @@ class Tensor : public Expr, public AbstractTensor, public Labeled {
                                          aux_.size());
   }
 
+  /// swaps bra and ket slots
+  void _swap_bra_ket() override final {
+    this->reset_hash_value();
+    std::swap(bra_.value(), ket_.value());
+    std::swap(bra_net_rank_, ket_net_rank_);
+
+    validate_indices();
+    canonicalize_slots();
+  }
+
 };  // class Tensor
 
 static_assert(is_tensor_v<Tensor>,

--- a/SeQuant/core/tensor_canonicalizer.cpp
+++ b/SeQuant/core/tensor_canonicalizer.cpp
@@ -257,7 +257,7 @@ ExprPtr NullTensorCanonicalizer::apply(AbstractTensor&) const { return {}; }
 
 void DefaultTensorCanonicalizer::tag_indices(AbstractTensor& t) const {
   // tag all indices as ext->true/ind->false
-  ranges::for_each(indices(t), [this](auto& idx) {
+  ranges::for_each(braketaux(t), [this](auto& idx) {
     auto it = external_indices_.find(idx);
     auto is_ext = it != external_indices_.end();
     idx.tag().assign(

--- a/SeQuant/core/tensor_network/utils.hpp
+++ b/SeQuant/core/tensor_network/utils.hpp
@@ -149,8 +149,9 @@ void apply_index_replacements(AbstractTensor &tensor,
                               const bool self_consistent) {
 #ifndef NDEBUG
   // assert that tensors' indices are not tagged since going to tag indices
-  assert(ranges::none_of(
-      indices(tensor), [](const Index &idx) { return idx.tag().has_value(); }));
+  assert(ranges::none_of(braketaux(tensor), [](const Index &idx) {
+    return idx.tag().has_value();
+  }));
 #endif
 
   bool pass_mutated;

--- a/SeQuant/core/tensor_network_v3.cpp
+++ b/SeQuant/core/tensor_network_v3.cpp
@@ -427,6 +427,24 @@ ExprPtr TensorNetworkV3::canonicalize_graph(
     return {};
 }
 
+TensorNetworkV3::TensorNetworkV3(TensorNetworkV3 &&) noexcept = default;
+TensorNetworkV3 &TensorNetworkV3::operator=(TensorNetworkV3 &&) noexcept =
+    default;
+
+TensorNetworkV3::TensorNetworkV3(const TensorNetworkV3 &other) {
+  tensors_.reserve(other.tensors_.size());
+  for (const auto &t : other.tensors_) {
+    tensors_.emplace_back(std::shared_ptr<AbstractTensor>(t->_clone()));
+  }
+  tensor_input_ordinals_ = other.tensor_input_ordinals_;
+}
+
+TensorNetworkV3 &TensorNetworkV3::operator=(
+    const TensorNetworkV3 &other) noexcept {
+  *this = TensorNetworkV3(other);
+  return *this;
+}
+
 ExprPtr TensorNetworkV3::canonicalize(
     const container::vector<std::wstring> &cardinal_tensor_labels, bool fast,
     const NamedIndexSet *named_indices_ptr) {

--- a/SeQuant/core/tensor_network_v3.cpp
+++ b/SeQuant/core/tensor_network_v3.cpp
@@ -909,7 +909,6 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
     const std::size_t num_braket_vertices = !is_symm ? num_particles + 1 : 1;
     const bool is_part_symm =
         particle_symmetry(tensor) == ParticleSymmetry::symm;
-    const bool is_braket_symm = braket_symmetry(tensor) == BraKetSymmetry::symm;
 
     // make braket slot bundles first
     for (std::size_t i = 0; i < num_braket_vertices; ++i) {
@@ -972,8 +971,15 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
           graph.vertex_texlabels.emplace_back(std::nullopt);
         graph.vertex_types.push_back(bra ? VertexType::TensorBraBundle
                                          : VertexType::TensorKetBundle);
-        graph.vertex_colors.push_back(bra ? colorizer(BraGroup{size})
-                                          : colorizer(KetGroup{size}));
+        tensor_network::VertexColor color;
+        if (braket_symmetry(tensor) ==
+            BraKetSymmetry::symm) {  // if have bra<->ket symmetry (not conj!),
+                                     // use same color for bra and ket
+          color = colorizer(BraGroup{size});
+        } else {
+          color = bra ? colorizer(BraGroup{size}) : colorizer(KetGroup{size});
+        }
+        graph.vertex_colors.push_back(color);
 
         const auto braket_vertex = tensor_vertex + 1;
         edges.push_back(std::make_pair(braket_vertex, nvertex));

--- a/SeQuant/core/tensor_network_v3.cpp
+++ b/SeQuant/core/tensor_network_v3.cpp
@@ -44,9 +44,7 @@ TensorNetworkV3::Vertex::Vertex(Origin origin, std::size_t terminal_idx,
       index_slot(index_slot),
       terminal_symm(terminal_symm) {}
 
-TensorNetworkV3::Origin TensorNetworkV3::Vertex::getOrigin() const {
-  return origin;
-}
+SlotType TensorNetworkV3::Vertex::getOrigin() const { return origin; }
 
 std::size_t TensorNetworkV3::Vertex::getTerminalIndex() const {
   return terminal_idx;
@@ -205,6 +203,9 @@ ExprPtr TensorNetworkV3::canonicalize_graph(
 
   std::vector<std::size_t> index_idx_to_vertex;
   index_idx_to_vertex.reserve(edges_.size() + pure_proto_indices_.size());
+  std::size_t tensor_braket_vertex_ord =
+      0;  // counts encountered braket bundle vertices, resets to zero when
+          // switching to new tensor
 
   for (std::size_t vertex = 0; vertex < graph.vertex_types.size(); ++vertex) {
     const auto vertex_type = graph.vertex_types[vertex];
@@ -231,11 +232,15 @@ ExprPtr TensorNetworkV3::canonicalize_graph(
         assert(tensor_count > 0);
         const std::size_t tensor_ord = tensor_count - 1;
         const AbstractTensor &tensor = *tensors_.at(tensor_ord);
+        const auto symm = symmetry(tensor);
         const auto psymm = particle_symmetry(tensor);
-        if (psymm == ParticleSymmetry::symm) {
+        if (symm == Symmetry::nonsymm && psymm == ParticleSymmetry::symm &&
+            /* skip the first one which connects bra and ket bundles */
+            tensor_braket_vertex_ord != 0) {
           canonical_braket_slot_order[tensor_ord].emplace_back(
               canonize_perm[vertex]);
         }
+        ++tensor_braket_vertex_ord;
         break;
       }
 
@@ -243,6 +248,7 @@ ExprPtr TensorNetworkV3::canonicalize_graph(
         assert(tensor_idx_to_vertex.size() == tensor_count);
         tensor_idx_to_vertex.emplace_back(tensor_idx_to_vertex.size()) = vertex;
         ++tensor_count;
+        tensor_braket_vertex_ord = 0;
         break;
 
       case VertexType::TensorAux:
@@ -328,22 +334,25 @@ ExprPtr TensorNetworkV3::canonicalize_graph(
 
       auto &sorted_ordinals = it->second;
 
-      if (Logger::instance().canonicalize) {
-        if (!ranges::is_sorted(sorted_ordinals)) {
-          for (const auto &idxpair : idxrepl) {
-            std::wcout << "TensorNetworkV3::canonicalize_graph: permuting "
-                          "braket slots in "
-                       << to_latex(tensor) << ":\n";
-            for (auto i = 0; i != sorted_ordinals.size(); ++i) {
-              std::wcout << "  {" << to_latex(tensor._bra()[sorted_ordinals[i]])
-                         << "," << to_latex(tensor._ket()[sorted_ordinals[i]])
-                         << "} -> {" << to_latex(tensor._bra()[i]) << ","
-                         << to_latex(tensor._ket()[i]) << "}\n";
-            }
-            std::wcout << std::endl;
-          }
-        }
-      }
+      // the logic of _permute_braket is too complicated to capture here
+      // if (Logger::instance().canonicalize) {
+      //   if (!ranges::is_sorted(sorted_ordinals)) {
+      //     for (const auto &idxpair : idxrepl) {
+      //       std::wcout << "TensorNetworkV3::canonicalize_graph: permuting "
+      //                     "braket slots in "
+      //                  << to_latex(tensor) << ":\n";
+      //       for (auto i = 0; i != sorted_ordinals.size(); ++i) {
+      //         std::wcout << "  {" <<
+      //         to_latex(tensor._bra()[sorted_ordinals[i]])
+      //                    << "," <<
+      //                    to_latex(tensor._ket()[sorted_ordinals[i]])
+      //                    << "} -> {" << to_latex(tensor._bra()[i]) << ","
+      //                    << to_latex(tensor._ket()[i]) << "}\n";
+      //       }
+      //       std::wcout << std::endl;
+      //     }
+      //   }
+      // }
 
       tensor._permute_braket(
           std::span(sorted_ordinals.data(), sorted_ordinals.size()));
@@ -827,29 +836,35 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
   container::vector<std::pair<std::size_t, std::size_t>> edges;
   edges.reserve(edges_.size() + tensors_.size());
 
-  // computes ordinal of the vertex representing slot in origin at index_ordinal
-  // of tensor to obtain ordinal of the slot add this to the ordinal of tensor
-  // core vertex
-  auto index_slot_offset = [](const AbstractTensor &tensor, Origin origin,
-                              std::size_t index_ordinal) {
+  // computes ordinal of the vertex representing index slot of type
+  // slot_type which is slot_ordinal'th (empty or nonempty) slot in the slot
+  // bundle to obtain ordinal of the slot vertex add this to to tensor_vertex
+  // (i.e. ordinal of the tensor core vertex)
+  auto index_slot_offset = [](const AbstractTensor &tensor, SlotType slot_type,
+                              std::size_t slot_ordinal) {
     const Symmetry tensor_sym = symmetry(tensor);
     const bool is_symm = tensor_sym != Symmetry::nonsymm;
     std::size_t offset = 0;
     // number of vertices before first index slot vertex varies with symmetry
     if (is_symm) {
-      offset += 3;
+      offset += /* {bra,ket} bundle vertex */ 1 +
+                /* bra and ket bundle vertices */ 2;
     } else {
       auto nbraket = std::max(bra_rank(tensor), ket_rank(tensor));
-      offset += nbraket;  // braket vertices first
+      offset += /* {bra,ket} bundle vertex */ 1 +
+                /* {bra_i,ket_i} bundle vertices */ nbraket +
+                /* bra and ket bundle vertices */ 2;
     }
 
     // now count slot vertices
-    if (origin == Origin::Bra)
-      offset += index_ordinal;
-    else if (origin == Origin::Ket)
-      offset += bra_rank(tensor) + index_ordinal;
+    // N.B. empty slots are NOT skipped to avoid having to map nonempty slot
+    // ordinal to overall slot ordinal
+    if (slot_type == SlotType::Bra)
+      offset += slot_ordinal;
+    else if (slot_type == SlotType::Ket)
+      offset += bra_rank(tensor) + slot_ordinal;
     else
-      offset += bra_rank(tensor) + ket_rank(tensor) + index_ordinal;
+      offset += bra_rank(tensor) + ket_rank(tensor) + slot_ordinal;
 
     return offset + 1;  // +1 to account for tensor core vertex
   };
@@ -887,44 +902,70 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
     const std::size_t num_paired_particles =
         std::max(bra_rank(tensor), ket_rank(tensor));
 
-    // - there is 1 braket vertex per particle for asymmetric tensors,
-    // and only 1 total for antisymmetric/symmetric tensors
-    const std::size_t num_braket_vertices = !is_symm ? num_particles : 1;
+    // vertices for braket bundles:
+    // - antisymmetric/symmetric tensors only need 1 bundle for {bra,ket}
+    // - asymmetric tensors also need 1 bundle for each pair of slots
+    // {bra_i,ket_i} (including pairs where one of the slots is empty/missing)
+    const std::size_t num_braket_vertices = !is_symm ? num_particles + 1 : 1;
     const bool is_part_symm =
         particle_symmetry(tensor) == ParticleSymmetry::symm;
     const bool is_braket_symm = braket_symmetry(tensor) == BraKetSymmetry::symm;
 
-    // make braket slots first
+    // make braket slot bundles first
     for (std::size_t i = 0; i < num_braket_vertices; ++i) {
       if (options.make_labels) {
-        std::wstring label =
-            !is_symm ? (L"p_" + std::to_wstring(i + 1))
-                     : (std::wstring(L"bk") +
-                        ((tensor_sym == Symmetry::antisymm) ? L"a" : L"s"));
+        std::wstring label;
+        if (i == 0) {  // {bra,ket} bundle -> "bk{a,s,}"
+          label = L"bk";
+          switch (tensor_sym) {
+            case Symmetry::symm:
+              label += L"s";
+              break;
+            case Symmetry::antisymm:
+              label += L"a";
+              break;
+            default:
+              assert(tensor_sym != Symmetry::invalid);
+          }
+        } else {
+          // {bra_i,ket_i} bundle -> "bk_i+1"
+          label = L"bk_" + std::to_wstring(i);
+        }
         graph.vertex_labels.emplace_back(label);
       }
       if (options.make_texlabels)
         graph.vertex_texlabels.emplace_back(std::nullopt);
       graph.vertex_types.push_back(VertexType::TensorBraKet);
+
       // If tensor is particle-symmetric use same color for all braket vertices,
       // else use different colors
-      graph.vertex_colors.push_back(
-          colorizer(ParticleGroup{is_part_symm ? 0 : i}));
+      std::size_t color_id;
+      if (i == 0) {  // {bra,ket} bundle -> 0
+        color_id = 0;
+      } else {
+        // {bra_i,ket_i} bundle -> particle_symmetric ? 1 : i+1
+        color_id = is_part_symm ? 1 : i;
+      }
+      graph.vertex_colors.push_back(colorizer(ParticleGroup{color_id}));
+
       edges.push_back(std::make_pair(tensor_vertex, nvertex));
       ++nvertex;
     }
 
-    // create single slot of symmetric/anstisymmetric bra/ket
-    // TNV1/TNV2 created such vertices also but did not create index slots in
-    // such case
-    if (is_symm) {
+    // create vertices for bra and ket slot bundles of any symmetry
+    // N.B. TNV1/TNV2 created such vertices for symmetric/anstisymmetric
+    // bra/ket also but did not create index slots. Here we create them
+    // even for asymmetric bra/ket
+    {
       for (auto s : {Origin::Bra, Origin::Ket}) {
         const bool bra = s == Origin::Bra;
         const auto size = bra ? bra_rank(tensor) : ket_rank(tensor);
         if (options.make_labels) {
           std::wstring label =
               std::wstring(bra ? L"bra" : L"ket") + std::to_wstring(size) +
-              ((tensor_sym == Symmetry::antisymm) ? L"a" : L"s");
+              ((tensor_sym == Symmetry::antisymm)
+                   ? L"a"
+                   : (tensor_sym == Symmetry::symm ? L"s" : L""));
           graph.vertex_labels.emplace_back(label);
         }
         if (options.make_texlabels)
@@ -942,17 +983,26 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
 
     // - Create vertex for every index slot, regardless of symmetry (V1 and V2
     // only created slots for antisymmetric/symmetric tensors)
-    {
-      for (std::size_t i = 0; i < bra_rank(tensor); ++i) {
+    for (auto &slot_type : {SlotType::Bra, SlotType::Ket}) {
+      const auto is_bra = slot_type == SlotType::Bra;
+      const auto vertex_type =
+          is_bra ? VertexType::TensorBra : VertexType::TensorKet;
+      const auto nslots = is_bra ? bra_rank(tensor) : ket_rank(tensor);
+      auto slots = is_bra ? tensor._bra() : tensor._ket();
+      for (std::size_t i = 0; i < nslots; ++i) {
         // N.B. currently AbstractTensor only supports "left"-aligned bra/ket
-        // slot sets (i.e. bra[0] is paired with ket[0], etc.) no gaps between
-        // occupied slots) we need to assign different colors to braket slots of
-        // different types so must track types of braket slots:
+        // slot sets (i.e. bra[0] is paired with ket[0], etc.), gaps between
+        // occupied slots are occupied by null indices) we need to assign
+        // different colors to braket slots of different types so must track
+        // types of braket slots:
         // - if tensor is not particle symmetric braket slots will already be
         // colored uniquely (by particle index)
         // - if tensor is symmetric/antisymmetric braket slots have same color
         // - if tensor is particle symmetric then assign different colors to
         // braket slots of different types (paired vs unpaired)
+
+        // N.B. emtpy slots are not skipped!
+
         const auto is_paired_particle = i < num_paired_particles;
         std::size_t color_id = i;
         if (is_symm)
@@ -965,65 +1015,41 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
         }
 
         if (options.make_labels)
-          graph.vertex_labels.emplace_back(L"bra_" + std::to_wstring(i + 1));
+          graph.vertex_labels.emplace_back((is_bra ? L"bra_" : L"ket_") +
+                                           std::to_wstring(i + 1));
         if (options.make_texlabels)
           graph.vertex_texlabels.emplace_back(std::nullopt);
-        graph.vertex_types.push_back(VertexType::TensorBra);
+        graph.vertex_types.push_back(vertex_type);
         // use different colors for each index slot if not particle symmetric
         graph.vertex_colors.push_back(colorizer(BraGroup{color_id}));
 
-        const std::size_t braket_vertex =
-            tensor_vertex + (is_symm ? 2 : (i + 1));
-        edges.push_back(std::make_pair(braket_vertex, nvertex));
+        // connect to bra bundle vertex, regardless of symmetry
+        {
+          const std::size_t slot_bundle_vertex_offset =
+              /* tensor core vertex */ 1 + /* {bra,ket} bundle vertex */ 1 +
+              /* {bra_i,ket_i} bundle vertices */
+              (!is_symm ? num_particles : 0);
+          const std::size_t slot_vertex =
+              tensor_vertex + slot_bundle_vertex_offset +
+              /* bra or ket bundle vertex */ (is_bra ? 0 : 1);
+          edges.push_back(std::make_pair(slot_vertex, nvertex));
+        }
+        // for asymmetric tensors also connect to the {bra_i,ket_i} bundle
+        // vertex
+        if (!is_symm) {
+          const std::size_t braket_bundle_vertex =
+              tensor_vertex +
+              /* tensor core vertex */ 1 +
+              /* {bra,ket} bundle vertex */ 1 +
+              /* {bra_i,ket_i} bundle vertex */ i;
+          edges.push_back(std::make_pair(braket_bundle_vertex, nvertex));
+        }
         // make sure logic in index_slot_offset is correct
         assert(nvertex ==
-               tensor_vertex + index_slot_offset(tensor, Origin::Bra, i));
+               tensor_vertex + index_slot_offset(tensor, slot_type, i));
         ++nvertex;
       }
-
-      for (std::size_t i = 0; i < ket_rank(tensor); ++i) {
-        // N.B. currently AbstractTensor only supports "left"-aligned bra/ket
-        // slot sets (i.e. bra[0] is paired with ket[0], etc.) no gaps between
-        // occupied slots) we need to assign different colors to braket slots of
-        // different types so must track types of braket slots:
-        // - if tensor is not particle symmetric braket slots will already be
-        // colored uniquely (by particle index)
-        // - if tensor is symmetric/antisymmetric braket slots have same color
-        // - if tensor is particle symmetric then assign different colors to
-        // braket slots of different types (paired vs unpaired)
-        const auto is_paired_particle = i < num_paired_particles;
-        std::size_t color_id = i;
-        if (is_symm)
-          color_id = 0;
-        else if (is_part_symm) {
-          if (is_paired_particle)
-            color_id = 0;
-          else
-            color_id = 1;
-        }
-
-        if (options.make_labels)
-          graph.vertex_labels.emplace_back(L"ket_" + std::to_wstring(i + 1));
-        if (options.make_texlabels)
-          graph.vertex_texlabels.emplace_back(std::nullopt);
-        graph.vertex_types.push_back(VertexType::TensorKet);
-        // - use same color for kets if symmetric wrt bra<->ket
-        // - use different colors for each index slot if not particle symmetric
-        if (is_braket_symm) {
-          graph.vertex_colors.push_back(colorizer(BraGroup{color_id}));
-        } else {
-          graph.vertex_colors.push_back(colorizer(KetGroup{color_id}));
-        }
-
-        const std::size_t braket_vertex =
-            tensor_vertex + (is_symm ? 3 : (i + 1));
-        edges.push_back(std::make_pair(braket_vertex, nvertex));
-        // make sure logic in index_slot_offset is correct
-        assert(nvertex ==
-               tensor_vertex + index_slot_offset(tensor, Origin::Ket, i));
-        ++nvertex;
-      }
-    }
+    }  // bra+ket slots
 
     // TODO: handle aux indices permutation symmetries once they are supported
     // for now, auxiliary indices are considered to always be asymmetric

--- a/SeQuant/core/tensor_network_v3.hpp
+++ b/SeQuant/core/tensor_network_v3.hpp
@@ -109,21 +109,25 @@ class TensorNetworkV3 {
               "to a non-aux slot");
         }
         // - can connect bra slot to ket slot, and vice versa, unless there is
-        // no distinction between primal and dual spaces if (first.getOrigin()
-        // == Origin::Bra &&
-        //     vertex.getOrigin() != Origin::Ket) {
-        //   throw std::invalid_argument(
-        //       "TensorNetworkV3::Edge::connect_to: bra slot can only be "
-        //       "connected "
-        //       "to a ket slot");
-        // }
-        // if (first.getOrigin() == Origin::Ket &&
-        //     vertex.getOrigin() != Origin::Bra) {
-        //   throw std::invalid_argument(
-        //       "TensorNetworkV3::Edge::connect_to: ket slot can only be "
-        //       "connected "
-        //       "to a bra slot");
-        // }
+        // no distinction between primal and dual spaces
+        if (get_default_context().braket_symmetry() != BraKetSymmetry::symm) {
+          if (first.getOrigin() == Origin::Bra &&
+              vertex.getOrigin() != Origin::Ket) {
+            throw std::invalid_argument(
+                "TensorNetworkV3::Edge::connect_to: bra slot can only be "
+                "connected "
+                "to a ket slot if default context's braket_symmetry() != "
+                "BraKetSymmetry::symm");
+          }
+          if (first.getOrigin() == Origin::Ket &&
+              vertex.getOrigin() != Origin::Bra) {
+            throw std::invalid_argument(
+                "TensorNetworkV3::Edge::connect_to: ket slot can only be "
+                "connected "
+                "to a bra slot if default context's braket_symmetry() != "
+                "BraKetSymmetry::symm");
+          }
+        }
         add_vertex(vertex);
       }
 

--- a/SeQuant/core/tensor_network_v3.hpp
+++ b/SeQuant/core/tensor_network_v3.hpp
@@ -108,21 +108,22 @@ class TensorNetworkV3 {
               "TensorNetworkV3::Edge::connect_to: aux slot cannot be connected "
               "to a non-aux slot");
         }
-        // - can connect bra slot to ket slot, and vice versa
-        if (first.getOrigin() == Origin::Bra &&
-            vertex.getOrigin() != Origin::Ket) {
-          throw std::invalid_argument(
-              "TensorNetworkV3::Edge::connect_to: bra slot can only be "
-              "connected "
-              "to a ket slot");
-        }
-        if (first.getOrigin() == Origin::Ket &&
-            vertex.getOrigin() != Origin::Bra) {
-          throw std::invalid_argument(
-              "TensorNetworkV3::Edge::connect_to: ket slot can only be "
-              "connected "
-              "to a bra slot");
-        }
+        // - can connect bra slot to ket slot, and vice versa, unless there is
+        // no distinction between primal and dual spaces if (first.getOrigin()
+        // == Origin::Bra &&
+        //     vertex.getOrigin() != Origin::Ket) {
+        //   throw std::invalid_argument(
+        //       "TensorNetworkV3::Edge::connect_to: bra slot can only be "
+        //       "connected "
+        //       "to a ket slot");
+        // }
+        // if (first.getOrigin() == Origin::Ket &&
+        //     vertex.getOrigin() != Origin::Bra) {
+        //   throw std::invalid_argument(
+        //       "TensorNetworkV3::Edge::connect_to: ket slot can only be "
+        //       "connected "
+        //       "to a bra slot");
+        // }
         add_vertex(vertex);
       }
 

--- a/SeQuant/core/tensor_network_v3.hpp
+++ b/SeQuant/core/tensor_network_v3.hpp
@@ -76,10 +76,15 @@ class TensorNetworkV3 {
 
   /// Edge in a TensorNetworkV3 = the Index annotating it +
   /// a list of vertices corresponding to the Tensor index slots it connects
+  /// @note this is move-only since using pointers to refer to Index objects
   // clang-format on
   class Edge {
    public:
     Edge() = default;
+    Edge(const Edge &) = delete;
+    Edge(Edge &&) = default;
+    Edge &operator=(const Edge &) = delete;
+    Edge &operator=(Edge &&) = default;
     explicit Edge(const Vertex &vertex) : vertices{vertex} {}
     explicit Edge(std::initializer_list<Vertex> vertices) {
       ranges::for_each(vertices,
@@ -225,6 +230,17 @@ class TensorNetworkV3 {
 
     init_edges();
   }
+
+  TensorNetworkV3(TensorNetworkV3 &&) noexcept;
+  TensorNetworkV3 &operator=(TensorNetworkV3 &&) noexcept;
+
+  /// copy constructor
+  /// @warning does not copy edges
+  TensorNetworkV3(const TensorNetworkV3 &other);
+
+  /// copy assignment
+  /// @warning does not copy edges
+  TensorNetworkV3 &operator=(const TensorNetworkV3 &other) noexcept;
 
   /// @return const reference to the sequence of tensors
   /// @note after invoking TensorNetwork::canonicalize() the order of

--- a/SeQuant/core/tensor_network_v3.hpp
+++ b/SeQuant/core/tensor_network_v3.hpp
@@ -45,11 +45,7 @@ class TensorNetworkV3 {
   // for unit testing only
   friend class TensorNetworkV3Accessor;
 
-  enum class Origin {
-    Bra = 1,
-    Ket,
-    Aux,
-  };
+  using Origin = SlotType;
 
   class Vertex {
    public:
@@ -486,15 +482,15 @@ class TensorNetworkV3 {
 
 template <typename CharT, typename Traits>
 std::basic_ostream<CharT, Traits> &operator<<(
-    std::basic_ostream<CharT, Traits> &stream, TensorNetworkV3::Origin origin) {
+    std::basic_ostream<CharT, Traits> &stream, SlotType origin) {
   switch (origin) {
-    case TensorNetworkV3::Origin::Bra:
+    case SlotType::Bra:
       stream << "Bra";
       break;
-    case TensorNetworkV3::Origin::Ket:
+    case SlotType::Ket:
       stream << "Ket";
       break;
-    case TensorNetworkV3::Origin::Aux:
+    case SlotType::Aux:
       stream << "Aux";
       break;
   }

--- a/SeQuant/core/wick.hpp
+++ b/SeQuant/core/wick.hpp
@@ -102,7 +102,7 @@ class WickTheorem {
       "basis")]] WickTheorem &
   spinfree(bool sf) {
     if (!((sf && get_default_context(S).spbasis() == SPBasis::spinfree) ||
-          (!sf && get_default_context(S).spbasis() == SPBasis::spinorbital))) {
+          (!sf && get_default_context(S).spbasis() == SPBasis::spinor))) {
       throw std::invalid_argument(
           "WickTheorem<S>::spinfree(sf): sf must match the contents of "
           "get_default_context(S).spbasis() (N.B. WickTheorem::spinfree() is "

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -866,7 +866,7 @@ ExprPtr P(nₚ np, nₕ nh) {
     const auto K = np;  // K = np = nh
     return S(-K);
   } else {
-    assert(get_default_context().spbasis() == SPBasis::spinorbital);
+    assert(get_default_context().spbasis() == SPBasis::spinor);
     return A(-np, -nh);
   }
 }
@@ -1039,10 +1039,9 @@ ExprPtr vac_av(ExprPtr expr, std::vector<std::pair<int, int>> nop_connections,
                bool use_top) {
   simplify(expr);
   auto isr = get_default_context().index_space_registry();
-  const auto spinorbital =
-      get_default_context().spbasis() == SPBasis::spinorbital;
+  const auto spinor = get_default_context().spbasis() == SPBasis::spinor;
   // convention is to use different label for spin-orbital and spin-free RDM
-  const auto rdm_label = spinorbital ? optype2label.at(OpType::RDM) : L"Γ";
+  const auto rdm_label = spinor ? optype2label.at(OpType::RDM) : L"Γ";
 
   // only need full contractions if don't have any density outside of
   // the orbitals occupied in the vacuum
@@ -1089,8 +1088,8 @@ ExprPtr vac_av(ExprPtr expr, std::vector<std::pair<int, int>> nop_connections,
             : isr->reference_occupied_space(Spin::any);
 
     // STEP1. replace NOPs by RDM
-    auto replace_nop_with_rdm = [&rdm_label, spinorbital](ExprPtr& exptr) {
-      auto replace = [&rdm_label, spinorbital](const auto& nop) -> ExprPtr {
+    auto replace_nop_with_rdm = [&rdm_label, spinor](ExprPtr& exptr) {
+      auto replace = [&rdm_label, spinor](const auto& nop) -> ExprPtr {
         using index_container = container::svector<Index>;
         auto braidxs = nop.annihilators() |
                        ranges::views::transform(
@@ -1105,7 +1104,7 @@ ExprPtr vac_av(ExprPtr expr, std::vector<std::pair<int, int>> nop_connections,
         const auto rank = braidxs.size();
         return ex<Tensor>(
             rdm_label, bra(std::move(braidxs)), ket(std::move(ketidxs)),
-            rank > 1 && spinorbital ? Symmetry::antisymm : Symmetry::nonsymm);
+            rank > 1 && spinor ? Symmetry::antisymm : Symmetry::nonsymm);
       };
 
       if (exptr.template is<FNOperator>()) {

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -561,7 +561,7 @@ namespace mbpt {
 /// and indices \f$ \{ b_i \} \f$ / \f$ \{ k_i \} \f$.
 /// @note The choice of computational basis can be controlled by the default Context.
 ///       See `SeQuant/core/context.hpp` and `SeQuant/mbpt/context.hpp`
-/// @warning Tensor \f$ T \f$ will be antisymmetrized if `get_default_context().spbasis() == SPBasis::spinorbital`, else it will be particle-symmetric; the latter is only valid if # of bra and ket indices coincide.
+/// @warning Tensor \f$ T \f$ will be antisymmetrized if `get_default_context().spbasis() == SPBasis::spinor`, else it will be particle-symmetric; the latter is only valid if # of bra and ket indices coincide.
 /// @internal bless the maker and his water
 // clang-format on
 template <Statistics S>
@@ -634,9 +634,8 @@ class OpMaker {
                       const container::svector<IndexSpace>& annihilators,
                       TensorGenerator&& tensor_generator,
                       UseDepIdx dep = UseDepIdx::None) {
-    const bool symm =
-        get_default_context().spbasis() ==
-        SPBasis::spinorbital;  // antisymmetrize if spin-orbital basis
+    const bool symm = get_default_context().spbasis() ==
+                      SPBasis::spinor;  // antisymmetrize if spin-orbital basis
     const auto dep_bra = dep == UseDepIdx::Bra;
     const auto dep_ket = dep == UseDepIdx::Ket;
 

--- a/benchmarks/main.cpp
+++ b/benchmarks/main.cpp
@@ -10,14 +10,14 @@ int main(int argc, char *argv[]) {
   // Disable multithreading
   set_num_threads(1);
   set_locale();
-  Context fermi_ctx = Context(mbpt::make_sr_spaces(), Vacuum::SingleProduct,
-                              IndexSpaceMetric::Unit, BraKetSymmetry::nonsymm,
-                              SPBasis::spinorbital);
+  Context fermi_ctx =
+      Context(mbpt::make_sr_spaces(), Vacuum::SingleProduct,
+              IndexSpaceMetric::Unit, BraKetSymmetry::nonsymm, SPBasis::spinor);
   set_default_context(fermi_ctx);
 
   Context bose_einstein_ctx =
       Context(mbpt::make_sr_spaces(), Vacuum::Physical, IndexSpaceMetric::Unit,
-              BraKetSymmetry::nonsymm, SPBasis::spinorbital);
+              BraKetSymmetry::nonsymm, SPBasis::spinor);
 
   set_default_context(bose_einstein_ctx, Statistics::BoseEinstein);
 

--- a/tests/integration/eomcc.cpp
+++ b/tests/integration/eomcc.cpp
@@ -82,7 +82,7 @@ class compute_eomcc {
   }
 
   void operator()(bool print) {
-    assert(get_default_context().spbasis() == SPBasis::spinorbital);
+    assert(get_default_context().spbasis() == SPBasis::spinor);
     timer_pool.start(N);
     std::vector<ExprPtr> eqvec;
     switch (type) {
@@ -189,7 +189,7 @@ int main(int argc, char* argv[]) {
   sequant::detail::OpIdRegistrar op_id_registrar;
   sequant::set_default_context(sequant::Context(
       make_min_sr_spaces(), Vacuum::SingleProduct, IndexSpaceMetric::Unit,
-      BraKetSymmetry::conjugate, SPBasis::spinorbital));
+      BraKetSymmetry::conjugate, SPBasis::spinor));
   TensorCanonicalizer::register_instance(
       std::make_shared<DefaultTensorCanonicalizer>());
 

--- a/tests/integration/eval/btas/main.cpp
+++ b/tests/integration/eval/btas/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char* argv[]) {
   detail::OpIdRegistrar op_id_registrar;
   sequant::set_default_context(Context(
       mbpt::make_min_sr_spaces(), Vacuum::SingleProduct, IndexSpaceMetric::Unit,
-      BraKetSymmetry::conjugate, SPBasis::spinorbital));
+      BraKetSymmetry::conjugate, SPBasis::spinor));
   TensorCanonicalizer::register_instance(
       std::make_shared<DefaultTensorCanonicalizer>());
 

--- a/tests/integration/eval/ta/main.cpp
+++ b/tests/integration/eval/ta/main.cpp
@@ -70,7 +70,7 @@ int main(int argc, char* argv[]) {
   detail::OpIdRegistrar op_id_registrar;
   sequant::set_default_context(Context(
       mbpt::make_min_sr_spaces(), Vacuum::SingleProduct, IndexSpaceMetric::Unit,
-      BraKetSymmetry::conjugate, SPBasis::spinorbital));
+      BraKetSymmetry::conjugate, SPBasis::spinor));
   TensorCanonicalizer::register_instance(
       std::make_shared<DefaultTensorCanonicalizer>());
 

--- a/tests/integration/osstcc.cpp
+++ b/tests/integration/osstcc.cpp
@@ -26,7 +26,7 @@ int main(int argc, char* argv[]) {
 
   sequant::set_default_context(Context(
       mbpt::make_min_sr_spaces(), Vacuum::SingleProduct, IndexSpaceMetric::Unit,
-      BraKetSymmetry::conjugate, SPBasis::spinorbital));
+      BraKetSymmetry::conjugate, SPBasis::spinor));
   TensorCanonicalizer::register_instance(
       std::make_shared<DefaultTensorCanonicalizer>());
 

--- a/tests/integration/srcc.cpp
+++ b/tests/integration/srcc.cpp
@@ -45,7 +45,7 @@ inline const std::map<std::string, mbpt::CSV> str2uocc = {
 
 /// maps SPBasis type string to enum
 inline const std::map<std::string, SPBasis> str2spbasis = {
-    {"so", SPBasis::spinorbital}, {"sf", SPBasis::spinfree}};
+    {"so", SPBasis::spinor}, {"sf", SPBasis::spinfree}};
 
 // profiles evaluation of all CC equations for a given ex rank N with projection
 // ex rank PMIN .. P
@@ -84,7 +84,7 @@ class compute_cceqvec {
       auto context_resetter = sequant::set_scoped_default_context(
           sequant::Context(make_min_sr_spaces(), Vacuum::SingleProduct,
                            IndexSpaceMetric::Unit, BraKetSymmetry::conjugate,
-                           SPBasis::spinorbital));
+                           SPBasis::spinor));
       std::vector<ExprPtr> eqvec_so;
       switch (type) {
         case EqnType::t:
@@ -119,7 +119,7 @@ class compute_cceqvec {
       // validate known sizes of some CC residuals
       // N.B. # of equations depends on whether we use symmetric or
       // antisymmetric amplitudes
-      if (get_default_context().spbasis() == SPBasis::spinorbital) {
+      if (get_default_context().spbasis() == SPBasis::spinor) {
         if (type == EqnType::t) {
           if (R == 1 && N == 1) runtime_assert(eqvec[R]->size() == 8);
           if (R == 1 && N == 2) runtime_assert(eqvec[R]->size() == 14);

--- a/tests/integration/stcc.cpp
+++ b/tests/integration/stcc.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) {
 
   sequant::set_default_context(Context(
       mbpt::make_min_sr_spaces(), Vacuum::SingleProduct, IndexSpaceMetric::Unit,
-      BraKetSymmetry::conjugate, SPBasis::spinorbital));
+      BraKetSymmetry::conjugate, SPBasis::spinor));
   TensorCanonicalizer::register_instance(
       std::make_shared<DefaultTensorCanonicalizer>());
 

--- a/tests/integration/stcc_rigorous.cpp
+++ b/tests/integration/stcc_rigorous.cpp
@@ -27,7 +27,7 @@ int main(int argc, char* argv[]) {
 
   sequant::set_default_context(Context(
       mbpt::make_min_sr_spaces(), Vacuum::SingleProduct, IndexSpaceMetric::Unit,
-      BraKetSymmetry::conjugate, SPBasis::spinorbital));
+      BraKetSymmetry::conjugate, SPBasis::spinor));
   TensorCanonicalizer::register_instance(
       std::make_shared<DefaultTensorCanonicalizer>());
 

--- a/tests/unit/test_canonicalize.cpp
+++ b/tests/unit/test_canonicalize.cpp
@@ -180,31 +180,25 @@ TEST_CASE("canonicalization", "[algorithms]") {
           ex<Tensor>(L"t", bra{L"p_3"}, ket{L"p_1"}, Symmetry::nonsymm);
       canonicalize(input);
       // because bra and ket are in same space dummy renaming flips the bra and
-      // ket even though the tensors are not bra-ket symmmetric
+      // ket even though the tensors are not bra-ket symmetric
       REQUIRE_THAT(
           input, EquivalentTo("1/2 t{p1;p3} t{p2;p4} B{p3;p1;p5} B{p4;p2;p5}"));
     }
     // with bra-ket symmetry
     {
-      // in this example bra and ket differ, so flipping them is nontrivial and
-      // must leverage the bra-ket symmetry
+      Context ctx = get_default_context();
+      ctx.set(BraKetSymmetry::symm);
+      auto resetter = set_scoped_default_context(ctx);
+      // TN is invariant wrt flipping one if the tensors
+      // N.B. it's not possible purely to canonicalize each tensor since bra and
+      // ket slots are equivalent, only the overall TN topology determines
+      // whether bra/ket swap should occur for each tensor
       auto input = ex<Constant>(rational{1, 2}) *
-                   ex<Tensor>(L"B", bra{L"a_2"}, ket{L"p_4"}, aux{L"p_5"},
+                   ex<Tensor>(L"B", bra{L"p_2"}, ket{L"p_1"}, aux{L"p_5"},
                               Symmetry::nonsymm, BraKetSymmetry::symm) *
-                   ex<Tensor>(L"B", bra{L"a_1"}, ket{L"p_3"}, aux{L"p_5"},
-                              Symmetry::nonsymm, BraKetSymmetry::symm) *
-                   ex<Tensor>(L"t", bra{L"p_4"}, ket{L"a_2"}, Symmetry::nonsymm,
-                              BraKetSymmetry::symm) *
-                   ex<Tensor>(L"t", bra{L"p_3"}, ket{L"a_1"}, Symmetry::nonsymm,
-                              BraKetSymmetry::symm);
-      REQUIRE_THAT(
-          input,
-          EquivalentTo(
-              "1/2 t{p3;a1}:N-S t{p4;a2}:N-S B{a1;p3;p5}:N-S B{a2;p4;p5}:N-S"));
-      REQUIRE_THAT(
-          input,
-          EquivalentTo(
-              "1/2 t{a1;p3}:N-S t{a2;p4}:N-S B{p3;a1;p5}:N-S B{p4;a2;p5}:N-S"));
+                   ex<Tensor>(L"B", bra{L"p_1"}, ket{L"p_2"}, aux{L"p_5"},
+                              Symmetry::nonsymm, BraKetSymmetry::symm);
+      REQUIRE_THAT(input, EquivalentTo("1/2 B{p1;p2;p5}:N-S B{p1;p2;p5}:N-S"));
     }
   }
 

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char* argv[]) {
   sequant::set_default_context(
       Context(sequant::mbpt::make_sr_spaces(), Vacuum::SingleProduct,
               IndexSpaceMetric::Unit, BraKetSymmetry::conjugate,
-              SPBasis::spinorbital, 100, BraKetTypesetting::ContraSub,
+              SPBasis::spinor, 100, BraKetTypesetting::ContraSub,
               // to_latex() reference outputs predominantly assume the original
               // (naive) convention
               BraKetSlotTypesetting::Naive));

--- a/tests/unit/test_runtime.cpp
+++ b/tests/unit/test_runtime.cpp
@@ -15,60 +15,69 @@
 TEST_CASE("context", "[runtime]") {
   using namespace sequant;
 
-  CHECK_NOTHROW(get_default_context());
-  auto initial_ctx = get_default_context();
+  SECTION("constructors") {
+    REQUIRE_NOTHROW(Context{});
 
-  // basic set_default_context test
-  CHECK_NOTHROW(set_default_context(Context(
-      mbpt::make_sr_spaces(), Vacuum::SingleProduct, IndexSpaceMetric::Unit,
-      BraKetSymmetry::symm, SPBasis::spinfree)));
-  CHECK(get_default_context().vacuum() == Vacuum::SingleProduct);
-  CHECK(get_default_context().metric() == IndexSpaceMetric::Unit);
-  CHECK(get_default_context().braket_symmetry() == BraKetSymmetry::symm);
-  CHECK(get_default_context().spbasis() == SPBasis::spinfree);
+    REQUIRE_NOTHROW(Context({.vacuum = Vacuum::Invalid}));
+    REQUIRE(Context({.vacuum = Vacuum::Invalid}).vacuum() == Vacuum::Invalid);
+  }
 
-  // set distinct contexts for fermi and bose statistics
-  auto [fermi_isr, bose_isr] = mbpt::make_fermi_and_bose_spaces();
-  CHECK(fermi_isr->spaces() ==
-        bose_isr->spaces());  // fermi_isr and bose_isr share the space set
-  CHECK_NOTHROW(set_default_context(
-      {{Statistics::FermiDirac, Context(fermi_isr, Vacuum::SingleProduct)},
-       {Statistics::BoseEinstein, Context(bose_isr, Vacuum::Physical)}}));
-  CHECK(get_default_context(Statistics::Arbitrary).vacuum() ==
-        Vacuum::SingleProduct);
-  CHECK(get_default_context(Statistics::FermiDirac).vacuum() ==
-        Vacuum::SingleProduct);
-  CHECK(get_default_context(Statistics::BoseEinstein).vacuum() ==
-        Vacuum::Physical);
+  SECTION("default context") {
+    CHECK_NOTHROW(get_default_context());
+    auto initial_ctx = get_default_context();
 
-  // reset back to default
-  CHECK_NOTHROW(reset_default_context());
-  CHECK(get_default_context().vacuum() == Vacuum::Physical);
-  CHECK(get_default_context().metric() == IndexSpaceMetric::Unit);
-  CHECK(get_default_context().braket_symmetry() == BraKetSymmetry::conjugate);
-  CHECK(get_default_context().spbasis() == SPBasis::spinor);
-
-  // reset back to initial context
-  CHECK_NOTHROW(set_default_context(initial_ctx));
-  CHECK(get_default_context() == initial_ctx);
-  CHECK(!(get_default_context() != initial_ctx));
-
-  // scoped changes to default context
-  {
-    // if we do not save the resetter context is reset back immediately
-    CHECK_NOTHROW(set_scoped_default_context(Context(
+    // basic set_default_context test
+    CHECK_NOTHROW(set_default_context(Context(
         mbpt::make_sr_spaces(), Vacuum::SingleProduct, IndexSpaceMetric::Unit,
         BraKetSymmetry::symm, SPBasis::spinfree)));
-    CHECK(get_default_context() == initial_ctx);
+    CHECK(get_default_context().vacuum() == Vacuum::SingleProduct);
+    CHECK(get_default_context().metric() == IndexSpaceMetric::Unit);
+    CHECK(get_default_context().braket_symmetry() == BraKetSymmetry::symm);
+    CHECK(get_default_context().spbasis() == SPBasis::spinfree);
 
-    auto ctx = get_default_context();
-    ctx.set(mbpt::make_sr_spaces());
-    ctx.set(BraKetSymmetry::symm);
-    ctx.set(SPBasis::spinfree);
-    const auto ctx_copy = ctx;
-    auto resetter = set_scoped_default_context(ctx);
-    CHECK(get_default_context() == ctx_copy);
+    // set distinct contexts for fermi and bose statistics
+    auto [fermi_isr, bose_isr] = mbpt::make_fermi_and_bose_spaces();
+    CHECK(fermi_isr->spaces() ==
+          bose_isr->spaces());  // fermi_isr and bose_isr share the space set
+    CHECK_NOTHROW(set_default_context(
+        {{Statistics::FermiDirac, Context(fermi_isr, Vacuum::SingleProduct)},
+         {Statistics::BoseEinstein, Context(bose_isr, Vacuum::Physical)}}));
+    CHECK(get_default_context(Statistics::Arbitrary).vacuum() ==
+          Vacuum::SingleProduct);
+    CHECK(get_default_context(Statistics::FermiDirac).vacuum() ==
+          Vacuum::SingleProduct);
+    CHECK(get_default_context(Statistics::BoseEinstein).vacuum() ==
+          Vacuum::Physical);
+
+    // reset back to default
+    CHECK_NOTHROW(reset_default_context());
+    CHECK(get_default_context().vacuum() == Vacuum::Physical);
+    CHECK(get_default_context().metric() == IndexSpaceMetric::Unit);
+    CHECK(get_default_context().braket_symmetry() == BraKetSymmetry::conjugate);
+    CHECK(get_default_context().spbasis() == SPBasis::spinor);
+
+    // reset back to initial context
+    CHECK_NOTHROW(set_default_context(initial_ctx));
+    CHECK(get_default_context() == initial_ctx);
+    CHECK(!(get_default_context() != initial_ctx));
+
+    // scoped changes to default context
+    {
+      // if we do not save the resetter context is reset back immediately
+      CHECK_NOTHROW(set_scoped_default_context(Context(
+          mbpt::make_sr_spaces(), Vacuum::SingleProduct, IndexSpaceMetric::Unit,
+          BraKetSymmetry::symm, SPBasis::spinfree)));
+      CHECK(get_default_context() == initial_ctx);
+
+      auto ctx = get_default_context();
+      ctx.set(mbpt::make_sr_spaces());
+      ctx.set(BraKetSymmetry::symm);
+      ctx.set(SPBasis::spinfree);
+      const auto ctx_copy = ctx;
+      auto resetter = set_scoped_default_context(ctx);
+      CHECK(get_default_context() == ctx_copy);
+    }
+    // leaving scope resets the context back
+    CHECK(get_default_context() == initial_ctx);
   }
-  // leaving scope resets the context back
-  CHECK(get_default_context() == initial_ctx);
 }

--- a/tests/unit/test_runtime.cpp
+++ b/tests/unit/test_runtime.cpp
@@ -46,7 +46,7 @@ TEST_CASE("context", "[runtime]") {
   CHECK(get_default_context().vacuum() == Vacuum::Physical);
   CHECK(get_default_context().metric() == IndexSpaceMetric::Unit);
   CHECK(get_default_context().braket_symmetry() == BraKetSymmetry::conjugate);
-  CHECK(get_default_context().spbasis() == SPBasis::spinorbital);
+  CHECK(get_default_context().spbasis() == SPBasis::spinor);
 
   // reset back to initial context
   CHECK_NOTHROW(set_default_context(initial_ctx));

--- a/tests/unit/test_tensor_network.cpp
+++ b/tests/unit/test_tensor_network.cpp
@@ -1775,10 +1775,6 @@ TEST_CASE("tensor_network_v3", "[elements]") {
     }
 
     SECTION("empty slots") {
-      // Logger::instance().canonicalize = true;
-      // Logger::instance().canonicalize_input_graph = true;
-      // Logger::instance().canonicalize_dot = true;
-
       // try 1
       ExprPtr result_1;
       {

--- a/tests/unit/test_tensor_network.cpp
+++ b/tests/unit/test_tensor_network.cpp
@@ -1546,7 +1546,7 @@ TEST_CASE("tensor_network_v3", "[elements]") {
       TN tn(*t1_x_t2);
 
       // edges
-      auto edges = tn.edges();
+      const auto& edges = tn.edges();
       REQUIRE(edges.size() == 3);
 
       // ext indices

--- a/tests/unit/test_wick.cpp
+++ b/tests/unit/test_wick.cpp
@@ -140,7 +140,7 @@ TEST_CASE("wick", "[algorithms][wick]") {
       SEQUANT_PRAGMA_GCC(diagnostic push)
       SEQUANT_PRAGMA_GCC(diagnostic ignored "-Wdeprecated-declarations")
 
-      if (get_default_context().spbasis() == SPBasis::spinorbital) {
+      if (get_default_context().spbasis() == SPBasis::spinor) {
         REQUIRE_NOTHROW(wick1.spinfree(false));
         REQUIRE_THROWS_AS(wick1.spinfree(true), std::invalid_argument);
       }
@@ -374,7 +374,7 @@ TEST_CASE("wick", "[algorithms][wick]") {
 
       // if Wick's theorem's result is in "canonical" (columns-matching-inputs
       // ... this is what Kutzelnigg calls generalized Wick's theorem) it works
-      // same for spinorbital and spinfree basis for physical vacuum
+      // same for spinor and spinfree basis for physical vacuum
       auto raii_tmp = switch_to_spinfree_context();
       REQUIRE_NOTHROW(wick.full_contractions(false).compute());
       auto result_sf = wick.full_contractions(false).compute();

--- a/utilities/external-interface/external_interface.cpp
+++ b/utilities/external-interface/external_interface.cpp
@@ -331,7 +331,7 @@ void generalSetup() {
 int main(int argc, char **argv) {
   set_locale();
   set_default_context(Context(Vacuum::SingleProduct, IndexSpaceMetric::Unit,
-                              BraKetSymmetry::conjugate, SPBasis::spinorbital));
+                              BraKetSymmetry::conjugate, SPBasis::spinor));
   generalSetup();
 
   CLI::App app(

--- a/utilities/tensor_network_graphs.cpp
+++ b/utilities/tensor_network_graphs.cpp
@@ -47,8 +47,10 @@ void print_help() {
       << "  <exe> [options] <network 1> [<network 2> [... [<network N>] ] ]\n";
   std::wcout << "Options:\n";
   std::wcout << "  --help     Shows this help message\n";
+  std::wcout
+      << "  --v1       Use original TensorNetwork (aka TensorNetworkV1)\n";
   std::wcout << "  --v2       Use TensorNetworkV2\n";
-  std::wcout << "  --v3       Use TensorNetworkV3\n";
+  std::wcout << "  --v3       Use TensorNetworkV3 [default]\n";
   std::wcout << "  --no-named Treat all indices as unnamed (even if they are "
                 "external)\n";
 }
@@ -60,7 +62,7 @@ int main(int argc, char **argv) {
       BraKetSymmetry::conjugate, SPBasis::spinorbital));
 
   bool use_named_indices = true;
-  int version = 1;
+  int version = 3;
   const TensorNetwork::named_indices_t empty_named_indices;
 
   if (argc <= 1) {
@@ -75,6 +77,9 @@ int main(int argc, char **argv) {
       return 0;
     } else if (current == L"--no-named") {
       use_named_indices = false;
+      continue;
+    } else if (current == L"--v1") {
+      version = 1;
       continue;
     } else if (current == L"--v2") {
       version = 2;

--- a/utilities/tensor_network_graphs.cpp
+++ b/utilities/tensor_network_graphs.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
   set_locale();
   sequant::set_default_context(Context(
       mbpt::make_sr_spaces(), Vacuum::SingleProduct, IndexSpaceMetric::Unit,
-      BraKetSymmetry::conjugate, SPBasis::spinorbital));
+      BraKetSymmetry::conjugate, SPBasis::spinor));
 
   bool use_named_indices = true;
   int version = 3;


### PR DESCRIPTION
this is implemented just like support for canonicalization of slots (bra and ket introduced in v3) and braket slot bundles (in v2). Need to introduce vertices for bra and ket slot bundles and swap them if needed. Currently we don't have the support for conjugation as canonicalization biproduct, but I think tensors already have the support for conjugation. For real tensors straight swap is enough.