### PR TITLE
CI: Add time limit

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   build:
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
To avoid instances like https://github.com/ValeevGroup/SeQuant/actions/runs/19897193642/attempts/1 (CI ran for 5 hours!)