### PR TITLE
Better error handling

### DIFF
--- a/SeQuant/core/attr.hpp
+++ b/SeQuant/core/attr.hpp
@@ -5,6 +5,8 @@
 #ifndef SEQUANT_ATTR_HPP
 #define SEQUANT_ATTR_HPP
 
+#include <SeQuant/core/utility/macros.hpp>
+
 #include <cassert>
 #include <cstdlib>
 #include <string>
@@ -45,8 +47,8 @@ inline std::wstring to_wolfram(const Symmetry& symmetry) {
     case Symmetry::nonsymm:
       result = L"indexSymm[0]";
       break;
-    default:
-      abort();
+    case Symmetry::invalid:
+      SEQUANT_ABORT("Invalid symmetry is not allowed here");
   }
   return result;
 }
@@ -62,7 +64,8 @@ inline std::wstring to_wstring(Symmetry sym) {
     case Symmetry::invalid:
       return L"invalid";
   }
-  abort();  // unreachable
+
+  SEQUANT_UNREACHABLE;
 }
 
 enum class BraKetPos { bra, ket, none };
@@ -110,9 +113,9 @@ inline std::wstring to_string(Vacuum V) {
       return L"MultiProductVacuum";
     case Vacuum::Invalid:
       return L"InvalidVacuum";
-    default:
-      abort();
   }
+
+  SEQUANT_UNREACHABLE;
 }
 
 /// describes LaTeX typesetting convention for contravariant (bra, annihilation)

--- a/SeQuant/core/export/export.hpp
+++ b/SeQuant/core/export/export.hpp
@@ -11,6 +11,7 @@
 #include <SeQuant/core/export/generator.hpp>
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/logger.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/core/utility/tensor.hpp>
 
 #include <algorithm>
@@ -63,7 +64,7 @@ class GenerationVisitor {
       case TreeTraversal::PreAndPostOrder:
       case TreeTraversal::PostAndInOrder:
       case TreeTraversal::None:
-        abort();  // unreachable
+        SEQUANT_UNREACHABLE;
     }
 
     if (!m_rootID.has_value()) {
@@ -532,7 +533,7 @@ class PreprocessVisitor {
       case TreeTraversal::PreAndPostOrder:
       case TreeTraversal::PostAndInOrder:
       case TreeTraversal::None:
-        abort();  // unreachable
+        SEQUANT_UNREACHABLE;
     }
   }
 

--- a/SeQuant/core/export/generation_optimizer.hpp
+++ b/SeQuant/core/export/generation_optimizer.hpp
@@ -5,6 +5,7 @@
 #include <SeQuant/core/export/generator.hpp>
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/parse.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/core/utility/tensor.hpp>
 
 #include <pv/polymorphic_variant.hpp>
@@ -98,7 +99,7 @@ class GenerationOptimizer final : public Generator<MainContext> {
           return false;
       }
 
-      abort();  // unreachable
+      SEQUANT_UNREACHABLE;
     }
 
     MemoryAction memory_action() const {
@@ -116,7 +117,7 @@ class GenerationOptimizer final : public Generator<MainContext> {
           return MemoryAction::None;
       }
 
-      abort();  // unreachable
+      SEQUANT_UNREACHABLE;
     }
 
     std::string to_string() const {

--- a/SeQuant/core/export/julia_tensor_operations.hpp
+++ b/SeQuant/core/export/julia_tensor_operations.hpp
@@ -6,6 +6,7 @@
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>
 #include <SeQuant/core/space.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/core/utility/string.hpp>
 
 #include <range/v3/view/join.hpp>
@@ -263,11 +264,11 @@ class JuliaTensorOperationsGenerator : public Generator<Context> {
   }
 
   void begin_named_section(std::string_view, const Context &) override {
-    std::abort();
+    SEQUANT_ABORT("This function should not have been called");
   }
 
   void end_named_section(std::string_view, const Context &) override {
-    std::abort();
+    SEQUANT_ABORT("This function should not have been called");
   }
 
   void begin_expression(const Context &) override {

--- a/SeQuant/core/export/reordering_context.cpp
+++ b/SeQuant/core/export/reordering_context.cpp
@@ -1,6 +1,6 @@
 #include <SeQuant/core/export/reordering_context.hpp>
 
-#include <SeQuant/core/parse.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -46,7 +46,7 @@ IndexSpace relevant_space(Range &&rng, MemoryLayout layout) {
       return {};
   }
 
-  abort();  // unreachable
+  SEQUANT_UNREACHABLE;
 }
 
 template <typename Comp>
