### PR TITLE
fixup SEQUANT_UNREACHABLE for safe uses with unscoped if-else clauses

### DIFF
--- a/SeQuant/core/utility/macros.hpp
+++ b/SeQuant/core/utility/macros.hpp
@@ -79,8 +79,10 @@
 #define SEQUANT_UNREACHABLE_TOKEN std::abort()
 #endif
 
-#define SEQUANT_UNREACHABLE                        \
-  assert(false && "Should have been unreachable"); \
-  SEQUANT_UNREACHABLE_TOKEN;
+#define SEQUANT_UNREACHABLE                      \
+  do {                                           \
+    assert(false && "reached unreachable code"); \
+    SEQUANT_UNREACHABLE_TOKEN;                   \
+  } while (0)
 
 #endif  // SEQUANT_CORE_UTILITY_MACROS_H


### PR DESCRIPTION
now this works:
```
if (1)
  MPQC_UNREACHABLE;
```