### PR TITLE
ci: Use CPU PyTorch wheel

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -75,7 +75,7 @@ jobs:
         python-version: '3.x'
 
     - name: Install Python packages
-      run: pip install numpy torch
+      run: pip install --index-url https://download.pytorch.org/whl/cpu numpy torch
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory


### PR DESCRIPTION
Switching to CPU wheel significantly reduces installation size (to potentially avoid instances like https://github.com/ValeevGroup/SeQuant/actions/runs/20143197987/job/57816318633?pr=452 and https://github.com/ValeevGroup/SeQuant/actions/runs/20143198671/job/57816320839?pr=452). We don't use CUDA capable runners anyway. 