@@ -229,7 +229,7 @@ bool ReorderingContext::is_less(const IndexSpace &lhs,
       return false;
   }
 
-  abort();  // unreachable
+  SEQUANT_UNREACHABLE;
 }
 
 bool ReorderingContext::is_ordered(const IndexSpace &lhs,

--- a/SeQuant/core/expressions/expr_operators.hpp
+++ b/SeQuant/core/expressions/expr_operators.hpp
@@ -10,6 +10,7 @@
 #include <SeQuant/core/expressions/expr_ptr.hpp>
 #include <SeQuant/core/expressions/product.hpp>
 #include <SeQuant/core/expressions/sum.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 
 #include <memory>
 
@@ -40,7 +41,8 @@ inline ExprPtr operator*(const ExprPtr &left, const ExprPtr &right) {
     result->prepend(1, left);
     return result;
   }
-  abort();  // unreachable
+
+  SEQUANT_UNREACHABLE;
 }
 
 /// Unlike @code operator*(const ExprPtr&, const ExprPtr&) @endcode this
@@ -59,7 +61,8 @@ inline ExprPtr operator^(const ExprPtr &left, const ExprPtr &right) {
     result->prepend(1, left);
     return result;
   }
-  abort();  // unreachable
+
+  SEQUANT_UNREACHABLE;
 }
 
 inline ExprPtr operator+(const ExprPtr &left, const ExprPtr &right) {
@@ -76,7 +79,8 @@ inline ExprPtr operator+(const ExprPtr &left, const ExprPtr &right) {
     result->prepend(left);
     return result;
   }
-  abort();  // unreachable
+
+  SEQUANT_UNREACHABLE;
 }
 
 inline ExprPtr operator-(const ExprPtr &left, const ExprPtr &right) {
@@ -94,7 +98,8 @@ inline ExprPtr operator-(const ExprPtr &left, const ExprPtr &right) {
       result->append(ex<Product>(-1, ExprPtrList{right}));
     return result;
   }
-  abort();  // unreachable
+
+  SEQUANT_UNREACHABLE;
 }
 
 }  // namespace sequant

--- a/SeQuant/core/op.hpp
+++ b/SeQuant/core/op.hpp
@@ -15,6 +15,7 @@
 #include <SeQuant/core/index.hpp>
 #include <SeQuant/core/ranges.hpp>
 #include <SeQuant/core/space.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/core/utility/strong.hpp>
 
 #include <cassert>
@@ -206,7 +207,8 @@ bool is_pure_qpcreator(const Op<S> &op,
     case Vacuum::Invalid:
       throw std::logic_error("Invalid Product not allowed");
   }
-  abort();  // unreachable
+
+  SEQUANT_UNREACHABLE;
 };
 
 /// @return true if this is a quasiparticle creator with respect to the given
@@ -231,7 +233,8 @@ bool is_qpcreator(const Op<S> &op,
         throw std::logic_error("is_qpcreator: cannot handle Invalid vacuum");
     }
   }
-  abort();  // unreachable
+
+  SEQUANT_UNREACHABLE;
 };
 
 template <Statistics S>
@@ -258,7 +261,7 @@ IndexSpace qpcreator_space(
       throw std::logic_error("qpcreator_space: cannot handle Invalid vacuum");
   }
 
-  abort();  // unreachable
+  SEQUANT_UNREACHABLE;
 }
 
 /// @return true if this is a pure quasiparticle annihilator with respect to
@@ -285,7 +288,7 @@ bool is_pure_qpannihilator(
           "is_pure_qpannihilator: cannot handle Invalid vacuum");
   }
 
-  abort();  // unreachable
+  SEQUANT_UNREACHABLE;
 };
 
 /// @return true if this is a quasiparticle annihilator with respect to the
@@ -311,7 +314,7 @@ bool is_qpannihilator(const Op<S> &op,
       throw std::logic_error("Invalid Product not allowed");
   }
 
