### PR TITLE
Undo indices() -> braketaux() renaming

### DIFF
--- a/SeQuant/core/abstract_tensor.hpp
+++ b/SeQuant/core/abstract_tensor.hpp
@@ -152,6 +152,11 @@ class AbstractTensor {
   virtual const_any_view_rand _braketaux() const {
     throw missing_instantiation_for("_braketaux");
   }
+  /// accesses all slots
+  /// @return view of a not necessarily contiguous range of Index objects
+  virtual const_any_view_rand _slots() const {
+    throw missing_instantiation_for("_slots");
+  }
   /// @return the number of bra slots (some may be empty, hence this is the
   /// gross rank)
   virtual std::size_t _bra_rank() const {
@@ -356,9 +361,9 @@ class AbstractTensor {
 /// objects.
 /// @{
 inline auto braket(const AbstractTensor& t) { return t._braket(); }
-inline auto braketaux(const AbstractTensor& t) { return t._braketaux(); }
-/// @return a view of all indices; currently equivalent to braketaux
-inline auto indices(const AbstractTensor& t) { return braketaux(t); }
+inline auto braketaux(const AbstractTensor& t) { return t._slots(); }
+/// @return a view of all slots
+inline auto slots(const AbstractTensor& t) { return t._slots(); }
 inline auto bra_rank(const AbstractTensor& t) { return t._bra_rank(); }
 inline auto bra_net_rank(const AbstractTensor& t) { return t._bra_net_rank(); }
 inline auto ket_rank(const AbstractTensor& t) { return t._ket_rank(); }

--- a/SeQuant/core/eval_expr.cpp
+++ b/SeQuant/core/eval_expr.cpp
@@ -39,7 +39,7 @@ namespace {
 size_t hash_terminal_tensor(Tensor const&) noexcept;
 
 bool is_tot(Tensor const& t) noexcept {
-  return ranges::any_of(t.const_braketaux_indices(), &Index::has_proto_indices);
+  return ranges::any_of(t.const_indices(), &Index::has_proto_indices);
 }
 
 }  // namespace
@@ -88,7 +88,7 @@ EvalExpr::EvalExpr(Tensor const& tnsr)
   } else {
     hash_value_ = hash_terminal_tensor(tnsr);
     canon_phase_ = 1;
-    canon_indices_ = tnsr.braketaux_indices() | ranges::to<index_vector>;
+    canon_indices_ = tnsr.indices() | ranges::to<index_vector>;
   }
 }
 
@@ -197,7 +197,7 @@ size_t hash_indices(T const& indices) noexcept {
 size_t hash_terminal_tensor(Tensor const& tnsr) noexcept {
   size_t h = 0;
   hash::combine(h, hash::value(tnsr.label()));
-  hash::combine(h, hash_indices(tnsr.const_braketaux()));
+  hash::combine(h, hash_indices(tnsr.const_slots()));
   return h;
 }
 

--- a/SeQuant/core/export/itf.cpp
+++ b/SeQuant/core/export/itf.cpp
@@ -566,7 +566,7 @@ std::wstring ITFGenerator::generate() const {
 
   // Tensor declarations
   for (const Tensor &current : m_importedTensors) {
-    if (current.braketaux().size() == 0 && current.label() == L"One") {
+    if (current.slots().size() == 0 && current.label() == L"One") {
       // The One[] tensor exists implicitly
       continue;
     }
@@ -576,13 +576,13 @@ std::wstring ITFGenerator::generate() const {
   }
   itf += L"\n";
   for (const Tensor &current : m_createdTensors) {
-    if (current.braketaux().size() == 0 && current.label() == L"One") {
+    if (current.slots().size() == 0 && current.label() == L"One") {
       // The One[] tensor exists implicitly
       continue;
     }
 
     itf += L"tensor: " + to_itf(current, *m_ctx);
-    if (current.braketaux().size() > 0) {
+    if (current.slots().size() > 0) {
       itf += +L", !Create{type:disk}\n";
     } else {
       itf += +L", !Create{type:scalar}\n";

--- a/SeQuant/core/op.hpp
+++ b/SeQuant/core/op.hpp
@@ -836,7 +836,7 @@ class NormalOperator : public Operator<S>,
            ranges::views::transform(
                [](auto &&op) -> const Index & { return op.index(); });
   }
-  AbstractTensor::const_any_view_rand _braketaux() const override final {
+  AbstractTensor::const_any_view_rand _slots() const override final {
     return _braket();
   }
   std::size_t _bra_rank() const override final { return nannihilators(); }

--- a/SeQuant/core/optimize.hpp
+++ b/SeQuant/core/optimize.hpp
@@ -192,7 +192,7 @@ EvalSequence single_term_opt(TensorNetworkV2 const& network,
 
     nth_tensor_indices.emplace_back();
     auto& ixs = nth_tensor_indices.back();
-    for (auto&& j : braketaux(tnsr)) ixs.emplace_back(j);
+    for (auto&& j : slots(tnsr)) ixs.emplace_back(j);
 
     ranges::sort(ixs, std::less<Index>{});
   }

--- a/SeQuant/core/tensor.hpp
+++ b/SeQuant/core/tensor.hpp
@@ -444,11 +444,18 @@ class Tensor : public Expr, public AbstractTensor, public Labeled {
   /// @return concatenated view of all indices of this tensor (bra, ket and
   /// aux)
   auto braketaux() const { return ranges::views::concat(bra_, ket_, aux_); }
+  /// @return concatenated view of all slots
+  auto slots() const { return ranges::views::concat(bra_, ket_, aux_); }
   /// @return concatenated view of all nonnull indices of this tensor (bra, ket
   /// and aux)
   auto braketaux_indices() const {
     return ranges::views::filter(
         braketaux(), [](const Index &idx) { return idx.nonnull(); });
+  }
+  /// @return concatenated view of all nonnull indices of this tensor
+  auto indices() const {
+    return ranges::views::filter(
+        slots(), [](const Index &idx) { return idx.nonnull(); });
   }
   /// @return view of the bra+ket slots
   /// @note this is to work around broken lookup rules
@@ -459,9 +466,15 @@ class Tensor : public Expr, public AbstractTensor, public Labeled {
   /// @return const view of all slots
   /// @note this is to work around broken lookup rules
   auto const_braketaux() const { return this->braketaux(); }
+  /// @return const view of all slots
+  /// @note this is to work around broken lookup rules
+  auto const_slots() const { return this->slots(); }
   /// @return const view of all indices
   /// @note this is to work around broken lookup rules
   auto const_braketaux_indices() const { return this->braketaux_indices(); }
+  /// @return const view of all indices
+  /// @note this is to work around broken lookup rules
+  auto const_indices() const { return this->indices(); }
   /// Returns the Symmetry object describing the symmetry of the bra and ket of
   /// the Tensor, i.e. what effect swapping indices in positions @c i  and @c j
   /// in <em>either bra or ket</em> has on the elements of the Tensor;
@@ -585,7 +598,7 @@ class Tensor : public Expr, public AbstractTensor, public Labeled {
   ExprPtr clone() const override { return ex<Tensor>(*this); }
 
   void reset_tags() const {
-    ranges::for_each(braketaux(), [](const auto &idx) { idx.reset_tag(); });
+    ranges::for_each(slots(), [](const auto &idx) { idx.reset_tag(); });
   }
 
   hash_type bra_hash_value() const {
@@ -722,6 +735,9 @@ class Tensor : public Expr, public AbstractTensor, public Labeled {
   }
   AbstractTensor::const_any_view_rand _braketaux() const override final {
     return braketaux();
+  }
+  AbstractTensor::const_any_view_rand _slots() const override final {
+    return slots();
   }
   std::size_t _bra_rank() const override final { return bra_rank(); }
   std::size_t _ket_rank() const override final { return ket_rank(); }

--- a/SeQuant/core/tensor_canonicalizer.cpp
+++ b/SeQuant/core/tensor_canonicalizer.cpp
@@ -257,7 +257,7 @@ ExprPtr NullTensorCanonicalizer::apply(AbstractTensor&) const { return {}; }
 
 void DefaultTensorCanonicalizer::tag_indices(AbstractTensor& t) const {
   // tag all indices as ext->true/ind->false
-  ranges::for_each(braketaux(t), [this](auto& idx) {
+  ranges::for_each(slots(t), [this](auto& idx) {
     auto it = external_indices_.find(idx);
     auto is_ext = it != external_indices_.end();
     idx.tag().assign(

--- a/SeQuant/core/tensor_network/utils.hpp
+++ b/SeQuant/core/tensor_network/utils.hpp
@@ -149,9 +149,8 @@ void apply_index_replacements(AbstractTensor &tensor,
                               const bool self_consistent) {
 #ifndef NDEBUG
   // assert that tensors' indices are not tagged since going to tag indices
-  assert(ranges::none_of(braketaux(tensor), [](const Index &idx) {
-    return idx.tag().has_value();
-  }));
+  assert(ranges::none_of(
+      slots(tensor), [](const Index &idx) { return idx.tag().has_value(); }));
 #endif
 
   bool pass_mutated;

--- a/SeQuant/core/utility/expr.cpp
+++ b/SeQuant/core/utility/expr.cpp
@@ -168,9 +168,9 @@ std::string toplevel_diff(const Tensor &lhs, const Tensor &rhs) {
            to_string(rhs.label());
   }
 
-  if (lhs.braketaux().size() != rhs.braketaux().size()) {
-    return std::to_string(lhs.braketaux().size()) + " indices vs. " +
-           std::to_string(rhs.braketaux().size()) + " indices";
+  if (lhs.slots().size() != rhs.slots().size()) {
+    return std::to_string(lhs.slots().size()) + " indices vs. " +
+           std::to_string(rhs.slots().size()) + " indices";
   }
 
   if (lhs.symmetry() != rhs.symmetry()) {

--- a/SeQuant/core/wick.impl.hpp
+++ b/SeQuant/core/wick.impl.hpp
@@ -246,7 +246,7 @@ inline bool apply_index_replacement_rules(
       const auto &factor = *it;
       if (factor->is<Tensor>()) {
         auto &tensor = factor->as<Tensor>();
-        assert(ranges::none_of(tensor.const_braketaux(), [](const Index &idx) {
+        assert(ranges::none_of(tensor.const_slots(), [](const Index &idx) {
           return idx.tag().has_value();
         }));
       }
@@ -372,11 +372,11 @@ void reduce_wick_impl(std::shared_ptr<Product> &expr,
       std::set<Index, Index::LabelCompare> all_indices;
       ranges::for_each(*expr, [&all_indices](const auto &factor) {
         if (factor->template is<Tensor>()) {
-          ranges::for_each(
-              factor->template as<const Tensor>().braketaux_indices(),
-              [&all_indices](const Index &idx) {
-                [[maybe_unused]] auto result = all_indices.insert(idx);
-              });
+          ranges::for_each(factor->template as<const Tensor>().indices(),
+                           [&all_indices](const Index &idx) {
+                             [[maybe_unused]] auto result =
+                                 all_indices.insert(idx);
+                           });
         }
       });
 

--- a/SeQuant/domain/mbpt/rules/csv.cpp
+++ b/SeQuant/domain/mbpt/rules/csv.cpp
@@ -100,8 +100,7 @@ ExprPtr csv_transform(ExprPtr const& expr, const IndexSpace& csv_basis,
   else if (expr->is<Tensor>()) {
     auto const& tnsr = expr->as<Tensor>();
     if (!ranges::contains(tensor_labels, tnsr.label())) return expr;
-    if (ranges::none_of(tnsr.braketaux_indices(), &Index::has_proto_indices))
-      return expr;
+    if (ranges::none_of(tnsr.indices(), &Index::has_proto_indices)) return expr;
     return csv_transform_impl(tnsr, csv_basis, coeff_tensor_label);
   } else if (expr->is<Product>()) {
     auto const& prod = expr->as<Product>();

--- a/SeQuant/domain/mbpt/spin.cpp
+++ b/SeQuant/domain/mbpt/spin.cpp
@@ -1129,7 +1129,7 @@ ExprPtr closed_shell_CC_spintrace_rigorous(ExprPtr const& expr) {
 container::set<Index, Index::LabelCompare> index_list(const ExprPtr& expr) {
   container::set<Index, Index::LabelCompare> grand_idxlist;
   if (expr->is<Tensor>()) {
-    ranges::for_each(expr->as<Tensor>().const_braketaux_indices(),
+    ranges::for_each(expr->as<Tensor>().const_indices(),
                      [&grand_idxlist](const Index& idx) {
                        idx.reset_tag();
                        grand_idxlist.insert(idx);

--- a/python/src/sequant/_sequant.cc
+++ b/python/src/sequant/_sequant.cc
@@ -143,6 +143,10 @@ PYBIND11_MODULE(_sequant, m) {
         auto slots = t.braketaux();
         return std::vector<Index>(slots.begin(), slots.end());
       });
+  .def_property_readonly("slots", [](const Tensor &t) {
+    auto slots = t.slots();
+    return std::vector<Index>(slots.begin(), slots.end());
+  });
 
   py::class_<Complex<rational>>(m, "zRational")
       .def_property_readonly("real",

--- a/tests/unit/test_eval_btas.cpp
+++ b/tests/unit/test_eval_btas.cpp
@@ -22,10 +22,10 @@ auto eval_node(sequant::ExprPtr const& expr) {
   auto node = binarize(expr);
   return transform_node(node, [](auto&& val) {
     if (val.is_tensor()) {
-      return EvalExprBTAS(*val.op_type(), val.result_type(), val.expr(),
-                          val.as_tensor().braketaux_indices() |
-                              ranges::to<EvalExpr::index_vector>(),
-                          val.canon_phase(), val.hash_value());
+      return EvalExprBTAS(
+          *val.op_type(), val.result_type(), val.expr(),
+          val.as_tensor().indices() | ranges::to<EvalExpr::index_vector>(),
+          val.canon_phase(), val.hash_value());
     } else
       return EvalExprBTAS(val);
   });

--- a/tests/unit/test_spin.cpp
+++ b/tests/unit/test_spin.cpp
@@ -40,7 +40,7 @@ TEST_CASE("spin", "[spin]") {
 
   auto reset_idx_tags = [](ExprPtr& expr) {
     if (expr->is<Tensor>())
-      ranges::for_each(expr->as<Tensor>().const_braketaux(),
+      ranges::for_each(expr->as<Tensor>().const_slots(),
                        [](const Index& idx) { idx.reset_tag(); });
   };
 

--- a/tests/unit/test_tensor.cpp
+++ b/tests/unit/test_tensor.cpp
@@ -52,8 +52,11 @@ TEST_CASE("tensor", "[elements]") {
     REQUIRE(t2.aux_rank() == 0);
     REQUIRE(t2.rank() == 1);
     REQUIRE(t2.const_braketaux().size() == 2);
+    REQUIRE(t2.const_slots().size() == 2);
     REQUIRE(ranges::distance(t2.const_braketaux_indices().begin(),
                              t2.const_braketaux_indices().end()) == 2);
+    REQUIRE(ranges::distance(t2.const_indices().begin(),
+                             t2.const_indices().end()) == 2);
     REQUIRE(t2.symmetry() == Symmetry::nonsymm);
     REQUIRE(t2.braket_symmetry() == BraKetSymmetry::conjugate);
     REQUIRE(t2.particle_symmetry() == ParticleSymmetry::symm);
@@ -70,8 +73,11 @@ TEST_CASE("tensor", "[elements]") {
     REQUIRE(t3.ket_net_rank() == 0);
     REQUIRE_THROWS(t3.rank());
     REQUIRE(t3.const_braketaux().size() == 2);
+    REQUIRE(t3.const_slots().size() == 2);
     REQUIRE(ranges::distance(t3.const_braketaux_indices().begin(),
                              t3.const_braketaux_indices().end()) == 2);
+    REQUIRE(ranges::distance(t3.const_indices().begin(),
+                             t3.const_indices().end()) == 2);
     REQUIRE(t3.symmetry() == Symmetry::nonsymm);
     REQUIRE(t3.braket_symmetry() == BraKetSymmetry::conjugate);
     REQUIRE(t3.particle_symmetry() == ParticleSymmetry::symm);
@@ -91,6 +97,7 @@ TEST_CASE("tensor", "[elements]") {
     REQUIRE(t4.aux_rank() == 1);
     REQUIRE(t4.rank() == 2);
     REQUIRE(ranges::size(t4.const_braketaux()) == 5);
+    REQUIRE(ranges::size(t4.const_slots()) == 5);
     REQUIRE(t4.symmetry() == Symmetry::nonsymm);
     REQUIRE(t4.braket_symmetry() == BraKetSymmetry::symm);
     REQUIRE(t4.particle_symmetry() == ParticleSymmetry::nonsymm);

--- a/tests/unit/test_tensor_network.cpp
+++ b/tests/unit/test_tensor_network.cpp
@@ -1162,7 +1162,7 @@ TEST_CASE("tensor_network_v2", "[elements]") {
       std::vector<Index> indices;
       for (std::size_t i = 0; i < expected.size(); ++i) {
         const Tensor& tensor = expected[i].as<Tensor>();
-        for (const Index& idx : tensor.braketaux_indices()) {
+        for (const Index& idx : tensor.indices()) {
           if (std::find(indices.begin(), indices.end(), idx) == indices.end()) {
             indices.push_back(idx);
           }
@@ -1848,7 +1848,7 @@ TEST_CASE("tensor_network_v3", "[elements]") {
       std::vector<Index> indices;
       for (std::size_t i = 0; i < expected.size(); ++i) {
         const Tensor& tensor = expected[i].as<Tensor>();
-        for (const Index& idx : tensor.braketaux_indices()) {
+        for (const Index& idx : tensor.indices()) {
           if (std::find(indices.begin(), indices.end(), idx) == indices.end()) {
             indices.push_back(idx);
           }


### PR DESCRIPTION
This renaming has changed the semantics of the code in a way that would cause bugs in the future, in case there will be another index group in addition to bra, ket and aux.

Additionally, AbstractTensor has gained a proper interface for indices and in the spirit of functions like braketaux_indices we now distinguish between indices() and slots().