### PR TITLE
temporarily revert default canonicalization to complete

### DIFF
--- a/SeQuant/core/options.hpp
+++ b/SeQuant/core/options.hpp
@@ -45,7 +45,15 @@ struct CanonicalizeOptions {
   enum class IgnoreNamedIndexLabel : bool { Yes = true, No = false };
 
   /// TN canonicalization method
-  CanonicalizationMethod method = CanonicalizationMethod::Topological;
+  /// @internal
+  /// TODO revert to CanonicalizationMethod::Topological once issues with
+  /// external index handling exemplified by
+  /// https://github.com/ValeevGroup/SeQuant/pull/406
+  /// https://github.com/ValeevGroup/SeQuant/issues/426
+  /// and https://github.com/ValeevGroup/SeQuant/issues/287
+  /// is fixed
+  /// @endinternal
+  CanonicalizationMethod method = CanonicalizationMethod::Complete;
   /// specifies named indices; by default all indices that appear only once are
   /// deduced to be named, but this may be misleading if e.g. single
   /// summed-over dummy index appears in an expression

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -41,6 +41,11 @@ int main(int argc, char* argv[]) {
        .braket_symmetry = BraKetSymmetry::Conjugate,
        .spbasis = SPBasis::Spinor,
        .first_dummy_index_ordinal = 100,
+       // TODO remove when CanonicalizeOptions::method is reverted to
+       // Topological
+       .canonicalization_options =
+           CanonicalizeOptions::default_options().copy_and_set(
+               CanonicalizationMethod::Topological),
        .braket_typesetting = BraKetTypesetting::ContraSub,
        // to_latex() reference outputs predominantly assume the original
        // (naive) convention


### PR DESCRIPTION
... since some user-facing API (spintracing) currently depends on it. This is a workaround for #426 .
