### PR TITLE
Addressing closed-shell spin-tracing issues

### DIFF
--- a/SeQuant/domain/mbpt/spin.cpp
+++ b/SeQuant/domain/mbpt/spin.cpp
@@ -605,11 +605,12 @@ ExprPtr symmetrize_expr(const ProductPtr& product) {
   auto result = std::make_shared<Sum>();
 
   // Drops canonical-order assumption; handles arbitrary sequence and variables.
-  auto it = ranges::find_if(product->factors(), [](const ExprPtr& factor) {
+  const auto& factors = product->factors();
+  auto it = ranges::find_if(factors, [](const ExprPtr& factor) {
     return factor->is<Tensor>() && factor->as<Tensor>().label() == L"A";
   });
-  if (it == ranges::end(product->factors())) return product;
-  auto A_tensor = (*it)->as<Tensor>();
+  if (it == ranges::end(factors)) return product;
+  const auto& A_tensor = (*it)->as<Tensor>();
   SEQUANT_ASSERT(A_tensor.label() == L"A");
 
   auto A_is_nconserving = A_tensor.bra_rank() == A_tensor.ket_rank();

--- a/tests/unit/test_spin.cpp
+++ b/tests/unit/test_spin.cpp
@@ -981,16 +981,16 @@ SECTION("Closed-shell spintrace CCSD") {
 
 SECTION("Closed-shell CC spintrace for variable, constant, product") {
   {  // test variable * tensors
-    auto expr1 = sequant::parse_expr(L"-1 ω * A{i1,i2;a1,a2} * t{a1,a2;i1,i2}",
+    auto expr1 = sequant::parse_expr(L"-ω A{i1,i2;a1,a2} t{a1,a2;i1,i2}",
                                      Symmetry::Antisymm);
 
     auto result_v1 = mbpt::closed_shell_CC_spintrace_v1(expr1);
     REQUIRE_THAT(result_v1,
-                 EquivalentTo(L"-2 ω * S{i1,i2;a1,a2} * t{a1,a2;i1,i2}"));
+                 EquivalentTo(L"-2 ω S{i1,i2;a1,a2} t{a1,a2;i1,i2}"));
 
     auto result_v2 = mbpt::closed_shell_CC_spintrace_v2(expr1);
     REQUIRE_THAT(result_v2,
-                 EquivalentTo(L"-2 ω * S{i1,i2;a1,a2} * t{a1,a2;i1,i2}"));
+                 EquivalentTo(L"-2 ω S{i1,i2;a1,a2} t{a1,a2;i1,i2}"));
   }
   {  // test a single variable
     auto expr1 = sequant::parse_expr(L"ω");


### PR DESCRIPTION
**First issue**: closed_shell_CC_spintrace methods expect Sum only
Direct parse_expr and casting so product also work.
**Second issue**: symmetrize_expr expects the first factor to be the A tensor. So it doesn't work when ω is present.
Both symmetrize_expr and S_maps expected canonical sequence of tensors; it's solved now.