### PR TITLE
[skip ci] publish docs if dispatched workflow manually

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
           cmake --build . --target sphinx-sequant
 
       - name: Deploy to gh-pages
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch' }}
         uses: peaceiris/actions-gh-pages@v4
         with:
           publish_branch: gh-pages


### PR DESCRIPTION
manual invocation is useful for hotfixes to the published docs