### PR TITLE
fix contractions

### DIFF
--- a/SeQuant/core/expressions/tensor.hpp
+++ b/SeQuant/core/expressions/tensor.hpp
@@ -95,6 +95,7 @@ class Tensor : public Expr, public AbstractTensor, public MutatableLabeled {
 
   // list of friends who can make Tensor objects with reserved labels
   friend ExprPtr make_overlap(const Index &bra_index, const Index &ket_index);
+  friend ExprPtr make_kronecker(const Index &bra_index, const Index &ket_index);
 
   /// validates bra, ket, and aux indices
 
@@ -812,11 +813,20 @@ static_assert(is_tensor_v<Tensor>,
 using TensorPtr = std::shared_ptr<Tensor>;
 
 /// make_overlap tensor label is reserved since it is used by low-level SeQuant
-/// machinery. Users can create make_overlap Tensor using make_overlap()
+/// machinery. Users can create overlap Tensor using make_overlap()
 inline std::wstring overlap_label() { return L"s"; }
 
 inline ExprPtr make_overlap(const Index &bra_index, const Index &ket_index) {
   return ex<Tensor>(Tensor(overlap_label(), bra{bra_index}, ket{ket_index},
+                           aux{}, Tensor::reserved_tag{}));
+}
+
+/// make_kronecker tensor label is reserved since it is used by low-level
+/// SeQuant machinery. Users can create Kronecker Tensor using make_kronecker()
+inline std::wstring kronecker_label() { return L"δ"; }
+
+inline ExprPtr make_kronecker(const Index &bra_index, const Index &ket_index) {
+  return ex<Tensor>(Tensor(kronecker_label(), bra{bra_index}, ket{ket_index},
                            aux{}, Tensor::reserved_tag{}));
 }
 

--- a/SeQuant/core/index_space_registry.hpp
+++ b/SeQuant/core/index_space_registry.hpp
@@ -887,6 +887,7 @@ class IndexSpaceRegistry {
     if (!IS) {
       return false;
     }
+    // this introduces icky dependence on bit footprint of vacuum_occupied_space
     if (IS.type().to_int32() <=
         vacuum_occupied_space(IS.qns()).type().to_int32()) {
       return true;
@@ -917,6 +918,9 @@ class IndexSpaceRegistry {
     if (!IS) {
       return false;
     } else {
+      // Q: would be better to express as IS is a subspace of
+      // vacuum_unoccupied_space? Then subspaces that are part of neither (this
+      // is not supposed to happen) will not cause an issue here
       return !IS.type().intersection(
           vacuum_occupied_space(physical_particle_attributes(IS.qns())).type());
     }

--- a/SeQuant/core/wick.hpp
+++ b/SeQuant/core/wick.hpp
@@ -1509,46 +1509,66 @@ class WickTheorem {
                           const std::shared_ptr<const IndexSpaceRegistry> &isr =
                               get_default_context(S).index_space_registry()) {
     assert(can_contract(left, right, vacuum, isr));
-    //    assert(
-    //        !left.index().has_proto_indices() &&
-    //            !right.index().has_proto_indices());  // I don't think the
-    //            logic is
-    // correct for dependent indices
-    if (is_pure_qpannihilator<S>(left, vacuum, isr) &&
-        is_pure_qpcreator<S>(right, vacuum, isr))
-      return make_overlap(left.index(), right.index());
-    else {
+    // contraction result depends on whether the left/right (L, R) spaces
+    // are pure qp annihilator (hole, H) or qp creator (particle, P) subspaces
+    // or not, i.e. on whether L ⊆ H and R ⊆ P. The either of the conditions
+    // does not hold need to "project" either L or R to the corresponding
+    // intersection with the hole/particle spaces (l = L ∩ H, r = R ∩ P)
+    // before adding the contraction result, i.e. overlap:
+    // - both pure (L ⊆ H and R ⊆ P): result = s(L,R)
+    // - neither pure: result = δ(L,l) s(s,r) δ(R,r)
+    // - only L ⊆ H: result = s(L,r) δ(R,r)
+    // - only R ⊆ P: result = δ(L,l) s(s,R)
+    // N.B. This is a simplified version of the reality, since qp character
+    // depends on the Op's action, so the H/P depend on whether left/right is
+    // a creator/annihilator
+    const auto left_is_pure = is_pure_qpannihilator<S>(left, vacuum, isr);
+    const auto right_is_pure = is_pure_qpcreator<S>(right, vacuum, isr);
+
+    IndexSpace qpspace_common;
+    if (!left_is_pure || !right_is_pure) {
       const auto qpspace_left = qpannihilator_space<S>(left, vacuum, isr);
       const auto qpspace_right = qpcreator_space<S>(right, vacuum, isr);
-      const auto qpspace_common =
-          isr->intersection(qpspace_left, qpspace_right);
-      const auto index_common = Index::make_tmp_index(qpspace_common);
+      qpspace_common = isr->intersection(qpspace_left, qpspace_right);
+    }
 
-      // preserve bra/ket positions of left & right
-      const auto left_is_ann = left.action() == Action::Annihilate;
-      assert(left_is_ann || right.action() == Action::Annihilate);
+    std::optional<Index> left_qp_idx;
+    if (!left_is_pure) {
+      left_qp_idx =
+          Index::make_tmp_index(qpspace_common, left.index().proto_indices());
+    }
 
-      if (qpspace_common != left.index().space() &&
-          qpspace_common !=
-              right.index().space()) {  // may need 2 overlaps if neither space
-        // is pure qp creator/annihilator
-        auto result = std::make_shared<Product>();
-        result->append(1, left_is_ann
-                              ? make_overlap(left.index(), index_common)
-                              : make_overlap(index_common, left.index()));
-        result->append(1, left_is_ann
-                              ? make_overlap(index_common, right.index())
-                              : make_overlap(right.index(), index_common));
-        return result;
-      } else {
-        return left_is_ann ? make_overlap(left.index(), right.index())
-                           : make_overlap(right.index(), left.index());
-      }
+    std::optional<Index> right_qp_idx;
+    if (!right_is_pure) {
+      right_qp_idx =
+          Index::make_tmp_index(qpspace_common, right.index().proto_indices());
+    }
+
+    // preserve bra/ket positions of left & right
+    const auto left_is_ann = left.action() == Action::Annihilate;
+    assert(left_is_ann || right.action() == Action::Annihilate);
+    const auto bra_is_pure = left_is_ann ? left_is_pure : right_is_pure;
+    const auto ket_is_pure = left_is_ann ? right_is_pure : left_is_pure;
+    const auto &bra_idx = left_is_ann ? left.index() : right.index();
+    const auto &ket_idx = left_is_ann ? right.index() : left.index();
+    const auto &bra_qp_idx_opt = left_is_ann ? left_qp_idx : right_qp_idx;
+    const auto &ket_qp_idx_opt = left_is_ann ? right_qp_idx : left_qp_idx;
+
+    if (bra_is_pure || ket_is_pure) {
+      return make_overlap(bra_idx, ket_idx);
+    } else {
+      auto result = std::make_shared<Product>();
+      assert(bra_qp_idx_opt);
+      assert(ket_qp_idx_opt);
+      result->append(1, make_overlap(*bra_qp_idx_opt, *ket_qp_idx_opt));
+      result->append(1, make_kronecker(bra_idx, *bra_qp_idx_opt));
+      result->append(1, make_kronecker(*ket_qp_idx_opt, ket_idx));
+      return result;
     }
   }
 
   /// @param[in,out] expr on input, Wick's theorem result, on output the result
-  /// of reducing the overlaps
+  /// of reducing the kroneckers/overlaps
   void reduce(ExprPtr &expr) const;
 };
 

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -12,10 +12,39 @@
 namespace sequant::mbpt {
 
 std::vector<std::wstring> cardinal_tensor_labels() {
-  return {L"κ", L"γ", L"Γ", L"A", L"S", L"P", L"L",  L"λ", L"λ¹",
-          L"h", L"f", L"f̃", L"g", L"θ", L"t", L"t¹", L"R", L"F",
-          L"X", L"μ", L"V", L"Ṽ", L"B", L"U", L"GR", L"C", overlap_label(),
-          L"a", L"ã", L"b", L"b̃", L"E"};
+  return {L"κ",
+          L"γ",
+          L"Γ",
+          L"A",
+          L"S",
+          L"P",
+          L"L",
+          L"λ",
+          L"λ¹",
+          L"h",
+          L"f",
+          L"f̃",
+          L"g",
+          L"θ",
+          L"t",
+          L"t¹",
+          L"R",
+          L"F",
+          L"X",
+          L"μ",
+          L"V",
+          L"Ṽ",
+          L"B",
+          L"U",
+          L"GR",
+          L"C",
+          overlap_label(),
+          kronecker_label(),
+          L"a",
+          L"ã",
+          L"b",
+          L"b̃",
+          L"E"};
 }
 
 std::wstring to_wstring(OpType op) {

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -88,11 +88,10 @@ enum class OpType {
   C,    //!< cabs singles op
   RDM,  //!< RDM
   RDMCumulant,  //!< RDM cumulant
-  δ,  //!< Kronecker delta (=identity) operator; same as overlap, but the latter
-      //!< is too special for all uses
-  h_1,  //!< Hamiltonian perturbation
-  t_1,  //!< first order perturbed excitation cluster operator
-  λ_1,  //!< first order perturbed deexcitation cluster operator
+  δ,            //!< Kronecker delta (=identity) operator
+  h_1,          //!< Hamiltonian perturbation
+  t_1,          //!< first order perturbed excitation cluster operator
+  λ_1,          //!< first order perturbed deexcitation cluster operator
 };
 
 /// maps operator types to their labels
@@ -101,6 +100,7 @@ inline const container::map<OpType, std::wstring> optype2label{
     {OpType::f, L"f"},
     {OpType::f̃, L"f̃"},
     {OpType::s, overlap_label()},
+    {OpType::δ, kronecker_label()},
     {OpType::g, L"g"},
     {OpType::θ, L"θ"},
     {OpType::t, L"t"},

--- a/tests/unit/test_wick.cpp
+++ b/tests/unit/test_wick.cpp
@@ -500,12 +500,10 @@ TEST_CASE("wick", "[algorithms][wick]") {
       REQUIRE_NOTHROW(wick.compute());
       auto result = wick.compute();
       REQUIRE(result->is<Product>());
-      REQUIRE(result->size() ==
-              2 * 2);  // product of 4 terms (since each contraction of 2
-                       // *general* indices produces 2 overlaps)
       REQUIRE(to_latex(result) ==
-              L"{{s^{{p_1}}_{{m_{102}}}}{s^{{m_{102}}}_{{p_4}}}{s^{{e_{103}}}_{"
-              L"{p_2}}}{s^{{p_3}}_{{e_{103}}}}}");
+              L"{{s^{{m_{104}}}_{{m_{105}}}}{\\delta^{{m_{105}}}_{{p_4}}}{"
+              L"\\delta^{{p_1}}_{{m_{104}}}}{s^{{e_{107}}}_{{e_{106}}}}{"
+              L"\\delta^{{e_{106}}}_{{p_2}}}{\\delta^{{p_3}}_{{e_{107}}}}}");
     }
     // two general 1-body operators, partial contractions: Eq. 21a of
     // DOI 10.1063/1.474405
@@ -520,15 +518,16 @@ TEST_CASE("wick", "[algorithms][wick]") {
       REQUIRE(
           4 ==
           GWT({1, 1}, /* full_contractions_only = */ false).result().size());
-      REQUIRE(
-          to_latex(result) ==
-          L"{ \\bigl( - "
-          L"{{s^{{p_1}}_{{m_{107}}}}{s^{{m_{107}}}_{{p_4}}}{\\tilde{a}^{{p_3}}_"
-          L"{{p_2}}}} + "
-          L"{{s^{{p_1}}_{{m_{107}}}}{s^{{m_{107}}}_{{p_4}}}{s^{{e_{108}}}_{{p_"
-          L"2}}}{s^{{p_3}}_{{e_{108}}}}} + "
-          L"{{s^{{e_{109}}}_{{p_2}}}{s^{{p_3}}_{{e_{109}}}}{\\tilde{a}^{{p_1}}_"
-          L"{{p_4}}}} + {{\\tilde{a}^{{p_1}{p_3}}_{{p_2}{p_4}}}}\\bigr) }");
+      REQUIRE(to_latex(result) ==
+              L"{ \\bigl( - "
+              L"{{s^{{m_{114}}}_{{m_{115}}}}{\\delta^{{m_{115}}}_{{p_4}}}{"
+              L"\\delta^{{p_1}}_{{m_{114}}}}{\\tilde{a}^{{p_3}}_{{p_2}}}} + "
+              L"{{s^{{m_{114}}}_{{m_{115}}}}{\\delta^{{m_{115}}}_{{p_4}}}{"
+              L"\\delta^{{p_1}}_{{m_{114}}}}{s^{{e_{117}}}_{{e_{116}}}}{"
+              L"\\delta^{{e_{116}}}_{{p_2}}}{\\delta^{{p_3}}_{{e_{117}}}}} + "
+              L"{{s^{{e_{119}}}_{{e_{118}}}}{\\delta^{{e_{118}}}_{{p_2}}}{"
+              L"\\delta^{{p_3}}_{{e_{119}}}}{\\tilde{a}^{{p_1}}_{{p_4}}}} + "
+              L"{{\\tilde{a}^{{p_1}{p_3}}_{{p_2}{p_4}}}}\\bigr) }");
     }
 
     // two (pure qp) 2-body operators
@@ -544,17 +543,16 @@ TEST_CASE("wick", "[algorithms][wick]") {
       // std::endl;
       REQUIRE(result->is<Sum>());
       REQUIRE(result->size() == 4);
-      REQUIRE(
-          result_latex ==
-          L"{ "
-          L"\\bigl({{s^{{i_4}}_{{i_1}}}{s^{{i_3}}_{{i_2}}}{s^{{a_3}}_{{a_2}}}"
-          L"{s^{{a_4}}_{{a_1}}}} - "
-          L"{{s^{{i_4}}_{{i_1}}}{s^{{i_3}}_{{i_2}}}{s^{{a_4}}_{{a_2}}}{s^{{a_"
-          L"3}}_{{a_1}}}} - "
-          L"{{s^{{i_3}}_{{i_1}}}{s^{{i_4}}_{{i_2}}}{s^{{a_3}}_{{a_2}}}{s^{{a_"
-          L"4}}_{{a_1}}}} + "
-          L"{{s^{{i_3}}_{{i_1}}}{s^{{i_4}}_{{i_2}}}{s^{{a_4}}_{{a_2}}}{s^{{a_"
-          L"3}}_{{a_1}}}}\\bigr) }");
+      REQUIRE(result_latex ==
+              L"{ "
+              L"\\bigl({{s^{{i_1}}_{{i_4}}}{s^{{i_2}}_{{i_3}}}{s^{{a_3}}_{{a_2}"
+              L"}}{s^{{a_4}}_{{a_1}}}} - "
+              L"{{s^{{i_1}}_{{i_4}}}{s^{{i_2}}_{{i_3}}}{s^{{a_4}}_{{a_2}}}{s^{{"
+              L"a_3}}_{{a_1}}}} - "
+              L"{{s^{{i_1}}_{{i_3}}}{s^{{i_2}}_{{i_4}}}{s^{{a_3}}_{{a_2}}}{s^{{"
+              L"a_4}}_{{a_1}}}} + "
+              L"{{s^{{i_1}}_{{i_3}}}{s^{{i_2}}_{{i_4}}}{s^{{a_4}}_{{a_2}}}{s^{{"
+              L"a_3}}_{{a_1}}}}\\bigr) }");
 
       // in spin-free result first and fourth terms are multiplied by 4, second
       // and third terms multiplied by 2
@@ -566,17 +564,16 @@ TEST_CASE("wick", "[algorithms][wick]") {
       //     << std::endl;
       REQUIRE(result_sf->is<Sum>());
       REQUIRE(result_sf->size() == 4);
-      REQUIRE(
-          result_sf_latex ==
-          L"{ "
-          L"\\bigl({{{4}}{s^{{i_4}}_{{i_1}}}{s^{{i_3}}_{{i_2}}}{s^{{a_3}}_{{"
-          L"a_2}}}{s^{{a_4}}_{{a_1}}}} - "
-          L"{{{2}}{s^{{i_4}}_{{i_1}}}{s^{{i_3}}_{{i_2}}}{s^{{a_4}}_{{a_2}}}{"
-          L"s^{{a_3}}_{{a_1}}}} - "
-          L"{{{2}}{s^{{i_3}}_{{i_1}}}{s^{{i_4}}_{{i_2}}}{s^{{a_3}}_{{a_2}}}{"
-          L"s^{{a_4}}_{{a_1}}}} + "
-          L"{{{4}}{s^{{i_3}}_{{i_1}}}{s^{{i_4}}_{{i_2}}}{s^{{a_4}}_{{a_2}}}{"
-          L"s^{{a_3}}_{{a_1}}}}\\bigr) }");
+      REQUIRE(result_sf_latex ==
+              L"{ "
+              L"\\bigl({{{4}}{s^{{i_1}}_{{i_4}}}{s^{{i_2}}_{{i_3}}}{s^{{a_3}}_{"
+              L"{a_2}}}{s^{{a_4}}_{{a_1}}}} - "
+              L"{{{2}}{s^{{i_1}}_{{i_4}}}{s^{{i_2}}_{{i_3}}}{s^{{a_4}}_{{a_2}}}"
+              L"{s^{{a_3}}_{{a_1}}}} - "
+              L"{{{2}}{s^{{i_1}}_{{i_3}}}{s^{{i_2}}_{{i_4}}}{s^{{a_3}}_{{a_2}}}"
+              L"{s^{{a_4}}_{{a_1}}}} + "
+              L"{{{4}}{s^{{i_1}}_{{i_3}}}{s^{{i_2}}_{{i_4}}}{s^{{a_4}}_{{a_2}}}"
+              L"{s^{{a_3}}_{{a_1}}}}\\bigr) }");
     }
     // two (pure qp) 3-body operators
     {


### PR DESCRIPTION
contractions between nonpurely hole or particle spaces were in some cases incorrectly expressed as products of 2 overlaps; also sometimes bra/ket positions in the overlap were wrong.

correct contraction expression is a single overlap or an overlap times 2 kronecker deltas, which is equivalent to the old expression only when all spaces are orthonormal (non-CSV). CSV-CC was OK too since it never involved contractions of two nonpurely hole or particle dependent indices.