-  abort();  // unreachable
+  SEQUANT_UNREACHABLE;
 };
 
 template <Statistics S>
@@ -338,7 +341,7 @@ IndexSpace qpannihilator_space(
       throw std::logic_error("Invalid Product not allowed");
   }
 
-  abort();  // unreachable
+  SEQUANT_UNREACHABLE;
 }
 
 template <Statistics S = Statistics::FermiDirac>
@@ -691,7 +694,7 @@ class NormalOperator : public Operator<S>,
       }
     }
 
-    abort();  // unreachable
+    SEQUANT_UNREACHABLE;
   }
 
   /// overload base_type::erase

--- a/SeQuant/core/options.cpp
+++ b/SeQuant/core/options.cpp
@@ -19,9 +19,9 @@ std::wstring to_wstring(CanonicalizationMethod m) {
       return L"lexicographic";
     case CanonicalizationMethod::Complete:
       return L"complete";
-    default:
-      abort();
   }
+
+  SEQUANT_UNREACHABLE;
 }
 
 CanonicalizeOptions CanonicalizeOptions::default_options() {

--- a/SeQuant/core/parse/ast_conversions.hpp
+++ b/SeQuant/core/parse/ast_conversions.hpp
@@ -12,6 +12,7 @@
 #include <SeQuant/core/parse.hpp>
 #include <SeQuant/core/parse/ast.hpp>
 #include <SeQuant/core/space.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/core/utility/string.hpp>
 
 #include <boost/variant.hpp>
@@ -331,7 +332,7 @@ ExprPtr ast_to_expr(const parse::ast::Product &product,
                     const PositionCache &position_cache, const Iterator &begin,
                     const DefaultSymmetries &default_symms) {
   if (product.factors.empty()) {
-    abort();  // unreachable
+    SEQUANT_ABORT("Product factors must not be empty");
   }
 
   if (product.factors.size() == 1) {

--- a/SeQuant/core/parse/deparse.cpp
+++ b/SeQuant/core/parse/deparse.cpp
@@ -5,6 +5,7 @@
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>
 #include <SeQuant/core/op.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/core/utility/string.hpp>
 
 #include <range/v3/all.hpp>
@@ -61,7 +62,8 @@ std::wstring deparse_symm(Symmetry symm) {
     case Symmetry::invalid:
       return L"INVALID";
   }
-  abort();  // unreachable
+
+  SEQUANT_UNREACHABLE;
 }
 
 std::wstring deparse_symm(BraKetSymmetry symm) {
@@ -75,7 +77,8 @@ std::wstring deparse_symm(BraKetSymmetry symm) {
     case BraKetSymmetry::invalid:
       return L"INVALID";
   }
-  abort();  // unreachable
+
+  SEQUANT_UNREACHABLE;
 }
 
 std::wstring deparse_symm(ParticleSymmetry symm) {
@@ -87,7 +90,8 @@ std::wstring deparse_symm(ParticleSymmetry symm) {
     case ParticleSymmetry::invalid:
       return L"INVALID";
   }
-  abort();  // unreachable
+
+  SEQUANT_UNREACHABLE;
 }
 
 std::wstring deparse_scalar(const Constant::scalar_type& scalar) {

--- a/SeQuant/core/tensor_canonicalizer.hpp
+++ b/SeQuant/core/tensor_canonicalizer.hpp
@@ -6,6 +6,7 @@
 #define SEQUANT_CORE_TENSOR_CANONICALIZER_HPP
 
 #include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 
 #include <functional>
 #include <memory>
@@ -219,8 +220,8 @@ class DefaultTensorCanonicalizer : public TensorCanonicalizer {
         }
       } break;
 
-      default:
-        abort();
+      case Symmetry::invalid:
+        SEQUANT_ABORT("Invalid symmetry should not appear here");
     }
 
     // TODO: Handle auxiliary index symmetries once they are introduced

--- a/SeQuant/core/tensor_network.cpp
+++ b/SeQuant/core/tensor_network.cpp
@@ -16,6 +16,7 @@
 #include <SeQuant/core/tensor_network.hpp>
 #include <SeQuant/core/tensor_network/vertex_painter.hpp>
 #include <SeQuant/core/tensor_network_v2.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/core/utility/tuple.hpp>
 #include <SeQuant/core/wstring.hpp>
 
@@ -768,7 +769,7 @@ TensorNetwork::GraphData TensorNetwork::make_bliss_graph(
             symmetric_protoindex_bundles.begin();
         graph->add_edge(index_cnt, spbundle_vertex_offset + spbundle_idx);
       } else {
-        abort();  // nonsymmetric proto indices not supported yet
+        SEQUANT_ABORT("nonsymmetric proto indices not supported yet");
       }
     }
     ++index_cnt;
