### PR TITLE
feat: add `min_repeats` option to `peak_cache`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type : [ Release, Debug ]
-        os : [ macos-15, ubuntu-24.04 ]
+        os : [ macos-26, ubuntu-24.04 ]
         valgrind: [ true, false ]
         sanitize: [ true, false ]
         exclude:
@@ -25,15 +25,15 @@ jobs:
             valgrind : true
           - build_type : Release
             sanitize : true
-          - os: macos-15
+          - os: macos-26
             sanitize: true
-          - os: macos-15
+          - os: macos-26
             valgrind: true
         include:
           - os: ubuntu-24.04
             cxx: /usr/bin/g++-14
             sanitize_flags: -fsanitize=address -fsanitize=leak -fsanitize=undefined -fno-omit-frame-pointer -fno-var-tracking
-          - os: macos-15
+          - os: macos-26
             cxx: clang++
             sanitize_flags: -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer -fno-var-tracking
 

--- a/SeQuant/core/eval/cache_manager.cpp
+++ b/SeQuant/core/eval/cache_manager.cpp
@@ -35,14 +35,15 @@ void max_cache(Node const& node,        //
 
 }  // namespace
 
-AsyCost peak_cache(Sum const& expr) {
+AsyCost peak_cache(Sum const& expr, std::optional<size_t> min_repeats) {
   // Materialize into a vector so that nodes have stable addresses for
   // pointer-based scanning in cache_manager()
   auto const nodes_vec = expr | ranges::views::transform([](const auto& expr) {
                            return binarize<EvalExpr>(expr);
                          }) |
                          ranges::to_vector;
-  auto cm = cache_manager(nodes_vec);
+  auto cm = min_repeats ? cache_manager(nodes_vec, min_repeats.value())
+                        : cache_manager(nodes_vec);
   auto max = AsyCost::zero();
   auto curr = AsyCost::zero();
   for (auto const& n : nodes_vec) max_cache(n, cm, curr, max);

--- a/SeQuant/core/eval/cache_manager.hpp
+++ b/SeQuant/core/eval/cache_manager.hpp
@@ -9,8 +9,10 @@
 #include <SeQuant/core/eval/result.hpp>
 #include <SeQuant/core/expr.hpp>
 
-#include <memory>
 #include <range/v3/view.hpp>
+
+#include <memory>
+#include <optional>
 #include <unordered_map>
 
 namespace sequant {
@@ -235,11 +237,14 @@ auto cache_manager(meta::eval_node_range auto const& nodes,
 /// \note Reordering the terms in a Sum affects the peak cache memory.
 ///
 /// \param expr A Sum whose terms will be evaluated by reusing intermediates.
+/// \param min_repeats Minimum number of repeats for a node to be cached. If not
+/// provided, will use the default of \c cache_manager().
 /// \return AsyCost object that represents the memory in terms of powers of
 ///         active occupied and active unoccupied index extents of stored
 ///         tensor.
 ///
-AsyCost peak_cache(Sum const& expr);
+AsyCost peak_cache(Sum const& expr,
+                   std::optional<size_t> min_repeats = std::nullopt);
 
 }  // namespace sequant
 


### PR DESCRIPTION
Add `min_repeats` option to `peak_cache()` to forward to the underlying `cache_manager()` call, defaulting to `cache_manager()`'s default when not provided.

**Misc**: Bumps CI macOS version to 26, [which is now well supported](https://github.blog/changelog/2026-02-26-macos-26-is-now-generally-available-for-github-hosted-runners/). 