### PR TITLE
Extend overloads for arithmetic operators of ExprPtr

### DIFF
--- a/SeQuant/core/expressions/expr_operators.hpp
+++ b/SeQuant/core/expressions/expr_operators.hpp
@@ -145,6 +145,10 @@ ExprPtr operator/(const ExprPtr &lhs, T &&rhs) {
   return lhs * ex<Constant>(rational(1, std::forward<T>(rhs)));
 }
 
+inline ExprPtr operator/(const ExprPtr &lhs, const Constant &rhs) {
+  return lhs * ex<Constant>(1.0 / rhs.value());
+}
+
 }  // namespace sequant
 
 #endif  // SEQUANT_EXPRESSIONS_OPERATORS_HPP

--- a/tests/unit/test_expr.cpp
+++ b/tests/unit/test_expr.cpp
@@ -850,6 +850,15 @@ TEST_CASE("expr", "[elements]") {
         simplify(res);
         REQUIRE(res == ex<Constant>(rational(1, 5)));
       }
+
+      SECTION("Divide by Constant") {
+        ex1 = ex<Constant>(5);
+
+        ExprPtr res = ex1 / Constant(3);
+        simplify(res);
+
+        REQUIRE(res == ex<Constant>(rational(5, 3)));
+      }
     }
   }
 


### PR DESCRIPTION
Note: I didn't add overloads for `+=`, `-=` and friends for now. They could be added once we have a need for them…

/CC @ajay-mk: these should allow you to shorten your expressions in the manuscript