### PR TITLE
`Product(Expr)` and `Product(ExprPtr)` do the "right" thing 

### DIFF
--- a/tests/unit/test_eval_node.cpp
+++ b/tests/unit/test_eval_node.cpp
@@ -114,12 +114,13 @@ TEST_CASE("eval_node", "[EvalNode]") {
                  EquivalentTo("t{a1,a2;i3,i4}:A"));
 
     // 1/16 * A * (B * C)
-    auto node2p = Product{p1->as<Product>().scalar(), {}};
-    node2p.append(1, p1->at(0), Product::Flatten::No);
-    node2p.append(1, ex<Product>(Product{p1->at(1), p1->at(2)}),
-                  Product::Flatten::No);
+    auto node2p =
+        std::make_shared<Product>(p1->as<Product>().scalar(), ExprPtrList{});
+    node2p->append(1, p1->at(0), Product::Flatten::No);
+    node2p->append(1, ex<Product>(Product{p1->at(1), p1->at(2)}),
+                   Product::Flatten::No);
 
-    auto const node2 = eval_node(ex<Product>(node2p));
+    auto const node2 = eval_node(node2p);
 
     REQUIRE_THAT(node(node2, {}).as_tensor(),
                  EquivalentTo("I{a1,a2;i1,i2}:N-N-N"));


### PR DESCRIPTION
along the lines of https://github.com/ValeevGroup/SeQuant/pull/413
