### PR TITLE
MBPT Utility Functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,7 @@ set(SeQuant_src
         SeQuant/domain/mbpt/spin.hpp
         SeQuant/domain/mbpt/vac_av.ipp
         SeQuant/domain/mbpt/utils.hpp
+        SeQuant/domain/mbpt/utils.cpp
         SeQuant/version.cpp
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,6 +368,7 @@ set(SeQuant_src
         SeQuant/domain/mbpt/spin.cpp
         SeQuant/domain/mbpt/spin.hpp
         SeQuant/domain/mbpt/vac_av.ipp
+        SeQuant/domain/mbpt/utils.hpp
         SeQuant/version.cpp
 )
 

--- a/SeQuant/core/utility/strong.hpp
+++ b/SeQuant/core/utility/strong.hpp
@@ -302,9 +302,9 @@ class strong_type_base {
 // interpret as T)
 #define DEFINE_STRONG_TYPE_FOR_RANGE(ID)                                       \
   template <typename T>                                                        \
-  struct ID : detail::strong_type_base<T, ID<T>> {                             \
+  struct ID : sequant::detail::strong_type_base<T, ID<T>> {                    \
     using value_type = T;                                                      \
-    using base_type = detail::strong_type_base<T, ID<T>>;                      \
+    using base_type = sequant::detail::strong_type_base<T, ID<T>>;             \
     using base_type::base_type;                                                \
     using base_type::operator=;                                                \
   };                                                                           \
@@ -335,15 +335,15 @@ class strong_type_base {
 #endif  // DEFINE_STRONG_TYPE_FOR_RANGE
 
 #ifndef DEFINE_STRONG_TYPE_FOR_INTEGER
-#define DEFINE_STRONG_TYPE_FOR_INTEGER(ID, IntType)          \
-  struct ID : detail::strong_type_base<IntType, ID> {        \
-    using value_type = IntType;                              \
-    using base_type = detail::strong_type_base<IntType, ID>; \
-    using base_type::base_type;                              \
-    using base_type::operator=;                              \
-    using base_type::operator-;                              \
-    ID(const base_type& b) noexcept : base_type(b) {}        \
-    ID(base_type&& b) noexcept : base_type(std::move(b)) {}  \
+#define DEFINE_STRONG_TYPE_FOR_INTEGER(ID, IntType)                   \
+  struct ID : sequant::detail::strong_type_base<IntType, ID> {        \
+    using value_type = IntType;                                       \
+    using base_type = sequant::detail::strong_type_base<IntType, ID>; \
+    using base_type::base_type;                                       \
+    using base_type::operator=;                                       \
+    using base_type::operator-;                                       \
+    ID(const base_type& b) noexcept : base_type(b) {}                 \
+    ID(base_type&& b) noexcept : base_type(std::move(b)) {}           \
   };
 #endif  // DEFINE_STRONG_TYPE_FOR_INTEGER
 #ifndef DEFINE_STRONG_TYPE_FOR_RANGE_AND_RANGESIZE

--- a/SeQuant/domain/mbpt/models/cc.hpp
+++ b/SeQuant/domain/mbpt/models/cc.hpp
@@ -49,13 +49,6 @@ class CC {
   /// @return whether topological optimization is used in WickTheorem
   [[nodiscard]] bool use_topology() const;
 
-  /// @brief derives similarity-transformed expressions of mbpt::Operators
-  /// @param expr expression to be transformed
-  /// @param r order of truncation
-  /// @pre expr should be composed of mbpt::Operators
-  /// @return transformed expression
-  ExprPtr sim_tr(ExprPtr expr, size_t r);
-
   /// @brief derives t amplitude equations, \f$ \langle P|\bar{H}|0 \rangle = 0
   /// \f$
   /// @param commutator_rank rank of commutators included in \f$ \bar{H} \f$ ;

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -1014,8 +1014,8 @@ ExprPtr L(nann na, ncre nc, const cre<IndexSpace>& cre_space,
 
 ExprPtr L(nₚ np, nₕ nh) { return L(nann(np), ncre(nh)); }
 
-bool can_change_qns(const ExprPtr& op_or_op_product, const qns_t target_qns,
-                    const qns_t source_qns = {}) {
+bool can_change_qns(const ExprPtr& op_or_op_product, const qns_t& target_qns,
+                    const qns_t& source_qns) {
   qns_t qns = source_qns;
   if (op_or_op_product.is<Product>()) {
     const auto& op_product = op_or_op_product.as<Product>();

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -1036,27 +1036,25 @@ bool can_change_qns(const ExprPtr& op_or_op_product, const qns_t& target_qns,
 }
 
 bool raises_vacuum_up_to_rank(const ExprPtr& op_or_op_product,
-                              const unsigned long k) {
+                              unsigned long k) {
   assert(op_or_op_product.is<op_t>() || op_or_op_product.is<Product>());
 
   return can_change_qns(op_or_op_product, interval_excitation_type_qns(k));
 }
 
 bool lowers_rank_or_lower_to_vacuum(const ExprPtr& op_or_op_product,
-                                    const unsigned long k) {
+                                    unsigned long k) {
   assert(op_or_op_product.is<op_t>() || op_or_op_product.is<Product>());
   return can_change_qns(op_or_op_product, qns_t{},
                         interval_excitation_type_qns(k));
 }
 
-bool raises_vacuum_to_rank(const ExprPtr& op_or_op_product,
-                           const unsigned long k) {
+bool raises_vacuum_to_rank(const ExprPtr& op_or_op_product, unsigned long k) {
   assert(op_or_op_product.is<op_t>() || op_or_op_product.is<Product>());
   return can_change_qns(op_or_op_product, excitation_type_qns(k));
 }
 
-bool lowers_rank_to_vacuum(const ExprPtr& op_or_op_product,
-                           const unsigned long k) {
+bool lowers_rank_to_vacuum(const ExprPtr& op_or_op_product, unsigned long k) {
   assert(op_or_op_product.is<op_t>() || op_or_op_product.is<Product>());
   return can_change_qns(op_or_op_product, qns_t{}, excitation_type_qns(k));
 }

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -1014,20 +1014,28 @@ ExprPtr L(nann na, ncre nc, const cre<IndexSpace>& cre_space,
 
 ExprPtr L(nₚ np, nₕ nh) { return L(nann(np), ncre(nh)); }
 
-bool can_change_qns(const ExprPtr& op_or_op_product, const qns_t& target_qns,
-                    const qns_t& source_qns) {
-  qns_t qns = source_qns;
-  if (op_or_op_product.is<Product>()) {
-    const auto& op_product = op_or_op_product.as<Product>();
+qns_t compute_qnc(const ExprPtr& expr) {
+  assert(expr.is<op_t>() || expr.is<Product>());
+  qns_t qns;
+  if (expr.is<op_t>()) {
+    qns = expr.as<op_t>()();
+  } else if (expr.is<Product>()) {
+    const auto& op_product = expr.as<Product>();
     for (auto& op_ptr : ranges::views::reverse(op_product.factors())) {
       assert(op_ptr->template is<op_t>());
       const auto& op = op_ptr->template as<op_t>();
       qns = op(qns);
     }
-    return qns.overlaps_with(target_qns);
-  } else if (op_or_op_product.is<op_t>()) {
-    const auto& op = op_or_op_product.as<op_t>();
-    qns = op();
+  }
+  return qns;
+}
+
+bool can_change_qns(const ExprPtr& op_or_op_product, const qns_t& target_qns,
+                    const qns_t& source_qns) {
+  qns_t qns = source_qns;
+  if (op_or_op_product.is<Product>() || op_or_op_product.is<op_t>()) {
+    auto qnc = compute_qnc(op_or_op_product);
+    qns = combine(qnc, qns);  // apply the operator qnc on the source qns
     return qns.overlaps_with(target_qns);
   } else
     throw std::invalid_argument(

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -1086,7 +1086,7 @@ ExprPtr Λ_pt_(std::size_t order, std::size_t K);
 /// @pre `order==1`, only first order perturbation is supported now
 ExprPtr Λ_pt(std::size_t order, std::size_t K, bool skip1 = false);
 
-/// Checks if a given Operator or Operator Product can change the quantum
+/// @brief Checks if a given Operator or Operator Product can change the quantum
 /// numbers from \p source_qns to \p target_qns
 /// @param op_or_op_product the operator or operator product to check
 /// @param target_qns the target quantum numbers
@@ -1094,17 +1094,23 @@ ExprPtr Λ_pt(std::size_t order, std::size_t K, bool skip1 = false);
 bool can_change_qns(const ExprPtr& op_or_op_product, const qns_t& target_qns,
                     const qns_t& source_qns = {});
 
-bool raises_vacuum_up_to_rank(const ExprPtr& op_or_op_product,
-                              const unsigned long k);
+/// @brief Checks if a given Operator or Operator Product can raise the vacuum
+/// quantum numbers up to rank \p k
+bool raises_vacuum_up_to_rank(const ExprPtr& op_or_op_product, unsigned long k);
 
+/// @brief Checks if a given Operator or Operator Product can lower quantum
+/// numbers of rank \p down up to vacuum
 bool lowers_rank_or_lower_to_vacuum(const ExprPtr& op_or_op_product,
-                                    const unsigned long k);
+                                    unsigned long k);
 
-bool raises_vacuum_to_rank(const ExprPtr& op_or_op_product,
-                           const unsigned long k);
+/// @brief Checks if a given Operator or Operator Product can raise the vacuum
+/// quantum numbers to rank \p k
+bool raises_vacuum_to_rank(const ExprPtr& op_or_op_product, unsigned long k);
 
-bool lowers_rank_to_vacuum(const ExprPtr& op_or_op_product,
-                           const unsigned long k);
+/// @brief Checks if a given Operator or Operator Product can lower quantum
+/// numbers of rank \p k down to vacuum
+bool lowers_rank_to_vacuum(const ExprPtr& op_or_op_product, unsigned long k);
+
 #include <SeQuant/domain/mbpt/vac_av.hpp>
 }  // namespace op
 }  // namespace mbpt

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -1086,6 +1086,14 @@ ExprPtr Λ_pt_(std::size_t order, std::size_t K);
 /// @pre `order==1`, only first order perturbation is supported now
 ExprPtr Λ_pt(std::size_t order, std::size_t K, bool skip1 = false);
 
+/// Checks if a given Operator or Operator Product can change the quantum
+/// numbers from \p source_qns to \p target_qns
+/// @param op_or_op_product the operator or operator product to check
+/// @param target_qns the target quantum numbers
+/// @param source_qns the source quantum numbers
+bool can_change_qns(const ExprPtr& op_or_op_product, const qns_t& target_qns,
+                    const qns_t& source_qns = {});
+
 bool raises_vacuum_up_to_rank(const ExprPtr& op_or_op_product,
                               const unsigned long k);
 

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -1086,6 +1086,14 @@ ExprPtr Λ_pt_(std::size_t order, std::size_t K);
 /// @pre `order==1`, only first order perturbation is supported now
 ExprPtr Λ_pt(std::size_t order, std::size_t K, bool skip1 = false);
 
+/// @brief computes the quantum number change effected by a given Operator or
+/// Operator Product
+/// @param expr the operator or operator product whose quantum number change is
+/// to be computed
+/// @return the quantum number change effected by \p expr
+/// @pre \p expr must be an Operator or an Operator Product
+qns_t compute_qnc(const ExprPtr& expr);
+
 /// @brief Checks if a given Operator or Operator Product can change the quantum
 /// numbers from \p source_qns to \p target_qns
 /// @param op_or_op_product the operator or operator product to check

--- a/SeQuant/domain/mbpt/utils.cpp
+++ b/SeQuant/domain/mbpt/utils.cpp
@@ -1,0 +1,112 @@
+//
+// Created by Ajay Melekamburath on 9/30/25.
+//
+
+#include <SeQuant/domain/mbpt/utils.hpp>
+
+namespace sequant::mbpt {
+
+ExprPtr sim_tr(const ExprPtr& A, const ExprPtr& B, size_t commutator_rank,
+               bool unitary) {
+  assert(commutator_rank >= 1 && "Truncation order must be at least 1");
+
+  auto expr = A.clone();  // work on a copy of A
+
+  // takes a product or an operator and applies the similarity transformation
+  auto transform = [&B, commutator_rank, unitary](const ExprPtr& e) {
+    assert(e.is<op_t>() || e.is<Product>());
+    auto result = e;  // start with expr
+    auto op_Sk = result;
+
+    for (size_t k = 1; k <= commutator_rank; ++k) {
+      ExprPtr op_Sk_comm_w_S;
+      op_Sk_comm_w_S = op_Sk * B;  // traditional ansatz: [O,B] = (O B)_c
+
+      if (unitary)  // unitary ansatz: [O,B-B^+] = (O B)_c + (B^+ O)_c
+        op_Sk_comm_w_S += adjoint(B) * op_Sk;
+
+      op_Sk = ex<Constant>(rational{1, k}) * op_Sk_comm_w_S;
+      simplify(op_Sk);
+      result += op_Sk;
+    }
+    return result;
+  };
+
+  // expression type dispatch
+  if (expr.is<op_t>()) {
+    return transform(expr);
+  } else if (expr.is<Product>()) {
+    auto& product = expr.as<Product>();
+    // Expand product as sum
+    if (ranges::any_of(product.factors(), [](const auto& factor) {
+          return factor.template is<Sum>();
+        })) {
+      expr = sequant::expand(expr);
+      simplify(expr);
+      return sim_tr(expr, B, commutator_rank, unitary);
+    } else {
+      return transform(expr);
+    }
+  } else if (expr.is<Sum>()) {
+    auto result = sequant::transform_reduce(
+        *expr, ex<Sum>(),
+        [](const ExprPtr& running_total, const ExprPtr& summand) {
+          return running_total + summand;
+        },
+        [=](const auto& op_product) { return transform(op_product); });
+    return result;
+  } else if (expr.is<Constant>() || expr.is<Variable>())
+    return expr;
+  else
+    throw std::invalid_argument(
+        "mbpt::sim_tr(A, B, commutator_rank, unitary): Unsupported expression "
+        "type");
+}
+
+ExprPtr screen_terms(const ExprPtr& input) {
+  auto expr = input.clone();  // work on a copy of input
+
+  auto screen = [](const ExprPtr& term) {
+    if (!(term->is<op_t>() || term->is<Product>())) {
+      throw std::invalid_argument("op::screen_terms: Unsupported term type");
+    }
+    qns_t term_qns;
+    if (term->is<op_t>()) {
+      term_qns = term->as<op_t>()();
+    } else if (term->is<Product>()) {
+      term_qns = detail::compute_qnc(term->as<Product>());
+    }
+    return is_vacuum(term_qns) ? term : ex<Constant>(0);
+  };
+
+  // expression type dispatch
+  if (expr.is<op_t>()) {
+    return screen(expr);
+  } else if (expr.is<Product>()) {
+    auto& product = expr.as<Product>();
+    // Expand product as sum
+    if (ranges::any_of(product.factors(), [](const auto& factor) {
+          return factor.template is<Sum>();
+        })) {
+      expr = sequant::expand(expr);
+      simplify(expr);
+      return screen_terms(expr);
+    } else {
+      return screen(expr);
+    }
+  } else if (expr.is<Variable>() || expr.is<Constant>()) {
+    return expr;
+  } else if (expr.is<Sum>()) {
+    auto result = sequant::transform_reduce(
+        *expr, ex<Sum>(),
+        [](const ExprPtr& running_total, const ExprPtr& summand) {
+          return running_total + summand;
+        },
+        [=](const auto& term) { return screen(term); });
+    return result;
+  } else
+    throw std::invalid_argument(
+        "mbpt::screen_terms(expr): Unsupported expression type");
+}
+
+}  // namespace sequant::mbpt

--- a/SeQuant/domain/mbpt/utils.cpp
+++ b/SeQuant/domain/mbpt/utils.cpp
@@ -74,7 +74,7 @@ ExprPtr screen_terms(const ExprPtr& input) {
     if (term->is<op_t>()) {
       term_qns = term->as<op_t>()();
     } else if (term->is<Product>()) {
-      term_qns = detail::compute_qnc(term->as<Product>());
+      term_qns = mbpt::detail::compute_qnc(term->as<Product>());
     }
     return is_vacuum(term_qns) ? term : ex<Constant>(0);
   };

--- a/SeQuant/domain/mbpt/utils.hpp
+++ b/SeQuant/domain/mbpt/utils.hpp
@@ -35,18 +35,21 @@ inline qns_t compute_qnc(const Product& pdt) {
 
 }  // namespace detail
 
-/// @brief Computes the similarity transformation e^(-B) A e^B using the
-/// commutator expansion up to the specified order.
-/// The expansion is given by: e^(-B) A e^B = A + [A,B] + (1/2!)[[A,B],B] +
-/// (1/3!)[[[A,B],B],B] + ...
+// clang-format off
+/// @brief Computes the similarity transformation e^(-B) A e^B using a commutator series truncated up to the specified order. Uses the Baker-Campbell-Hausdorff expansion.
+/// The transformation is given by: e^(-B) A e^B = A + [A,B] + (1/2!)[[A,B],B] + (1/3!)[[[A,B],B],B] + ...
 ///
-/// @param A Operator A
-/// @param B Operator B
-/// @param commutator_rank The order at which to truncate the expansion (number
-/// of nested commutators)
+/// Notes:
+/// - This implementation is specific to the exponential ansatz B = e^X, not the general similarity transform B^{-1} A B.
+/// - If \p unitary is true, the ansatz uses B - B^+ instead of B, corresponding to a unitary coupled-cluster type transformation.
+///
+/// @param A Expression A (e.g., the Hamiltonian)
+/// @param B Expression B (e.g., the cluster operator T)
+/// @param commutator_rank The maximum order of nested commutators to retain (e.g. 4 for traditional coupled-cluster)
 /// @param unitary If true, uses unitary ansatz with B-B^+
 /// @param skip_clone if true, will not clone the input expression
 /// @pre This function expects \p A and \p B to be composed of mbpt::Operators
+// clang-format on
 ExprPtr sim_tr(ExprPtr A, const ExprPtr& B, size_t commutator_rank,
                bool unitary = false, bool skip_clone = false);
 

--- a/SeQuant/domain/mbpt/utils.hpp
+++ b/SeQuant/domain/mbpt/utils.hpp
@@ -14,27 +14,6 @@
 #include <range/v3/view.hpp>
 
 namespace sequant::mbpt {
-
-namespace detail {
-
-/// @brief Computes the net quantum number change produced by a product of
-/// mbpt::Operators
-/// @param pdt a product of mbpt::op_t
-/// @return net quantum number change produced by \p pdt
-/// @pre This function expects \p pdt to be a Product of mbpt::op_t
-inline qns_t compute_qnc(const Product& pdt) {
-  qns_t qns;
-  for (auto& factor : ranges::views::reverse(pdt.factors())) {
-    if (factor->template is<Variable>()) continue;  // skip Variables
-    assert(factor->template is<op_t>());  // everything else must be op_t
-    const auto& op = factor->template as<op_t>();
-    qns = op(qns);
-  }
-  return qns;
-}
-
-}  // namespace detail
-
 // clang-format off
 /// @brief Computes the similarity transformation e^(-B) A e^B using a commutator series truncated up to the specified order. Uses the Baker-Campbell-Hausdorff expansion.
 /// The transformation is given by: e^(-B) A e^B = A + [A,B] + (1/2!)[[A,B],B] + (1/3!)[[[A,B],B],B] + ...

--- a/SeQuant/domain/mbpt/utils.hpp
+++ b/SeQuant/domain/mbpt/utils.hpp
@@ -45,13 +45,15 @@ inline qns_t compute_qnc(const Product& pdt) {
 /// @param commutator_rank The order at which to truncate the expansion (number
 /// of nested commutators)
 /// @param unitary If true, uses unitary ansatz with B-B^+
+/// @param skip_clone if true, will not clone the input expression
 /// @pre This function expects \p A and \p B to be composed of mbpt::Operators
-ExprPtr sim_tr(const ExprPtr& A, const ExprPtr& B, size_t commutator_rank,
-               bool unitary = false);
+ExprPtr sim_tr(ExprPtr A, const ExprPtr& B, size_t commutator_rank,
+               bool unitary = false, bool skip_clone = false);
 
 /// @brief Screens out terms in the expression \p expr that cannot contribute to
 /// expectation value
-/// @param input input expression
+/// @param expr input expression
+/// @param skip_clone if true, will not clone the input expression
 /// @return return screened expression
 /// @code
 /// // example usage:
@@ -59,7 +61,7 @@ ExprPtr sim_tr(const ExprPtr& A, const ExprPtr& B, size_t commutator_rank,
 /// auto expr2 = screen_terms(P(2) * expr); // screens for <P(2)| expr |0>
 /// @endcode
 /// @pre This function expects \p input to be composed of mbpt::Operators
-ExprPtr screen_terms(const ExprPtr& input);
+ExprPtr screen_terms(ExprPtr expr, bool skip_clone = false);
 
 }  // namespace sequant::mbpt
 

--- a/SeQuant/domain/mbpt/utils.hpp
+++ b/SeQuant/domain/mbpt/utils.hpp
@@ -60,11 +60,11 @@ ExprPtr sim_tr(ExprPtr A, const ExprPtr& B, size_t commutator_rank,
 /// @return return screened expression
 /// @code
 /// // example usage:
-/// auto expr1 = screen_terms(expr); // screens for <0| expr |0>
-/// auto expr2 = screen_terms(P(2) * expr); // screens for <P(2)| expr |0>
+/// auto expr1 = screen_zero_terms(expr); // screens for <0| expr |0>
+/// auto expr2 = screen_zero_terms(P(2) * expr); // screens for <P(2)| expr |0>
 /// @endcode
 /// @pre This function expects \p input to be composed of mbpt::Operators
-ExprPtr screen_terms(ExprPtr expr, bool skip_clone = false);
+ExprPtr screen_zero_terms(ExprPtr expr, bool skip_clone = false);
 
 }  // namespace sequant::mbpt
 

--- a/SeQuant/domain/mbpt/utils.hpp
+++ b/SeQuant/domain/mbpt/utils.hpp
@@ -28,7 +28,7 @@ inline ExprPtr sim_tr(const ExprPtr& A, const ExprPtr& B,
                       size_t commutator_rank, bool unitary = false) {
   assert(commutator_rank >= 1 && "Truncation order must be at least 1");
 
-  auto expr = A.clone();  // work on a copy
+  auto expr = A.clone();  // work on a copy of A
 
   // takes a product or an operator and applies the similarity transformation
   auto transform = [&B, commutator_rank, unitary](const ExprPtr& e) {
@@ -77,7 +77,8 @@ inline ExprPtr sim_tr(const ExprPtr& A, const ExprPtr& B,
     return expr;
   else
     throw std::invalid_argument(
-        "mbpt::sim_tr(expr): Unsupported expression type");
+        "mbpt::sim_tr(A, B, commutator_rank, unitary): Unsupported expression "
+        "type");
 }
 
 }  // namespace sequant::mbpt

--- a/SeQuant/domain/mbpt/utils.hpp
+++ b/SeQuant/domain/mbpt/utils.hpp
@@ -11,7 +11,29 @@
 
 #include <SeQuant/domain/mbpt/op.hpp>
 
+#include <range/v3/view.hpp>
+
 namespace sequant::mbpt {
+
+namespace detail {
+
+/// @brief Computes the net quantum number change produced by a product of
+/// mbpt::Operators
+/// @param pdt a product of mbpt::op_t
+/// @return net quantum number change produced by \p pdt
+/// @pre This function expects \p pdt to be a Product of mbpt::op_t
+inline qns_t compute_qnc(const Product& pdt) {
+  qns_t qns;
+  for (auto& factor : ranges::views::reverse(pdt.factors())) {
+    if (factor->template is<Variable>()) continue;  // skip Variables
+    assert(factor->template is<op_t>());  // everything else must be op_t
+    const auto& op = factor->template as<op_t>();
+    qns = op(qns);
+  }
+  return qns;
+}
+
+}  // namespace detail
 
 /// @brief Computes the similarity transformation e^(-B) A e^B using the
 /// commutator expansion up to the specified order.

--- a/SeQuant/domain/mbpt/utils.hpp
+++ b/SeQuant/domain/mbpt/utils.hpp
@@ -1,0 +1,85 @@
+//
+// Created by Ajay Melekamburath on 9/26/25.
+//
+
+#ifndef SEQUANT_DOMAIN_MBPT_UTILS_HPP
+#define SEQUANT_DOMAIN_MBPT_UTILS_HPP
+
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/runtime.hpp>
+
+#include <SeQuant/domain/mbpt/op.hpp>
+
+namespace sequant::mbpt {
+
+/// @brief Computes the similarity transformation e^(-B) A e^B using the
+/// commutator expansion up to the specified order.
+/// The expansion is given by: e^(-B) A e^B = A + [A,B] + (1/2!)[[A,B],B] +
+/// (1/3!)[[[A,B],B],B] + ...
+///
+/// @param A Operator A
+/// @param B Operator B
+/// @param commutator_rank The order at which to truncate the expansion (number
+/// of nested commutators)
+/// @param unitary If true, uses unitary ansatz with B-B^+
+/// @pre This function expects \p A and \p B to be composed of mbpt::Operators
+inline ExprPtr sim_tr(const ExprPtr& A, const ExprPtr& B,
+                      size_t commutator_rank, bool unitary = false) {
+  assert(commutator_rank >= 1 && "Truncation order must be at least 1");
+
+  auto expr = A.clone();  // work on a copy
+
+  // takes a product or an operator and applies the similarity transformation
+  auto transform = [&B, commutator_rank, unitary](const ExprPtr& e) {
+    assert(e.is<op_t>() || e.is<Product>());
+    auto result = e;  // start with expr
+    auto op_Sk = result;
+
+    for (size_t k = 1; k <= commutator_rank; ++k) {
+      ExprPtr op_Sk_comm_w_S;
+      op_Sk_comm_w_S = op_Sk * B;  // traditional ansatz: [O,B] = (O B)_c
+
+      if (unitary)  // unitary ansatz: [O,B-B^+] = (O B)_c + (B^+ O)_c
+        op_Sk_comm_w_S += adjoint(B) * op_Sk;
+
+      op_Sk = ex<Constant>(rational{1, k}) * op_Sk_comm_w_S;
+      simplify(op_Sk);
+      result += op_Sk;
+    }
+    return result;
+  };
+
+  // expression type dependent dispatch
+  if (expr.is<op_t>()) {
+    return transform(expr);
+  } else if (expr.is<Product>()) {
+    auto& product = expr.as<Product>();
+    // Expand product as sum
+    if (ranges::any_of(product.factors(), [](const auto& factor) {
+          return factor.template is<Sum>();
+        })) {
+      expr = sequant::expand(expr);
+      simplify(expr);
+      return sim_tr(expr, B, commutator_rank, unitary);
+    } else {
+      return transform(expr);
+    }
+  } else if (expr.is<Sum>()) {
+    auto result = sequant::transform_reduce(
+        *expr, ex<Sum>(),
+        [](const ExprPtr& running_total, const ExprPtr& summand) {
+          return running_total + summand;
+        },
+        [=](const auto& op_product) { return transform(op_product); });
+    return result;
+  } else if (expr.is<Constant>() || expr.is<Variable>())
+    return expr;
+  else
+    throw std::invalid_argument(
+        "mbpt::sim_tr(expr): Unsupported expression type");
+}
+
+}  // namespace sequant::mbpt
+
+#endif  // SEQUANT_DOMAIN_MBPT_UTILS_HPP

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -15,6 +15,7 @@
 #include <SeQuant/domain/mbpt/convention.hpp>
 #include <SeQuant/domain/mbpt/op.hpp>
 #include <SeQuant/domain/mbpt/rules/df.hpp>
+#include <SeQuant/domain/mbpt/utils.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
@@ -313,6 +314,26 @@ TEST_CASE("mbpt", "[mbpt]") {
       auto vev2_op = op::vac_av(expr2);
       auto vev2_t = tensor::vac_av(expr2_tnsr);  // no operator level screening
       REQUIRE(to_latex(vev2_op) == to_latex(vev2_t));
+
+      // Test op::screen_zero_terms
+      auto hbar = mbpt::sim_tr(H(), T_(2), 4);  // CCD Hbar
+      auto screened_hbar = op::screen_zero_terms(hbar);
+      auto expected = H_(2) * T_(2);
+      REQUIRE(simplify(screened_hbar - expected) == ex<Constant>(0));
+
+      auto expr3 = P(2) * hbar * R_(nₚ(2), nₕ(2));
+      auto screened_expr3 = op::screen_zero_terms(expr3);
+      auto expected3 =
+          op::P(2) * (H_(2) * T_(2) + H_(2) + H_(1)) * R_(nₚ(2), nₕ(2));
+      REQUIRE(simplify(screened_expr3 - expected3) == ex<Constant>(0));
+
+      auto expr4 = P(nₚ(2), nₕ(1)) * hbar * R(nₚ(1), nₕ(0));
+      auto screened_expr4 = op::screen_zero_terms(expr4);
+      auto expected4 = P(nₚ(2), nₕ(1)) *
+                       (H_(1) + H_(1) * T_(2) + H_(2) * T_(2) + H_(2)) *
+                       R(nₚ(1), nₕ(0));
+      REQUIRE(simplify(screened_expr4 - expected4) == ex<Constant>(0));
+
     }  // SECTION("screen")
 
     SECTION("predefined") {


### PR DESCRIPTION
### Changelist
- Factors out similarity transformation logic from CC class: #393 
- Introduce a general function to screen out non-contributing terms from expectation values
- Update `can_change_qns` function and factor out the logic to compute quantum number change produced by a product of operators. 
- Docs++