@@ -953,7 +954,7 @@ void TensorNetwork::init_edges() const {
 }
 
 container::svector<std::pair<long, long>> TensorNetwork::factorize() {
-  abort();  // not yet implemented
+  SEQUANT_ABORT("TensorNetwork::factorize is not yet implemented");
 }
 
 size_t TensorNetwork::SlotCanonicalizationMetadata::hash_value() const {

--- a/SeQuant/core/tensor_network_v2.cpp
+++ b/SeQuant/core/tensor_network_v2.cpp
@@ -17,6 +17,7 @@
 #include <SeQuant/core/tensor_network/utils.hpp>
 #include <SeQuant/core/tensor_network/vertex_painter.hpp>
 #include <SeQuant/core/tensor_network_v2.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/core/utility/swap.hpp>
 #include <SeQuant/core/utility/tuple.hpp>
 #include <SeQuant/core/wstring.hpp>
@@ -1026,7 +1027,7 @@ TensorNetworkV2::Graph TensorNetworkV2::create_graph(
 
       assert(idx_vertex != uninitialized_vertex);
       if (idx_vertex == uninitialized_vertex) {
-        std::abort();
+        SEQUANT_ABORT("Expected all vertices to be initialized at this point");
       }
 
       edges.push_back(std::make_pair(idx_vertex, vertex));
@@ -1208,7 +1209,7 @@ void TensorNetworkV2::init_edges() {
 }
 
 container::svector<std::pair<long, long>> TensorNetworkV2::factorize() {
-  abort();  // not yet implemented
+  SEQUANT_ABORT("TensorNetworkV2::factorize is not yet implemented");
 }
 
 size_t TensorNetworkV2::SlotCanonicalizationMetadata::hash_value() const {

--- a/SeQuant/core/tensor_network_v3.cpp
+++ b/SeQuant/core/tensor_network_v3.cpp
@@ -17,6 +17,7 @@
 #include <SeQuant/core/tensor_network/utils.hpp>
 #include <SeQuant/core/tensor_network/vertex_painter.hpp>
 #include <SeQuant/core/tensor_network_v3.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/core/utility/swap.hpp>
 #include <SeQuant/core/utility/tuple.hpp>
 
@@ -1260,7 +1261,7 @@ TensorNetworkV3::Graph TensorNetworkV3::create_graph(
 
       assert(idx_vertex != uninitialized_vertex);
       if (idx_vertex == uninitialized_vertex) {
-        std::abort();
+        SEQUANT_ABORT("Expected all vertices to be initialized at this point");
       }
 
       edges.emplace_back(std::make_pair(idx_vertex, vertex));
@@ -1442,7 +1443,7 @@ void TensorNetworkV3::init_edges() {
 }
 
 container::svector<std::pair<long, long>> TensorNetworkV3::factorize() {
-  abort();  // not yet implemented
+  SEQUANT_ABORT("TensorNetworkV3::factorize is not yet implemented");
 }
 
 size_t TensorNetworkV3::SlotCanonicalizationMetadata::hash_value() const {

--- a/SeQuant/core/utility/expr.cpp
+++ b/SeQuant/core/utility/expr.cpp
@@ -1,5 +1,6 @@
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/utility/expr.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/core/utility/string.hpp>
 
 #include <bitset>
@@ -115,7 +116,7 @@ std::string diff_spaces(const IndexSpace &lhs, const IndexSpace &rhs) {
     stream << "Size differs: " << std::to_string(lhs.approximate_size())
            << " vs. " << std::to_string(rhs.approximate_size());
   } else {
-    abort();  // unreachable
+    SEQUANT_UNREACHABLE;
   }
 
   assert(!stream.str().empty());
@@ -152,7 +153,7 @@ std::string toplevel_diff(const Index &lhs, const Index &rhs) {
   }
 
   // We have run out of ideas of what to check
-  abort();
+  SEQUANT_ABORT("Unexpected difference between indices");
 }
 
 std::string toplevel_diff(const Tensor &lhs, const Tensor &rhs) {
@@ -197,7 +198,7 @@ std::string toplevel_diff(const Tensor &lhs, const Tensor &rhs) {
 
   // Really, this shouldn't produce an empty diff as the objects compare as
   // non-equal but we have run out of ideas of what to check
-  abort();
+  SEQUANT_ABORT("Unhandled difference between tensors");
 }
 
 std::string toplevel_diff(const Sum & /*lhs*/, const Sum & /*rhs*/) {
@@ -274,7 +275,7 @@ std::string diff(const Expr &lhs, const Expr &rhs) {
   } else if (lhs.is<Variable>()) {
     diff_str = toplevel_diff(lhs.as<Variable>(), rhs.as<Variable>());
   } else {
-    abort();
+    SEQUANT_ABORT("Unhandled expression type");
   }
 
   return diff_str;

--- a/SeQuant/core/utility/macros.hpp
+++ b/SeQuant/core/utility/macros.hpp
@@ -5,6 +5,10 @@
 #ifndef SEQUANT_CORE_UTILITY_MACROS_H
 #define SEQUANT_CORE_UTILITY_MACROS_H
 
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+
 /* detect C++ compiler id:
 - ids taken from CMake
 - macros are discussed at https://sourceforge.net/p/predef/wiki/Compilers/
@@ -57,5 +61,26 @@
 #else
 #define SEQUANT_PRAGMA_GCC(x)
 #endif
+
+#define SEQUANT_ABORT(msg)       \
+  assert(false && msg);          \
+  std::cerr << msg << std::endl; \
+  std::abort();
+
+#if defined(__cpp_lib_unreachable)
+#include <utility>
+
+#define SEQUANT_UNREACHABLE_TOKEN std::unreachable()
+#elif defined(SEQUANT_CXX_COMPILER_IS_GCC) || \
+    defined(SEQUANT_CXX_COMPILER_IS_CLANG)
+#define SEQUANT_UNREACHABLE_TOKEN __builtin_unreachable()
+#else
+// Compiler-independent fallback
+#define SEQUANT_UNREACHABLE_TOKEN std::abort()
+#endif
+
+#define SEQUANT_UNREACHABLE                        \
+  assert(false && "Should have been unreachable"); \
+  SEQUANT_UNREACHABLE_TOKEN;
 
 #endif  // SEQUANT_CORE_UTILITY_MACROS_H

--- a/SeQuant/core/utility/permutation.hpp
+++ b/SeQuant/core/utility/permutation.hpp
@@ -2,6 +2,7 @@
 #define SEQUANT_PERMUTATION_HPP
 
 #include <SeQuant/core/index.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 
 #include <range/v3/algorithm.hpp>
 
@@ -39,8 +40,9 @@ std::size_t count_cycles(Seq0&& v0, const Seq1& v1) {
       return -1;
     } else if constexpr (std::is_same_v<T, Index>) {
       return L"p_50";
-    } else  // unreachable
-      abort();
+    }
+
+    SEQUANT_UNREACHABLE;
   };
 
   const auto null = make_null();

--- a/SeQuant/core/wick.impl.hpp
+++ b/SeQuant/core/wick.impl.hpp
@@ -10,6 +10,7 @@
 #include <SeQuant/core/tensor_canonicalizer.hpp>
 #include <SeQuant/core/tensor_network/vertex.hpp>
 #include <SeQuant/core/tensor_network_v3.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 
 #ifdef SEQUANT_HAS_EXECUTION_HEADER
 #include <execution>
@@ -360,53 +361,54 @@ template <Statistics S>
 void reduce_wick_impl(std::shared_ptr<Product> &expr,
                       const container::set<Index> &external_indices,
                       const Context &ctx) {
-  if (ctx.metric() == IndexSpaceMetric::Unit) {
-    bool pass_mutated = false;
-    do {
-      pass_mutated = false;
+  if (ctx.metric() != IndexSpaceMetric::Unit) {
+    SEQUANT_ABORT(
+        "reduce_wick_impl expects to only work with IndexSpaceMetric::Unit");
+  }
 
-      // extract current indices
-      std::set<Index, Index::LabelCompare> all_indices;
-      ranges::for_each(*expr, [&all_indices](const auto &factor) {
-        if (factor->template is<Tensor>()) {
-          ranges::for_each(factor->template as<const Tensor>().indices(),
-                           [&all_indices](const Index &idx) {
-                             [[maybe_unused]] auto result =
-                                 all_indices.insert(idx);
-                           });
-        }
+  bool pass_mutated = false;
+  do {
+    pass_mutated = false;
+
+    // extract current indices
+    std::set<Index, Index::LabelCompare> all_indices;
+    ranges::for_each(*expr, [&all_indices](const auto &factor) {
+      if (factor->template is<Tensor>()) {
+        ranges::for_each(factor->template as<const Tensor>().indices(),
+                         [&all_indices](const Index &idx) {
+                           [[maybe_unused]] auto result =
+                               all_indices.insert(idx);
+                         });
+      }
+    });
+
+    const auto replacement_rules = compute_index_replacement_rules<S>(
+        expr, external_indices, all_indices, ctx.index_space_registry());
+
+    if (Logger::instance().wick_reduce) {
+      std::wcout << "reduce_wick_impl(expr, external_indices):\n  expr = "
+                 << expr->to_latex() << "\n  external_indices = ";
+      ranges::for_each(external_indices,
+                       [](auto &index) { std::wcout << index.label() << " "; });
+      std::wcout << "\n  replrules = ";
+      ranges::for_each(replacement_rules, [](auto &index) {
+        std::wcout << to_latex(index.first) << "\\to" << to_latex(index.second)
+                   << "\\,";
       });
+      std::wcout.flush();
+    }
 
-      const auto replacement_rules = compute_index_replacement_rules<S>(
-          expr, external_indices, all_indices, ctx.index_space_registry());
+    if (!replacement_rules.empty()) {
+      auto isr = ctx.index_space_registry();
+      pass_mutated = apply_index_replacement_rules(
+          expr, replacement_rules, external_indices, all_indices, isr);
+    }
 
-      if (Logger::instance().wick_reduce) {
-        std::wcout << "reduce_wick_impl(expr, external_indices):\n  expr = "
-                   << expr->to_latex() << "\n  external_indices = ";
-        ranges::for_each(external_indices, [](auto &index) {
-          std::wcout << index.label() << " ";
-        });
-        std::wcout << "\n  replrules = ";
-        ranges::for_each(replacement_rules, [](auto &index) {
-          std::wcout << to_latex(index.first) << "\\to"
-                     << to_latex(index.second) << "\\,";
-        });
-        std::wcout.flush();
-      }
+    if (Logger::instance().wick_reduce) {
+      std::wcout << "\n  result = " << expr->to_latex() << std::endl;
+    }
 
-      if (!replacement_rules.empty()) {
-        auto isr = ctx.index_space_registry();
-        pass_mutated = apply_index_replacement_rules(
-            expr, replacement_rules, external_indices, all_indices, isr);
-      }
-
-      if (Logger::instance().wick_reduce) {
-        std::wcout << "\n  result = " << expr->to_latex() << std::endl;
-      }
-
-    } while (pass_mutated);  // keep reducing until stop changing
-  } else
-    abort();  // programming error?
+  } while (pass_mutated);  // keep reducing until stop changing
 }
 
 template <Statistics S>
@@ -1007,18 +1009,15 @@ ExprPtr WickTheorem<S>::compute(const bool count_only,
     }  // expr_input_->is<Product>()
     // ... else if NormalOperatorSequence already, compute ...
     else if (expr_input_->is<NormalOperatorSequence<S>>()) {
-      abort();  // expr_input_ should no longer be nonnull if constructed with
-                // an expression that's a NormalOperatorSequence<S>
-      init_input(
-          expr_input_.template as_shared_ptr<NormalOperatorSequence<S>>());
-      // NB no simplification possible for a bare product w/ full contractions
-      // ... partial contractions will need simplification
-      return compute_nopseq(count_only);
+      SEQUANT_ABORT(
+          "expr_input_ should no longer be nonnull if constructed with an "
+          "expression that's a NormalOperatorSequence<S>");
     } else  // ... else do nothing
       return expr_input_;
   } else  // given a NormalOperatorSequence instead of an expression
     return compute_nopseq(count_only);
-  abort();
+
+  SEQUANT_UNREACHABLE;
 }
 
 template <Statistics S>

--- a/SeQuant/core/wstring.hpp
+++ b/SeQuant/core/wstring.hpp
@@ -85,8 +85,8 @@ constexpr decltype(auto) select_string_literal(
     return u16str;
   else if constexpr (std::is_same_v<Char, char32_t>)
     return u32str;
-  else
-    abort();
+
+  SEQUANT_ABORT("Unhandled character type");
 }
 }  // namespace detail
 
@@ -112,8 +112,8 @@ constexpr decltype(auto) select_string_literal(const char (&str)[NChar],
     return str;
   else if constexpr (std::is_same_v<Char, wchar_t>)
     return wstr;
-  else
-    abort();
+
+  SEQUANT_ABORT("Unhandled character type");
 }
 
 }  // namespace detail

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -1,3 +1,4 @@
+#include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/domain/mbpt/context.hpp>
 #include <SeQuant/domain/mbpt/op.hpp>
 
@@ -489,16 +490,16 @@ ExprPtr H_(std::size_t k) {
           return OpMaker<Statistics::FermiDirac>(OpType::f, 1)();
         case Vacuum::MultiProduct:
           return OpMaker<Statistics::FermiDirac>(OpType::f, 1)();
-        default:
-          abort();
+        case Vacuum::Invalid:
+          SEQUANT_ABORT("Invalid vacuum not allowed here");
       }
+      SEQUANT_UNREACHABLE;
 
     case 2:
       return OpMaker<Statistics::FermiDirac>(OpType::g, 2)();
-
-    default:
-      abort();
   }
+
+  SEQUANT_ABORT("Unhandled k value");
 }
 
 ExprPtr H(std::size_t k) {
@@ -728,9 +729,11 @@ ExprPtr H_(std::size_t k) {
                 return L"f";
               case Vacuum::MultiProduct:
                 return L"f";
-              default:
-                abort();
+              case Vacuum::Invalid:
+                SEQUANT_ABORT("Invalid vacuum not allowed here");
             }
+
+            SEQUANT_UNREACHABLE;
           },
           [=]() -> ExprPtr { return tensor::H_(1); },
           [=](qnc_t& qns) {
@@ -745,10 +748,9 @@ ExprPtr H_(std::size_t k) {
                         qnc_t op_qnc_t = general_type_qns(2);
                         qns = combine(op_qnc_t, qns);
                       });
-
-    default:
-      abort();
   }
+
+  SEQUANT_ABORT("Unhandled k value");
 }
 
 ExprPtr H(std::size_t k) {

--- a/SeQuant/domain/mbpt/spin.hpp
+++ b/SeQuant/domain/mbpt/spin.hpp
@@ -12,6 +12,7 @@
 #include <SeQuant/core/container.hpp>
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>
+#include <SeQuant/core/utility/macros.hpp>
 
 #include <cassert>
 #include <cstddef>
@@ -85,10 +86,10 @@ std::wstring spinannotation_add(WS&& label, Spin s) {
     case Spin::beta:
       return to_wstring(std::forward<WS>(label)) + L'↓';
     case Spin::null:
-      break;
+      SEQUANT_ABORT("Invalid spin quantum number");
   }
-  assert(false && "invalid quantum number");
-  abort();
+
+  SEQUANT_UNREACHABLE;
 }
 
 /// replaces spin annotation to


### PR DESCRIPTION
Instead of only calling abort, we use an assert that will always fail (if enabled) which contains an error message (and will report the exact spot where failure happened). In cases in which assertions are disabled, we print the error message to the console instead.

Additionally, unreachable code has now been marked by a dedicated macro, which will use compiler builtins (or C++23 features) to tell the compiler about this unreachability. Only in cases where we don't have a standard or compiler-specific way of encoding this, do we fall back to doing a plain abort.
If assertions are enabled, we'll trigger an assertion if code takes the supposedly unreachable path.

Fixes #122