### PR TITLE
Add avoided connections support and introduce `EVOptions`

### DIFF
--- a/SeQuant/core/wick.hpp
+++ b/SeQuant/core/wick.hpp
@@ -259,8 +259,9 @@ class WickTheorem {
 
   /// @name avoided-connectivity specifiers
   ///
-  /// Ensures that the given pairs of normal operators are never directly
-  /// contracted; by default will not constrain any connectivity
+  /// Ensures that no contraction is ever made between the given pairs of
+  /// normal operators; every individual contraction attempt between an
+  /// avoided pair is rejected.
   /// @param op_index_pairs the list of pairs of op indices that must not be
   /// directly contracted
   /// @throw Exception if @p op_index_pairs contains duplicates
@@ -935,7 +936,8 @@ class WickTheorem {
 
     /// If the target connectivity will be violated by this contraction, keep
     /// the state unchanged and return false.
-    /// Also rejects contractions between avoided operator pairs.
+    /// Also rejects contractions between operator pairs specified via
+    /// set_nop_avoided_connections().
     template <typename Cursor>
     inline bool connect(const container::svector<std::bitset<max_input_size>>
                             &target_nop_connections,

--- a/SeQuant/core/wick.hpp
+++ b/SeQuant/core/wick.hpp
@@ -257,6 +257,83 @@ class WickTheorem {
   }
   ///@}
 
+  /// @name avoided-connectivity specifiers
+  ///
+  /// Ensures that the given pairs of normal operators are never directly
+  /// contracted; by default will not constrain any connectivity
+  /// @param op_index_pairs the list of pairs of op indices that must not be
+  /// directly contracted
+  /// @throw Exception if @p op_index_pairs contains duplicates
+  ///@{
+
+  /// @tparam IndexPairContainer a sequence of std::pair<Integer,Integer>
+  template <typename IndexPairContainer>
+  WickTheorem &set_nop_avoided_connections(
+      IndexPairContainer &&op_index_pairs) {
+    auto has_duplicates = [](const auto &op_index_pairs) {
+      const auto the_end = end(op_index_pairs);
+      for (auto it = begin(op_index_pairs); it != the_end; ++it) {
+        const auto found_dup_it = std::find(it + 1, the_end, *it);
+        if (found_dup_it != the_end) {
+          return true;
+        }
+      }
+      return false;
+    };
+    if (has_duplicates(op_index_pairs)) {
+      throw Exception(
+          "WickTheorem::set_nop_avoided_connections(arg): arg contains "
+          "duplicates");
+    }
+
+    if (expr_input_ == nullptr || !nop_avoided_connections_input_.empty()) {
+      for (const auto &opidx_pair : op_index_pairs) {
+        constexpr bool signed_indices =
+            std::is_signed_v<typename std::remove_reference_t<
+                decltype(op_index_pairs)>::value_type::first_type>;
+        if (static_cast<std::size_t>(opidx_pair.first) >= input_->size() ||
+            static_cast<std::size_t>(opidx_pair.second) >= input_->size()) {
+          throw Exception(
+              "WickTheorem::set_nop_avoided_connections: nop index out of "
+              "range");
+        }
+        if constexpr (signed_indices) {
+          if (opidx_pair.first < 0 || opidx_pair.second < 0) {
+            throw Exception(
+                "WickTheorem::set_nop_avoided_connections: nop index out of "
+                "range");
+          }
+        }
+      }
+      if (op_index_pairs.size() != 0ul) {
+        nop_avoided_connections_.resize(input_->size());
+        for (auto &v : nop_avoided_connections_) {
+          v.set();  // 1 = not avoided (same convention as nop_connections_)
+        }
+        for (const auto &opidx_pair : op_index_pairs) {
+          nop_avoided_connections_[opidx_pair.first].reset(opidx_pair.second);
+          nop_avoided_connections_[opidx_pair.second].reset(opidx_pair.first);
+        }
+      }
+      nop_avoided_connections_input_.clear();
+    } else {
+      ranges::for_each(op_index_pairs, [this](const auto &idxpair) {
+        nop_avoided_connections_input_.push_back(idxpair);
+      });
+    }
+
+    return *this;
+  }
+
+  /// @tparam Integer an integral type
+  template <typename Integer = long>
+  WickTheorem &set_nop_avoided_connections(
+      std::initializer_list<std::pair<Integer, Integer>> op_index_pairs) {
+    return this->template set_nop_avoided_connections<
+        const decltype(op_index_pairs) &>(op_index_pairs);
+  }
+  ///@}
+
   /// @name specifiers of partitions composed of topologically-equivalent
   ///       normal operators
   ///
@@ -486,7 +563,7 @@ class WickTheorem {
                                //!< act on the same particle
 
   /// for each operator specifies the reverse bitmask of target connections
-  /// (0 = must connect)
+  /// (0 = must connect, 1 = not required or already satisfied)
   container::svector<std::bitset<max_input_size>> nop_connections_;
   std::size_t nop_nconnections_total_ =
       0;  // # of total (bidirectional) connections in nop_connections_ (i.e.
@@ -494,6 +571,13 @@ class WickTheorem {
   container::svector<std::pair<size_t, size_t>>
       nop_connections_input_;  // only used to cache input to
                                // set_nop_connections_
+
+  /// for each operator specifies the reverse bitmask of avoided connections
+  /// (0 = must not directly contract, 1 = allowed)
+  container::svector<std::bitset<max_input_size>> nop_avoided_connections_;
+  container::svector<std::pair<size_t, size_t>>
+      nop_avoided_connections_input_;  // only used to cache input to
+                                       // set_nop_avoided_connections_
 
   enum class TopologicalPartitionType { NormalOperator, Index };
 
@@ -626,6 +710,10 @@ class WickTheorem {
     if (!nop_connections_input_.empty())
       const_cast<WickTheorem<S> &>(*this).set_nop_connections(
           nop_connections_input_);
+    // process cached nop_avoided_connections_input_, if needed
+    if (!nop_avoided_connections_input_.empty())
+      const_cast<WickTheorem<S> &>(*this).set_nop_avoided_connections(
+          nop_avoided_connections_input_);
     // size nop_topological_partition_ to match input_, if needed
     upsize_topological_partitions(input_->size(),
                                   TopologicalPartitionType::NormalOperator);
@@ -846,12 +934,25 @@ class WickTheorem {
     /// @brief Updates connectivity if contraction satisfies target connectivity
 
     /// If the target connectivity will be violated by this contraction, keep
-    /// the state unchanged and return false
+    /// the state unchanged and return false.
+    /// Also rejects contractions between avoided operator pairs.
     template <typename Cursor>
     inline bool connect(const container::svector<std::bitset<max_input_size>>
                             &target_nop_connections,
+                        const container::svector<std::bitset<max_input_size>>
+                            &avoided_nop_connections,
                         const Cursor &op1_cursor, const Cursor &op2_cursor) {
       SEQUANT_ASSERT(op1_cursor.ordinal() < op2_cursor.ordinal());
+
+      // reject if this pair of normal operators is forbidden from contracting
+      {
+        const auto nop1_idx = op1_cursor.range_ordinal();
+        const auto nop2_idx = op2_cursor.range_ordinal();
+        if (!avoided_nop_connections.empty() &&
+            !avoided_nop_connections[nop1_idx].test(nop2_idx)) {
+          return false;
+        }
+      }
 
       // add contraction to the grand list
       auto register_contraction = [&]() {
@@ -1351,7 +1452,7 @@ class WickTheorem {
                            ctx.index_space_registry())) {
             auto &&[is_unique, nop_top_degen] = is_topologically_unique();
             if (is_unique) {
-              if (state.connect(nop_connections_,
+              if (state.connect(nop_connections_, nop_avoided_connections_,
                                 ranges::get_cursor(op_left_iter),
                                 ranges::get_cursor(op_right_iter))) {
                 if (Logger::instance().wick_contract) {

--- a/SeQuant/core/wick.hpp
+++ b/SeQuant/core/wick.hpp
@@ -210,6 +210,8 @@ class WickTheorem {
           "WickTheorem::set_nop_connections(arg): arg contains duplicates");
     }
 
+    // process now if input is resolved, or is a deferred call from
+    // compute_nopseq (already cached list)
     if (expr_input_ == nullptr || !nop_connections_input_.empty()) {
       for (const auto &opidx_pair : op_index_pairs) {
         constexpr bool signed_indices =
@@ -287,6 +289,8 @@ class WickTheorem {
           "duplicates");
     }
 
+    // process now if input is resolved, or is a deferred call from
+    // compute_nopseq (already cached list)
     if (expr_input_ == nullptr || !nop_avoided_connections_input_.empty()) {
       for (const auto &opidx_pair : op_index_pairs) {
         constexpr bool signed_indices =

--- a/SeQuant/domain/mbpt/models/cc.cpp
+++ b/SeQuant/domain/mbpt/models/cc.cpp
@@ -125,13 +125,12 @@ std::vector<ExprPtr> CC::λ() {
 
   auto lhbar = simplify((1 + Λ(N)) * hbar);
 
-  const auto op_connect = concat(default_op_connections(),
-                                 OpConnections<std::wstring>{{L"h", asymm},
-                                                             {L"f", asymm},
-                                                             {L"g", asymm},
-                                                             {L"h", symm},
-                                                             {L"f", symm},
-                                                             {L"g", symm}});
+  const auto op_connect = concat(default_op_connections(), {{L"h", asymm},
+                                                            {L"f", asymm},
+                                                            {L"g", asymm},
+                                                            {L"h", symm},
+                                                            {L"f", symm},
+                                                            {L"g", symm}});
 
   // 2. project onto each manifold, screen, lower to tensor form and wick it
   std::vector<ExprPtr> result(N + 1);
@@ -217,14 +216,13 @@ std::vector<ExprPtr> CC::tʼ(size_t rank, size_t order,
   const auto expr = simplify(h1_bar + hbar_pert);
 
   // connectivity: empty for unitary ansatz, build otherwise
-  OpConnections<std::wstring> op_connect = {};
+  OpConnections<std::wstring> op_connect;
   if (!this->unitary()) {
     // connect t and t1 with {h,f,g}
     // connect h1 with t
     op_connect =
         concat(default_op_connections(),
-               OpConnections<std::wstring>{
-                   {L"h", L"t¹"}, {L"f", L"t¹"}, {L"g", L"t¹"}, {L"h¹", L"t"}});
+               {{L"h", L"t¹"}, {L"f", L"t¹"}, {L"g", L"t¹"}, {L"h¹", L"t"}});
   }
 
   std::vector<ExprPtr> result(N + 1);
@@ -275,19 +273,18 @@ std::vector<ExprPtr> CC::λʼ(size_t rank, size_t order,
   // projectors with {h,f,g}
   // h1 with t
   // h1 with projectors
-  const auto op_connect = concat(default_op_connections(),
-                                 OpConnections<std::wstring>{{L"h", L"t¹"},
-                                                             {L"f", L"t¹"},
-                                                             {L"g", L"t¹"},
-                                                             {L"h¹", L"t"},
-                                                             {L"h", asymm},
-                                                             {L"f", asymm},
-                                                             {L"g", asymm},
-                                                             {L"h", symm},
-                                                             {L"f", symm},
-                                                             {L"g", symm},
-                                                             {L"h¹", asymm},
-                                                             {L"h¹", symm}});
+  const auto op_connect = concat(default_op_connections(), {{L"h", L"t¹"},
+                                                            {L"f", L"t¹"},
+                                                            {L"g", L"t¹"},
+                                                            {L"h¹", L"t"},
+                                                            {L"h", asymm},
+                                                            {L"f", asymm},
+                                                            {L"g", asymm},
+                                                            {L"h", symm},
+                                                            {L"f", symm},
+                                                            {L"g", symm},
+                                                            {L"h¹", asymm},
+                                                            {L"h¹", symm}});
 
   std::vector<ExprPtr> result(N + 1);
   for (auto p = N; p >= 1; --p) {
@@ -327,12 +324,11 @@ std::vector<ExprPtr> CC::eom_r(nₚ np, nₕ nh) {
   }
 
   // connectivity: empty for unitary ansatz, build otherwise
-  OpConnections<std::wstring> op_connect = {};
+  OpConnections<std::wstring> op_connect;
   if (!this->unitary()) {
     // default connections + connect R with {h,f,g}
-    op_connect = concat(
-        default_op_connections(),
-        OpConnections<std::wstring>{{L"h", L"R"}, {L"f", L"R"}, {L"g", L"R"}});
+    op_connect = concat(default_op_connections(),
+                        {{L"h", L"R"}, {L"f", L"R"}, {L"g", L"R"}});
   }
   // initialize result vector
   std::vector<ExprPtr> result;
@@ -373,13 +369,12 @@ std::vector<ExprPtr> CC::eom_l(nₚ np, nₕ nh) {
 
   // connectivity:
   // default connections + connect H with projectors
-  const auto op_connect = concat(default_op_connections(),
-                                 OpConnections<std::wstring>{{L"h", asymm},
-                                                             {L"f", asymm},
-                                                             {L"g", asymm},
-                                                             {L"h", symm},
-                                                             {L"f", symm},
-                                                             {L"g", symm}});
+  const auto op_connect = concat(default_op_connections(), {{L"h", asymm},
+                                                            {L"f", asymm},
+                                                            {L"g", asymm},
+                                                            {L"h", symm},
+                                                            {L"f", symm},
+                                                            {L"g", symm}});
 
   // initialize result vector
   std::vector<ExprPtr> result;

--- a/SeQuant/domain/mbpt/models/cc.hpp
+++ b/SeQuant/domain/mbpt/models/cc.hpp
@@ -141,13 +141,16 @@ class CC {
   /// @brief computes reference expectation value of an expression. Dispatches
   /// to `mbpt::op::ref_av()`
   /// @param[in] expr input expression
-  /// @param[in] connections list of operator label pairs to connect.
+  /// @param[in] connect list of operator label pairs to connect.
+  /// @param[in] do_not_connect list of operator label pairs to never connect.
   /// @note Uses use_topology() and screen() from the CC instance to set other
   /// EVOptions
-  auto ref_av(const ExprPtr& expr,
-              const OpConnections<std::wstring>& connections =
-                  default_op_connections()) const {
-    return op::ref_av(expr, {.connect = connections,
+  auto ref_av(
+      const ExprPtr& expr,
+      const OpConnections<std::wstring>& connect = default_op_connections(),
+      const OpConnections<std::wstring>& do_not_connect = {}) const {
+    return op::ref_av(expr, {.connect = connect,
+                             .do_not_connect = do_not_connect,
                              .screen = this->screen(),
                              .use_topology = this->use_topology()});
   }

--- a/SeQuant/domain/mbpt/models/cc.hpp
+++ b/SeQuant/domain/mbpt/models/cc.hpp
@@ -141,12 +141,15 @@ class CC {
   /// @brief computes reference expectation value of an expression. Dispatches
   /// to `mbpt::op::ref_av()`
   /// @param[in] expr input expression
-  /// @param[in] op_connect list of pairs of operators to be connected. Default
-  /// is given by `mbpt::default_op_connections()`.
+  /// @param[in] connections list of operator label pairs to connect.
+  /// @note Uses use_topology() and screen() from the CC instance to set other
+  /// EVOptions
   auto ref_av(const ExprPtr& expr,
-              const OpConnections<std::wstring>& op_connect =
+              const OpConnections<std::wstring>& connections =
                   default_op_connections()) const {
-    return op::ref_av(expr, op_connect, this->use_topology(), this->screen());
+    return op::ref_av(expr, {.connect = connections,
+                             .screen = this->screen(),
+                             .use_topology = this->use_topology()});
   }
 };  // class CC
 

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -1236,8 +1236,7 @@ bool lowers_rank_to_vacuum(const ExprPtr& op_or_op_product,
 
 namespace tensor {
 
-ExprPtr expectation_value_impl(ExprPtr expr,
-                               std::vector<std::pair<int, int>> nop_connections,
+ExprPtr expectation_value_impl(ExprPtr expr, OpConnectivity<int> connectivity,
                                bool use_top, bool full_contractions) {
   simplify(expr);
   auto isr = get_default_context().index_space_registry();
@@ -1255,7 +1254,9 @@ ExprPtr expectation_value_impl(ExprPtr expr,
   }
 
   FWickTheorem wick{expr};
-  wick.use_topology(use_top).set_nop_connections(nop_connections);
+  wick.use_topology(use_top).set_nop_connections(connectivity.connect);
+  if (!connectivity.avoid.empty())
+    wick.set_nop_avoided_connections(connectivity.avoid);
   wick.full_contractions(full_contractions);
   auto result = wick.compute(/* count_only = */ false,
                              /* skip_input_canonicalization? true since already
@@ -1456,19 +1457,17 @@ ExprPtr expectation_value_impl(ExprPtr expr,
   }
 }
 
-ExprPtr ref_av(ExprPtr expr, std::vector<std::pair<int, int>> nop_connections,
-               bool use_top) {
+ExprPtr ref_av(ExprPtr expr, OpConnectivity<int> connectivity, bool use_top) {
   auto isr = get_default_context().index_space_registry();
   const bool full_contractions =
       (isr->reference_occupied_space() == isr->vacuum_occupied_space()) ? true
                                                                         : false;
-  return expectation_value_impl(expr, nop_connections, use_top,
+  return expectation_value_impl(expr, std::move(connectivity), use_top,
                                 full_contractions);
 }
 
-ExprPtr vac_av(ExprPtr expr, std::vector<std::pair<int, int>> nop_connections,
-               bool use_top) {
-  return expectation_value_impl(expr, nop_connections, use_top,
+ExprPtr vac_av(ExprPtr expr, OpConnectivity<int> connectivity, bool use_top) {
+  return expectation_value_impl(expr, std::move(connectivity), use_top,
                                 /* full_contractions*/ true);
 }
 

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -1236,8 +1236,9 @@ bool lowers_rank_to_vacuum(const ExprPtr& op_or_op_product,
 
 namespace tensor {
 
-ExprPtr expectation_value_impl(ExprPtr expr, OpConnectivity<int> connectivity,
-                               bool use_top, bool full_contractions) {
+ExprPtr expectation_value_impl(ExprPtr expr, OpConnections<int> connect,
+                               OpConnections<int> avoid, bool use_top,
+                               bool full_contractions) {
   simplify(expr);
   auto isr = get_default_context().index_space_registry();
   const auto spinor = get_default_context().spbasis() == SPBasis::Spinor;
@@ -1254,9 +1255,8 @@ ExprPtr expectation_value_impl(ExprPtr expr, OpConnectivity<int> connectivity,
   }
 
   FWickTheorem wick{expr};
-  wick.use_topology(use_top).set_nop_connections(connectivity.connect);
-  if (!connectivity.avoid.empty())
-    wick.set_nop_avoided_connections(connectivity.avoid);
+  wick.use_topology(use_top).set_nop_connections(connect);
+  if (!avoid.empty()) wick.set_nop_avoided_connections(avoid);
   wick.full_contractions(full_contractions);
   auto result = wick.compute(/* count_only = */ false,
                              /* skip_input_canonicalization? true since already
@@ -1457,17 +1457,17 @@ ExprPtr expectation_value_impl(ExprPtr expr, OpConnectivity<int> connectivity,
   }
 }
 
-ExprPtr ref_av(ExprPtr expr, OpConnectivity<int> connectivity, bool use_top) {
+ExprPtr ref_av(ExprPtr expr, EVOptions<int> opts) {
   auto isr = get_default_context().index_space_registry();
   const bool full_contractions =
-      (isr->reference_occupied_space() == isr->vacuum_occupied_space()) ? true
-                                                                        : false;
-  return expectation_value_impl(expr, std::move(connectivity), use_top,
-                                full_contractions);
+      isr->reference_occupied_space() == isr->vacuum_occupied_space();
+  return expectation_value_impl(expr, opts.connect, opts.avoid,
+                                opts.use_topology, full_contractions);
 }
 
-ExprPtr vac_av(ExprPtr expr, OpConnectivity<int> connectivity, bool use_top) {
-  return expectation_value_impl(expr, std::move(connectivity), use_top,
+ExprPtr vac_av(ExprPtr expr, EVOptions<int> opts) {
+  return expectation_value_impl(expr, opts.connect, opts.avoid,
+                                opts.use_topology,
                                 /* full_contractions*/ true);
 }
 

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -1461,12 +1461,12 @@ ExprPtr ref_av(ExprPtr expr, EVOptions<int> opts) {
   auto isr = get_default_context().index_space_registry();
   const bool full_contractions =
       isr->reference_occupied_space() == isr->vacuum_occupied_space();
-  return expectation_value_impl(expr, opts.connect, opts.avoid,
+  return expectation_value_impl(expr, opts.connect, opts.do_not_connect,
                                 opts.use_topology, full_contractions);
 }
 
 ExprPtr vac_av(ExprPtr expr, EVOptions<int> opts) {
-  return expectation_value_impl(expr, opts.connect, opts.avoid,
+  return expectation_value_impl(expr, opts.connect, opts.do_not_connect,
                                 opts.use_topology,
                                 /* full_contractions*/ true);
 }

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -542,12 +542,16 @@ namespace tensor {
 /// @brief computes the reference expectation value of a tensor-level expression
 /// @param expr input expression
 /// @param opts defines the behavior, @see EVOptions
+/// @note The default `EVOptions<int>{}` has empty connections, unlike the
+///       operator-level overload which defaults to `default_op_connections()`.
 ExprPtr ref_av(ExprPtr expr, EVOptions<int> opts = {});
 
 /// @brief computes the vacuum expectation value of a tensor-level expression,
 /// forces full contractions in WickTheorem
 /// @param expr input expression
 /// @param opts defines the behavior, @see EVOptions
+/// @note The default `EVOptions<int>{}` has empty connections, unlike the
+///       operator-level overload which defaults to `default_op_connections()`.
 ExprPtr vac_av(ExprPtr expr, EVOptions<int> opts = {});
 }  // namespace tensor
 }  // namespace op

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -511,11 +511,13 @@ qns_t generic_deexcitation_qns(std::size_t particle_rank, std::size_t hole_rank,
                                IndexSpace particle_space, IndexSpace hole_space,
                                IndexSpace::QuantumNumbers SQN = Spin::any);
 
+inline namespace op {
+
 /// type of operator connectivity constraints
 template <typename T>
 using OpConnections = std::vector<std::pair<T, T>>;
 
-/// Defines the behavior of expectation value methods
+/// Defines the behavior of expectation value methods.
 /// The struct is used by both tensor and operator level methods, but there are
 /// parameters in here which are only meaningful at the operator level.
 template <typename T>
@@ -536,8 +538,6 @@ struct EVOptions {
   /// calls
   bool skip_clone = false;
 };
-
-inline namespace op {
 namespace tensor {
 /// @brief computes the reference expectation value of a tensor-level expression
 /// @param expr input expression

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -526,7 +526,7 @@ struct EVOptions {
   OpConnections<T> connect = {};
   /// List of pairs of operator labels that should not be connected, defined
   /// left-to-right.
-  OpConnections<T> avoid = {};
+  OpConnections<T> do_not_connect = {};
   /// If true, expressions are screened before lowering to Tensor level and
   /// calling WickTheorem. Only valid in Operator level calls
   bool screen = true;

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -539,10 +539,6 @@ struct EVOptions {
 
 inline namespace op {
 namespace tensor {
-ExprPtr expectation_value_impl(ExprPtr expr, OpConnections<int> connect,
-                               OpConnections<int> avoid, bool use_top,
-                               bool full_contractions);
-
 /// @brief computes the reference expectation value of a tensor-level expression
 /// @param expr input expression
 /// @param opts defines the behavior, @see EVOptions

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -511,28 +511,68 @@ qns_t generic_deexcitation_qns(std::size_t particle_rank, std::size_t hole_rank,
                                IndexSpace particle_space, IndexSpace hole_space,
                                IndexSpace::QuantumNumbers SQN = Spin::any);
 
+/// @brief Specifies operator connectivity constraints for expectation values.
+///
+/// Contains two lists of operator label pairs:
+/// - `connect`: pairs of operators that must be connected (at least one
+///   contraction between them)
+/// - `avoid`: pairs of operators that must never be directly contracted
+///
+/// Connections are directional (left-to-right): pair `{opL, opR}` declares
+/// that `opL` and `opR` are to be connected when `opR` precedes `opL`,
+/// i.e. `opL` is to the left of `opR`.
+template <typename T = std::wstring>
+struct OpConnectivity {
+  using pair_type = std::pair<T, T>;
+  using container_type = std::vector<pair_type>;
+
+  container_type connect = {};
+  container_type avoid = {};
+};
+
+/// convenience alias for operator connectivity constraints
+template <typename T = std::wstring>
+using OpConnections = typename OpConnectivity<T>::container_type;
+
 inline namespace op {
 namespace tensor {
-ExprPtr expectation_value_impl(ExprPtr expr,
-                               std::vector<std::pair<int, int>> nop_connections,
+ExprPtr expectation_value_impl(ExprPtr expr, OpConnectivity<int> connectivity,
                                bool use_top, bool full_contractions);
 
+/// @name ref_av
 /// @brief computes the reference expectation value of a tensor-level expression
 /// @param expr input expression
-/// @param nop_connections connectivity information
+/// @param connectivity operator connectivity constraints
 /// @param use_top if true, WickTheorem uses topological equivalence of terms
-ExprPtr ref_av(ExprPtr expr,
-               std::vector<std::pair<int, int>> nop_connections = {},
+///@{
+ExprPtr ref_av(ExprPtr expr, OpConnectivity<int> connectivity = {},
                bool use_top = true);
+/// @overload
+inline ExprPtr ref_av(ExprPtr expr, OpConnections<int> connections,
+                      bool use_top = true) {
+  return ref_av(std::move(expr),
+                OpConnectivity<int>{.connect = std::move(connections)},
+                use_top);
+}
+///@}
 
+/// @name vac_av
 /// @brief computes the vacuum expectation value of a tensor-level expression,
 /// forces full contractions in WickTheorem
 /// @param expr input expression
-/// @param nop_connections connectivity information
+/// @param connectivity operator connectivity constraints
 /// @param use_top if true, WickTheorem uses topological equivalence of terms
-ExprPtr vac_av(ExprPtr expr,
-               std::vector<std::pair<int, int>> nop_connections = {},
+///@{
+ExprPtr vac_av(ExprPtr expr, OpConnectivity<int> connectivity = {},
                bool use_top = true);
+/// @overload
+inline ExprPtr vac_av(ExprPtr expr, OpConnections<int> connections,
+                      bool use_top = true) {
+  return vac_av(std::move(expr),
+                OpConnectivity<int>{.connect = std::move(connections)},
+                use_top);
+}
+///@}
 }  // namespace tensor
 }  // namespace op
 

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -511,23 +511,30 @@ qns_t generic_deexcitation_qns(std::size_t particle_rank, std::size_t hole_rank,
                                IndexSpace particle_space, IndexSpace hole_space,
                                IndexSpace::QuantumNumbers SQN = Spin::any);
 
-/// @brief Specifies operator connectivity constraints for expectation values.
-///
-/// Contains two lists of operator label pairs:
-/// - `connect`: pairs of operators that must be connected (at least one
-///   contraction between them)
-/// - `avoid`: pairs of operators that must never be directly contracted
-///
-/// Connections are directional (left-to-right): pair `{opL, opR}` declares
-/// that `opL` and `opR` are to be connected when `opR` precedes `opL`,
-/// i.e. `opL` is to the left of `opR`.
-template <typename T = std::wstring>
-struct OpConnectivity {
-  using pair_type = std::pair<T, T>;
-  using container_type = std::vector<pair_type>;
+/// type of operator connectivity constraints
+template <typename T>
+using OpConnections = std::vector<std::pair<T, T>>;
 
-  container_type connect = {};
-  container_type avoid = {};
+/// Defines the behavior of expectation value methods
+/// The struct is used by both tensor and operator level methods, but there are
+/// parameters in here which are only meaningful at the operator level.
+template <typename T>
+struct EVOptions {
+  /// List of pairs of operator labels to be connected; connections are defined
+  /// left-to-right, i.e., pair `{opL,opR}` declares that `opL` and `opR` are to
+  /// be connected when `opR` precedes `opL`, i.e. `opL` is to the left of `opR`
+  OpConnections<T> connect = {};
+  /// List of pairs of operator labels that should not be connected, defined
+  /// left-to-right.
+  OpConnections<T> avoid = {};
+  /// If true, expressions are screened before lowering to Tensor level and
+  /// calling WickTheorem. Only valid in Operator level calls
+  bool screen = true;
+  /// If true, WickTheorem uses topological equivalence of terms
+  bool use_topology = true;
+  /// If true, will not clone the input expression. Only valid in Operator level
+  /// calls
+  bool skip_clone = false;
 };
 
 /// convenience alias for operator connectivity constraints

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -537,49 +537,22 @@ struct EVOptions {
   bool skip_clone = false;
 };
 
-/// convenience alias for operator connectivity constraints
-template <typename T = std::wstring>
-using OpConnections = typename OpConnectivity<T>::container_type;
-
 inline namespace op {
 namespace tensor {
-ExprPtr expectation_value_impl(ExprPtr expr, OpConnectivity<int> connectivity,
-                               bool use_top, bool full_contractions);
+ExprPtr expectation_value_impl(ExprPtr expr, OpConnections<int> connect,
+                               OpConnections<int> avoid, bool use_top,
+                               bool full_contractions);
 
-/// @name ref_av
 /// @brief computes the reference expectation value of a tensor-level expression
 /// @param expr input expression
-/// @param connectivity operator connectivity constraints
-/// @param use_top if true, WickTheorem uses topological equivalence of terms
-///@{
-ExprPtr ref_av(ExprPtr expr, OpConnectivity<int> connectivity = {},
-               bool use_top = true);
-/// @overload
-inline ExprPtr ref_av(ExprPtr expr, OpConnections<int> connections,
-                      bool use_top = true) {
-  return ref_av(std::move(expr),
-                OpConnectivity<int>{.connect = std::move(connections)},
-                use_top);
-}
-///@}
+/// @param opts defines the behavior, @see EVOptions
+ExprPtr ref_av(ExprPtr expr, EVOptions<int> opts = {});
 
-/// @name vac_av
 /// @brief computes the vacuum expectation value of a tensor-level expression,
 /// forces full contractions in WickTheorem
 /// @param expr input expression
-/// @param connectivity operator connectivity constraints
-/// @param use_top if true, WickTheorem uses topological equivalence of terms
-///@{
-ExprPtr vac_av(ExprPtr expr, OpConnectivity<int> connectivity = {},
-               bool use_top = true);
-/// @overload
-inline ExprPtr vac_av(ExprPtr expr, OpConnections<int> connections,
-                      bool use_top = true) {
-  return vac_av(std::move(expr),
-                OpConnectivity<int>{.connect = std::move(connections)},
-                use_top);
-}
-///@}
+/// @param opts defines the behavior, @see EVOptions
+ExprPtr vac_av(ExprPtr expr, EVOptions<int> opts = {});
 }  // namespace tensor
 }  // namespace op
 

--- a/SeQuant/domain/mbpt/vac_av.cpp
+++ b/SeQuant/domain/mbpt/vac_av.cpp
@@ -177,13 +177,13 @@ ExprPtr ref_av(ExprPtr expr, EVOptions<std::wstring> opts) {
   auto isr = get_default_context().index_space_registry();
   const bool full_contractions =
       isr->reference_occupied_space() == isr->vacuum_occupied_space();
-  return expectation_value_impl(expr, opts.connect, opts.avoid,
+  return expectation_value_impl(expr, opts.connect, opts.do_not_connect,
                                 opts.use_topology, opts.screen, opts.skip_clone,
                                 full_contractions);
 }
 
 ExprPtr vac_av(ExprPtr expr, EVOptions<std::wstring> opts) {
-  return expectation_value_impl(expr, opts.connect, opts.avoid,
+  return expectation_value_impl(expr, opts.connect, opts.do_not_connect,
                                 opts.use_topology, opts.screen, opts.skip_clone,
                                 /* full_contractions */ true);
 }

--- a/SeQuant/domain/mbpt/vac_av.cpp
+++ b/SeQuant/domain/mbpt/vac_av.cpp
@@ -20,8 +20,39 @@ namespace sequant {
 namespace mbpt {
 inline namespace op {
 
+namespace {
+
+/// @brief Lowers operator label pairs to normal-operator position pairs
+/// @param[in] oplbl2pos map from operator labels to their positions in the
+///            product
+/// @param[in] label_pairs the label pairs to lower
+/// @return lowered position pairs
+template <typename Container>
+std::vector<std::pair<int, int>> lower_label_pairs(
+    const container::map<std::wstring, std::vector<int>>& oplbl2pos,
+    const Container& label_pairs) {
+  std::vector<std::pair<int, int>> result;
+  for (const auto& [op1_lbl, op2_lbl] : label_pairs) {
+    auto it1 = oplbl2pos.find(op1_lbl);
+    auto it2 = oplbl2pos.find(op2_lbl);
+    if (it1 == oplbl2pos.end() || it2 == oplbl2pos.end())
+      continue;  // one of the op labels is not present in the product
+    const auto& [dummy1, op1_indices] = *it1;
+    const auto& [dummy2, op2_indices] = *it2;
+    for (const auto& op1_idx : op1_indices) {
+      for (const auto& op2_idx : op2_indices) {
+        if (op1_idx < op2_idx) {  // N.B. connections are directional
+          result.emplace_back(op1_idx, op2_idx);
+        }
+      }
+    }
+  }
+  return result;
+}
+}  // namespace
+
 ExprPtr expectation_value_impl(
-    ExprPtr expr, const OpConnections<std::wstring>& op_connections,
+    ExprPtr expr, const OpConnectivity<std::wstring>& op_connections,
     bool use_topology, bool screen, bool skip_clone, bool full_contractions) {
   // use cloned expr to avoid side effects
   if (!skip_clone) expr = expr->clone();
@@ -47,8 +78,9 @@ ExprPtr expectation_value_impl(
     auto product =
         ex<Product>(scalar, factors_filtered.begin(), factors_filtered.end());
 
-    // compute connections
+    // compute connections (both required and avoided)
     std::vector<std::pair<int, int>> connections;
+    std::vector<std::pair<int, int>> avoided_connections;
     {
       container::map<std::wstring, std::vector<int>>
           oplbl2pos;  // maps operator labels to the operator positions in the
@@ -79,21 +111,9 @@ ExprPtr expectation_value_impl(
         }
       }
 
-      for (const auto& [op1_lbl, op2_lbl] : op_connections) {
-        auto it1 = oplbl2pos.find(op1_lbl);
-        auto it2 = oplbl2pos.find(op2_lbl);
-        if (it1 == oplbl2pos.end() || it2 == oplbl2pos.end())
-          continue;  // one of the op labels is not present in the product
-        const auto& [dummy1, op1_indices] = *it1;
-        const auto& [dummy2, op2_indices] = *it2;
-        for (const auto& op1_idx : op1_indices) {
-          for (const auto& op2_idx : op2_indices) {
-            if (op1_idx < op2_idx) {  // N.B. connections are directional
-              connections.emplace_back(op1_idx, op2_idx);
-            }
-          }
-        }
-      }
+      // assemble connectivity info
+      connections = lower_label_pairs(oplbl2pos, op_connections.connect);
+      avoided_connections = lower_label_pairs(oplbl2pos, op_connections.avoid);
     }
 
     // lower to tensor form
@@ -102,8 +122,11 @@ ExprPtr expectation_value_impl(
 
     // compute expectation value
     // call the tensor-level impl function directly
-    auto vev = tensor::expectation_value_impl(product, connections,
-                                              use_topology, full_contractions);
+    auto vev = tensor::expectation_value_impl(
+        product,
+        OpConnectivity<int>{.connect = std::move(connections),
+                            .avoid = std::move(avoided_connections)},
+        use_topology, full_contractions);
     // restore Variable types to the Product
     if (!variables.empty())
       ranges::for_each(variables, [&vev](const auto& var) { vev *= var; });
@@ -144,7 +167,7 @@ ExprPtr expectation_value_impl(
       "type");
 }
 
-ExprPtr ref_av(ExprPtr expr, const OpConnections<std::wstring>& op_connections,
+ExprPtr ref_av(ExprPtr expr, const OpConnectivity<std::wstring>& op_connections,
                bool use_topology, bool screen, bool skip_clone) {
   auto isr = get_default_context().index_space_registry();
   const bool full_contractions =
@@ -154,7 +177,7 @@ ExprPtr ref_av(ExprPtr expr, const OpConnections<std::wstring>& op_connections,
                                 skip_clone, full_contractions);
 }
 
-ExprPtr vac_av(ExprPtr expr, const OpConnections<std::wstring>& op_connections,
+ExprPtr vac_av(ExprPtr expr, const OpConnectivity<std::wstring>& op_connections,
                bool use_topology, bool screen, bool skip_clone) {
   return expectation_value_impl(expr, op_connections, use_topology, screen,
                                 skip_clone,

--- a/SeQuant/domain/mbpt/vac_av.cpp
+++ b/SeQuant/domain/mbpt/vac_av.cpp
@@ -51,13 +51,15 @@ std::vector<std::pair<int, int>> lower_label_pairs(
 }
 }  // namespace
 
-ExprPtr expectation_value_impl(
-    ExprPtr expr, const OpConnectivity<std::wstring>& op_connections,
-    bool use_topology, bool screen, bool skip_clone, bool full_contractions) {
+ExprPtr expectation_value_impl(ExprPtr expr,
+                               const OpConnections<std::wstring>& connect,
+                               const OpConnections<std::wstring>& avoid,
+                               bool use_topology, bool screen, bool skip_clone,
+                               bool full_contractions) {
   // use cloned expr to avoid side effects
   if (!skip_clone) expr = expr->clone();
 
-  auto vac_av_product = [&op_connections, use_topology, screen,
+  auto vac_av_product = [&connect, &avoid, use_topology, screen,
                          full_contractions](ExprPtr expr) {
     SEQUANT_ASSERT(expr.is<Product>());
     // extract scalar and factors
@@ -79,8 +81,8 @@ ExprPtr expectation_value_impl(
         ex<Product>(scalar, factors_filtered.begin(), factors_filtered.end());
 
     // compute connections (both required and avoided)
-    std::vector<std::pair<int, int>> connections;
-    std::vector<std::pair<int, int>> avoided_connections;
+    OpConnections<int> t_connect;
+    OpConnections<int> t_avoid;
     {
       container::map<std::wstring, std::vector<int>>
           oplbl2pos;  // maps operator labels to the operator positions in the
@@ -111,9 +113,9 @@ ExprPtr expectation_value_impl(
         }
       }
 
-      // assemble connectivity info
-      connections = lower_label_pairs(oplbl2pos, op_connections.connect);
-      avoided_connections = lower_label_pairs(oplbl2pos, op_connections.avoid);
+      // assemble connectivity info for tensor level call
+      t_connect = lower_label_pairs(oplbl2pos, connect);
+      t_avoid = lower_label_pairs(oplbl2pos, avoid);
     }
 
     // lower to tensor form
@@ -122,11 +124,8 @@ ExprPtr expectation_value_impl(
 
     // compute expectation value
     // call the tensor-level impl function directly
-    auto vev = tensor::expectation_value_impl(
-        product,
-        OpConnectivity<int>{.connect = std::move(connections),
-                            .avoid = std::move(avoided_connections)},
-        use_topology, full_contractions);
+    auto vev = tensor::expectation_value_impl(product, t_connect, t_avoid,
+                                              use_topology, full_contractions);
     // restore Variable types to the Product
     if (!variables.empty())
       ranges::for_each(variables, [&vev](const auto& var) { vev *= var; });
@@ -142,16 +141,16 @@ ExprPtr expectation_value_impl(
         })) {
       expr = expand(expr);
       simplify(expr);  // condense equivalent terms after expansion
-      return expectation_value_impl(expr, op_connections, use_topology, screen,
+      return expectation_value_impl(expr, connect, avoid, use_topology, screen,
                                     /* skip_clone = */ true, full_contractions);
     } else
       return vac_av_product(expr);
   } else if (expr.is<Sum>()) {
     result = sequant::transform_sum_expr(
-        *expr, [&op_connections, use_topology, screen,
+        *expr, [&connect, &avoid, use_topology, screen,
                 full_contractions](const auto& op_product) {
           return expectation_value_impl(
-              op_product, op_connections, use_topology, screen,
+              op_product, connect, avoid, use_topology, screen,
               /* skip_clone = */ true, full_contractions);
         });
     simplify(result);  // combine possible equivalent summands
@@ -167,20 +166,18 @@ ExprPtr expectation_value_impl(
       "type");
 }
 
-ExprPtr ref_av(ExprPtr expr, const OpConnectivity<std::wstring>& op_connections,
-               bool use_topology, bool screen, bool skip_clone) {
+ExprPtr ref_av(ExprPtr expr, EVOptions<std::wstring> opts) {
   auto isr = get_default_context().index_space_registry();
   const bool full_contractions =
-      (isr->reference_occupied_space() == isr->vacuum_occupied_space()) ? true
-                                                                        : false;
-  return expectation_value_impl(expr, op_connections, use_topology, screen,
-                                skip_clone, full_contractions);
+      isr->reference_occupied_space() == isr->vacuum_occupied_space();
+  return expectation_value_impl(expr, opts.connect, opts.avoid,
+                                opts.use_topology, opts.screen, opts.skip_clone,
+                                full_contractions);
 }
 
-ExprPtr vac_av(ExprPtr expr, const OpConnectivity<std::wstring>& op_connections,
-               bool use_topology, bool screen, bool skip_clone) {
-  return expectation_value_impl(expr, op_connections, use_topology, screen,
-                                skip_clone,
+ExprPtr vac_av(ExprPtr expr, EVOptions<std::wstring> opts) {
+  return expectation_value_impl(expr, opts.connect, opts.avoid,
+                                opts.use_topology, opts.screen, opts.skip_clone,
                                 /* full_contractions */ true);
 }
 

--- a/SeQuant/domain/mbpt/vac_av.cpp
+++ b/SeQuant/domain/mbpt/vac_av.cpp
@@ -51,6 +51,13 @@ std::vector<std::pair<int, int>> lower_label_pairs(
 }
 }  // namespace
 
+// fwd declare the tensor level impl function
+namespace tensor {
+ExprPtr expectation_value_impl(ExprPtr expr, OpConnections<int> connect,
+                               OpConnections<int> avoid, bool use_top,
+                               bool full_contractions);
+}  // namespace tensor
+
 ExprPtr expectation_value_impl(ExprPtr expr,
                                const OpConnections<std::wstring>& connect,
                                const OpConnections<std::wstring>& avoid,
@@ -162,7 +169,7 @@ ExprPtr expectation_value_impl(ExprPtr expr,
     return expr;  // vacuum is normalized
   }
   throw Exception(
-      "mbpt::op::detail::expectation_value_impl(expr): unknown expression "
+      "mbpt::op::expectation_value_impl(expr): unknown expression "
       "type");
 }
 

--- a/SeQuant/domain/mbpt/vac_av.hpp
+++ b/SeQuant/domain/mbpt/vac_av.hpp
@@ -34,9 +34,8 @@ inline OpConnections<std::wstring> default_op_connections() {
 }
 
 /// concat 2 sets of op connections
-inline OpConnections<std::wstring> concat(
-    const OpConnections<std::wstring>& a,
-    const OpConnections<std::wstring>& b) {
+template <typename T>
+OpConnections<T> concat(const OpConnections<T>& a, const OpConnections<T>& b) {
   return ranges::concat_view(a, b) | ranges::to_vector;
 }
 

--- a/SeQuant/domain/mbpt/vac_av.hpp
+++ b/SeQuant/domain/mbpt/vac_av.hpp
@@ -10,9 +10,6 @@
 namespace sequant::mbpt {
 inline namespace op {
 
-template <typename T>
-using OpConnections = std::vector<std::pair<T, T>>;
-
 /// defines the default op connections
 inline OpConnections<std::wstring> default_op_connections() {
   static const OpConnections<std::wstring> defaults = {
@@ -22,13 +19,13 @@ inline OpConnections<std::wstring> default_op_connections() {
       {L"g", L"t"},
       // NBs
       // - for unitary ansatz can also connect t^+ with Hamiltonian
-      // - for exact (non-approximated) unitary ansatz will also need to connect
-      // t^+ with t;
-      //   for MR unitary ansatz can also connect t with t and t^+ with t^+ ,
-      //   but since adjoint() does not change OpType all of these are expressed
-      //   as same connection ... this points out the need to have a separate
-      //   OpType for t^+ and t, and in general the contents of OpType must be
-      //   customizable
+      // - for exact (non-approximated) unitary ansatz will also
+      // need to connect t^+ with t; for MR unitary ansatz can also
+      // connect t with t and t^+ with t^+, but since adjoint() does
+      // not change OpType all of these are expressed as same
+      // connection ... this points out the need to have a separate
+      // OpType for t^+ and t, and in general the contents of OpType
+      // must be customizable
       {L"t", L"h"},
       {L"t", L"f"},
       {L"t", L"f̃"},
@@ -38,9 +35,17 @@ inline OpConnections<std::wstring> default_op_connections() {
 
 /// concat 2 sets of op connections
 inline OpConnections<std::wstring> concat(
-    const OpConnections<std::wstring>& connections1,
-    const OpConnections<std::wstring>& connections2) {
-  return ranges::concat_view(connections1, connections2) | ranges::to_vector;
+    const OpConnections<std::wstring>& a,
+    const OpConnections<std::wstring>& b) {
+  return ranges::concat_view(a, b) | ranges::to_vector;
+}
+
+/// concat 2 sets of op connectivity constraints
+inline OpConnectivity<std::wstring> concat(
+    const OpConnectivity<std::wstring>& a,
+    const OpConnectivity<std::wstring>& b) {
+  return {.connect = concat(a.connect, b.connect),
+          .avoid = concat(a.avoid, b.avoid)};
 }
 
 /// @brief lowers an expression composed of Operators to tensor form
@@ -65,18 +70,19 @@ inline ExprPtr lower_to_tensor_form(const ExprPtr& expr_inp) {
 }
 
 ExprPtr expectation_value_impl(
-    ExprPtr expr, const OpConnections<std::wstring>& op_connections,
+    ExprPtr expr, const OpConnectivity<std::wstring>& op_connections,
     bool use_topology, bool screen, bool skip_clone, bool full_contractions);
 
 // clang-format off
+/// @name ref_av
 /// @brief computes the reference expectation value
 /// @note equivalent to vac_av if the reference state is the Wick vacuum,
 ///       i.e. if `get_default_context().index_space_registry()->reference_occupied_space() == get_default_context().index_space_registry()->vacuum_occupied_space()`
 /// @param[in] expr input expression
-/// @param[in] op_connections list of pairs of operator labels to be
-/// connected; connections are defined left-to-right, i.e., pair
-/// `{opL,opR}` declares that `opL` and `opR` are to be connected
-/// when `opR` precedes `opL`, i.e. `opL` is to the left of `opR`
+/// @param[in] op_connections operator connectivity constraints; `connect`
+/// pairs are defined left-to-right, i.e., pair `{opL,opR}` declares that
+/// `opL` and `opR` are to be connected when `opR` precedes `opL`;
+/// `avoid` pairs specify operators that must never be directly contracted
 /// @param[in] use_topology if true, WickTheorem uses topological equivalence of
 /// terms, default is true
 /// @param[in] screen if true, expressions are screened before lowering to
@@ -84,26 +90,45 @@ ExprPtr expectation_value_impl(
 /// @param[in] skip_clone if true, will not clone the input expression
 /// @return the reference expectation value
 // clang_format on
-ExprPtr ref_av(ExprPtr expr, const OpConnections<std::wstring>& op_connections = default_op_connections(),
+///@{
+ExprPtr ref_av(ExprPtr expr, const OpConnectivity<std::wstring>& op_connections = {.connect = default_op_connections()},
                bool use_topology = true, bool screen = true,
                bool skip_clone = false);
+/// @overload
+inline ExprPtr ref_av(ExprPtr expr, const OpConnections<std::wstring>& op_connections,
+                      bool use_topology = true, bool screen = true,
+                      bool skip_clone = false) {
+  return ref_av(std::move(expr), OpConnectivity<std::wstring>{.connect = op_connections},
+                use_topology, screen, skip_clone);
+}
+///@}
 
+/// @name vac_av
 /// @brief computes the vacuum expectation value
 /// @internal evaluates only full contractions in  WickTheorem
 /// @param[in] expr input expression
-/// @param[in] op_connections list of pairs of operator labels to be
-/// connected; connections are defined left-to-right, i.e., pair
-/// `{opL,opR}` declares that `opL` and `opR` are to be connected
-/// when `opR` precedes `opL`, i.e. `opL` is to the left of `opR`
+/// @param[in] op_connections operator connectivity constraints; `connect`
+/// pairs are defined left-to-right, i.e., pair `{opL,opR}` declares that
+/// `opL` and `opR` are to be connected when `opR` precedes `opL`;
+/// `avoid` pairs specify operators that must never be directly contracted
 /// @param[in] use_topology if true, WickTheorem uses topological equivalence of
 /// terms, default is true
 /// @param[in] screen if true, expressions are screened before lowering to
 /// Tensor level and calling WickTheorem, default is true
 /// @param[in] skip_clone if true, will not clone the input expression
 /// @return the VEV
-ExprPtr vac_av(ExprPtr expr, const OpConnections<std::wstring>& op_connections = default_op_connections(),
+///@{
+ExprPtr vac_av(ExprPtr expr, const OpConnectivity<std::wstring>& op_connections = {.connect = default_op_connections()},
                bool use_topology = true, bool screen = true,
                bool skip_clone = false);
+/// @overload
+inline ExprPtr vac_av(ExprPtr expr, const OpConnections<std::wstring>& op_connections,
+                      bool use_topology = true, bool screen = true,
+                      bool skip_clone = false) {
+  return vac_av(std::move(expr), OpConnectivity<std::wstring>{.connect = op_connections},
+                use_topology, screen, skip_clone);
+}
+///@}
 
 }  // namespace op
 }  // namespace sequant::mbpt

--- a/SeQuant/domain/mbpt/vac_av.hpp
+++ b/SeQuant/domain/mbpt/vac_av.hpp
@@ -40,14 +40,6 @@ inline OpConnections<std::wstring> concat(
   return ranges::concat_view(a, b) | ranges::to_vector;
 }
 
-/// concat 2 sets of op connectivity constraints
-inline OpConnectivity<std::wstring> concat(
-    const OpConnectivity<std::wstring>& a,
-    const OpConnectivity<std::wstring>& b) {
-  return {.connect = concat(a.connect, b.connect),
-          .avoid = concat(a.avoid, b.avoid)};
-}
-
 /// @brief lowers an expression composed of Operators to tensor form
 /// @param[in] expr input expression
 /// @return expression with all Operators lowered to tensor form
@@ -69,66 +61,31 @@ inline ExprPtr lower_to_tensor_form(const ExprPtr& expr_inp) {
   return expr;
 }
 
-ExprPtr expectation_value_impl(
-    ExprPtr expr, const OpConnectivity<std::wstring>& op_connections,
-    bool use_topology, bool screen, bool skip_clone, bool full_contractions);
+ExprPtr expectation_value_impl(ExprPtr expr,
+                               const OpConnections<std::wstring>& connect,
+                               const OpConnections<std::wstring>& avoid,
+                               bool use_topology, bool screen, bool skip_clone,
+                               bool full_contractions);
 
 // clang-format off
-/// @name ref_av
 /// @brief computes the reference expectation value
 /// @note equivalent to vac_av if the reference state is the Wick vacuum,
 ///       i.e. if `get_default_context().index_space_registry()->reference_occupied_space() == get_default_context().index_space_registry()->vacuum_occupied_space()`
 /// @param[in] expr input expression
-/// @param[in] op_connections operator connectivity constraints; `connect`
-/// pairs are defined left-to-right, i.e., pair `{opL,opR}` declares that
-/// `opL` and `opR` are to be connected when `opR` precedes `opL`;
-/// `avoid` pairs specify operators that must never be directly contracted
-/// @param[in] use_topology if true, WickTheorem uses topological equivalence of
-/// terms, default is true
-/// @param[in] screen if true, expressions are screened before lowering to
-/// Tensor level and calling WickTheorem, default is true
-/// @param[in] skip_clone if true, will not clone the input expression
-/// @return the reference expectation value
-// clang_format on
-///@{
-ExprPtr ref_av(ExprPtr expr, const OpConnectivity<std::wstring>& op_connections = {.connect = default_op_connections()},
-               bool use_topology = true, bool screen = true,
-               bool skip_clone = false);
-/// @overload
-inline ExprPtr ref_av(ExprPtr expr, const OpConnections<std::wstring>& op_connections,
-                      bool use_topology = true, bool screen = true,
-                      bool skip_clone = false) {
-  return ref_av(std::move(expr), OpConnectivity<std::wstring>{.connect = op_connections},
-                use_topology, screen, skip_clone);
-}
-///@}
+/// @param[in] opts controls the behavior, @see EVOptions
+/// @note Uses `op::default_op_connections()` as default connectivity
+// clang-format on
+ExprPtr ref_av(ExprPtr expr, EVOptions<std::wstring> opts = {
+                                 .connect = default_op_connections()});
 
-/// @name vac_av
 /// @brief computes the vacuum expectation value
 /// @internal evaluates only full contractions in  WickTheorem
 /// @param[in] expr input expression
-/// @param[in] op_connections operator connectivity constraints; `connect`
-/// pairs are defined left-to-right, i.e., pair `{opL,opR}` declares that
-/// `opL` and `opR` are to be connected when `opR` precedes `opL`;
-/// `avoid` pairs specify operators that must never be directly contracted
-/// @param[in] use_topology if true, WickTheorem uses topological equivalence of
-/// terms, default is true
-/// @param[in] screen if true, expressions are screened before lowering to
-/// Tensor level and calling WickTheorem, default is true
-/// @param[in] skip_clone if true, will not clone the input expression
+/// @param[in] opts controls the behavior, @see EVOptions
+/// @note Uses `op::default_op_connections()` as default connectivity
 /// @return the VEV
-///@{
-ExprPtr vac_av(ExprPtr expr, const OpConnectivity<std::wstring>& op_connections = {.connect = default_op_connections()},
-               bool use_topology = true, bool screen = true,
-               bool skip_clone = false);
-/// @overload
-inline ExprPtr vac_av(ExprPtr expr, const OpConnections<std::wstring>& op_connections,
-                      bool use_topology = true, bool screen = true,
-                      bool skip_clone = false) {
-  return vac_av(std::move(expr), OpConnectivity<std::wstring>{.connect = op_connections},
-                use_topology, screen, skip_clone);
-}
-///@}
+ExprPtr vac_av(ExprPtr expr, EVOptions<std::wstring> opts = {
+                                 .connect = default_op_connections()});
 
 }  // namespace op
 }  // namespace sequant::mbpt

--- a/SeQuant/domain/mbpt/vac_av.hpp
+++ b/SeQuant/domain/mbpt/vac_av.hpp
@@ -61,11 +61,11 @@ inline ExprPtr lower_to_tensor_form(const ExprPtr& expr_inp) {
   return expr;
 }
 
-ExprPtr expectation_value_impl(ExprPtr expr,
-                               const OpConnections<std::wstring>& connect,
-                               const OpConnections<std::wstring>& avoid,
-                               bool use_topology, bool screen, bool skip_clone,
-                               bool full_contractions);
+// ExprPtr expectation_value_impl(ExprPtr expr,
+//                                const OpConnections<std::wstring>& connect,
+//                                const OpConnections<std::wstring>& avoid,
+//                                bool use_topology, bool screen, bool
+//                                skip_clone, bool full_contractions);
 
 // clang-format off
 /// @brief computes the reference expectation value

--- a/SeQuant/domain/mbpt/vac_av.hpp
+++ b/SeQuant/domain/mbpt/vac_av.hpp
@@ -19,13 +19,13 @@ inline OpConnections<std::wstring> default_op_connections() {
       {L"g", L"t"},
       // NBs
       // - for unitary ansatz can also connect t^+ with Hamiltonian
-      // - for exact (non-approximated) unitary ansatz will also
-      // need to connect t^+ with t; for MR unitary ansatz can also
-      // connect t with t and t^+ with t^+, but since adjoint() does
-      // not change OpType all of these are expressed as same
-      // connection ... this points out the need to have a separate
-      // OpType for t^+ and t, and in general the contents of OpType
-      // must be customizable
+      // - for exact (non-approximated) unitary ansatz will also need to connect
+      // t^+ with t;
+      //   for MR unitary ansatz can also connect t with t and t^+ with t^+ ,
+      //   but since adjoint() does not change OpType all of these are expressed
+      //   as same connection ... this points out the need to have a separate
+      //   OpType for t^+ and t, and in general the contents of OpType must be
+      //   customizable
       {L"t", L"h"},
       {L"t", L"f"},
       {L"t", L"f̃"},
@@ -59,12 +59,6 @@ inline ExprPtr lower_to_tensor_form(const ExprPtr& expr_inp) {
   lower_to_tensor_form(expr);
   return expr;
 }
-
-// ExprPtr expectation_value_impl(ExprPtr expr,
-//                                const OpConnections<std::wstring>& connect,
-//                                const OpConnections<std::wstring>& avoid,
-//                                bool use_topology, bool screen, bool
-//                                skip_clone, bool full_contractions);
 
 // clang-format off
 /// @brief computes the reference expectation value

--- a/benchmarks/wick.cpp
+++ b/benchmarks/wick.cpp
@@ -158,7 +158,8 @@ static void mbpt_vac_av(benchmark::State &state, bool csv) {
   for (auto _ : state) {
     ExprPtr result = [&]() {
       if (input.connections) {
-        return mbpt::tensor::vac_av(input.expr, input.connections.value());
+        return mbpt::tensor::vac_av(input.expr,
+                                    {.connect = input.connections.value()});
       } else {
         return mbpt::tensor::vac_av(input.expr);
       }

--- a/python/src/sequant/mbpt.h
+++ b/python/src/sequant/mbpt.h
@@ -29,10 +29,11 @@ ExprPtr VacuumAverage(const ExprPtr& e) { return sequant::mbpt::op::vac_av(e); }
 ExprPtr VacuumAverage(
     const ExprPtr& e,
     const std::vector<std::pair<std::string, std::string>>& op_connections) {
-  sequant::mbpt::OpConnections<std::wstring> wop_connections;
-  wop_connections.reserve(op_connections.size());
+  sequant::mbpt::OpConnectivity<std::wstring> wop_connections;
+  wop_connections.connect.reserve(op_connections.size());
   for (const auto& [op1, op2] : op_connections) {
-    wop_connections.emplace_back(sequant::toUtf16(op1), sequant::toUtf16(op2));
+    wop_connections.connect.emplace_back(sequant::toUtf16(op1),
+                                         sequant::toUtf16(op2));
   }
   return sequant::mbpt::op::vac_av(e, wop_connections);
 }

--- a/python/src/sequant/mbpt.h
+++ b/python/src/sequant/mbpt.h
@@ -28,7 +28,7 @@ ExprPtr VacuumAverage(const ExprPtr& e) { return sequant::mbpt::op::vac_av(e); }
 
 ExprPtr VacuumAverage(const ExprPtr& e, const PyEVOptions& opts) {
   // helper for converting connections lists
-  auto convert = [](const PyEVOptions::container_type& pairs) {
+  auto convert = [](const sequant::mbpt::OpConnections<std::string>& pairs) {
     sequant::mbpt::OpConnections<std::wstring> result;
     result.reserve(pairs.size());
     for (const auto& [a, b] : pairs) {

--- a/python/src/sequant/mbpt.h
+++ b/python/src/sequant/mbpt.h
@@ -36,11 +36,12 @@ ExprPtr VacuumAverage(const ExprPtr& e, const PyEVOptions& opts) {
     }
     return result;
   };
-  return sequant::mbpt::op::vac_av(e, {.connect = convert(opts.connect),
-                                       .avoid = convert(opts.avoid),
-                                       .screen = opts.screen,
-                                       .use_topology = opts.use_topology,
-                                       .skip_clone = opts.skip_clone});
+  return sequant::mbpt::op::vac_av(
+      e, {.connect = convert(opts.connect),
+          .do_not_connect = convert(opts.do_not_connect),
+          .screen = opts.screen,
+          .use_topology = opts.use_topology,
+          .skip_clone = opts.skip_clone});
 }
 
 #define SR_OP(OP) \
@@ -68,7 +69,7 @@ inline void __init__(py::module m) {
   py::class_<PyEVOptions>(m, "EVOptions")
       .def(py::init<>())
       .def_readwrite("connect", &PyEVOptions::connect)
-      .def_readwrite("avoid", &PyEVOptions::avoid)
+      .def_readwrite("do_not_connect", &PyEVOptions::do_not_connect)
       .def_readwrite("screen", &PyEVOptions::screen)
       .def_readwrite("use_topology", &PyEVOptions::use_topology)
       .def_readwrite("skip_clone", &PyEVOptions::skip_clone);

--- a/python/src/sequant/mbpt.h
+++ b/python/src/sequant/mbpt.h
@@ -22,20 +22,25 @@ auto make_sr_op(F f) {
   return op;
 }
 
-// Overload for no op_connections
+using PyEVOptions = sequant::mbpt::EVOptions<std::string>;
+
 ExprPtr VacuumAverage(const ExprPtr& e) { return sequant::mbpt::op::vac_av(e); }
 
-// overload  with string conversion
-ExprPtr VacuumAverage(
-    const ExprPtr& e,
-    const std::vector<std::pair<std::string, std::string>>& op_connections) {
-  sequant::mbpt::OpConnectivity<std::wstring> wop_connections;
-  wop_connections.connect.reserve(op_connections.size());
-  for (const auto& [op1, op2] : op_connections) {
-    wop_connections.connect.emplace_back(sequant::toUtf16(op1),
-                                         sequant::toUtf16(op2));
-  }
-  return sequant::mbpt::op::vac_av(e, wop_connections);
+ExprPtr VacuumAverage(const ExprPtr& e, const PyEVOptions& opts) {
+  // helper for converting connections lists
+  auto convert = [](const PyEVOptions::container_type& pairs) {
+    sequant::mbpt::OpConnections<std::wstring> result;
+    result.reserve(pairs.size());
+    for (const auto& [a, b] : pairs) {
+      result.emplace_back(sequant::toUtf16(a), sequant::toUtf16(b));
+    }
+    return result;
+  };
+  return sequant::mbpt::op::vac_av(e, {.connect = convert(opts.connect),
+                                       .avoid = convert(opts.avoid),
+                                       .screen = opts.screen,
+                                       .use_topology = opts.use_topology,
+                                       .skip_clone = opts.skip_clone});
 }
 
 #define SR_OP(OP) \
@@ -60,14 +65,19 @@ inline void __init__(py::module m) {
   m.def(SR_OP(T));
   m.def(SR_OP(t));
 
+  py::class_<PyEVOptions>(m, "EVOptions")
+      .def(py::init<>())
+      .def_readwrite("connect", &PyEVOptions::connect)
+      .def_readwrite("avoid", &PyEVOptions::avoid)
+      .def_readwrite("screen", &PyEVOptions::screen)
+      .def_readwrite("use_topology", &PyEVOptions::use_topology)
+      .def_readwrite("skip_clone", &PyEVOptions::skip_clone);
+
   m.def("VacuumAverage", py::overload_cast<const ExprPtr&>(&VacuumAverage),
         py::arg("expr"));
   m.def("VacuumAverage",
-        py::overload_cast<
-            const ExprPtr&,
-            const std::vector<std::pair<std::string, std::string>>&>(
-            &VacuumAverage),
-        py::arg("expr"), py::arg("op_connections"));
+        py::overload_cast<const ExprPtr&, const PyEVOptions&>(&VacuumAverage),
+        py::arg("expr"), py::arg("EVOptions"));
 }
 
 }  // namespace sequant::python::mbpt

--- a/python/src/sequant/mbpt.h
+++ b/python/src/sequant/mbpt.h
@@ -77,7 +77,7 @@ inline void __init__(py::module m) {
         py::arg("expr"));
   m.def("VacuumAverage",
         py::overload_cast<const ExprPtr&, const PyEVOptions&>(&VacuumAverage),
-        py::arg("expr"), py::arg("EVOptions"));
+        py::arg("expr"), py::arg("options"));
 }
 
 }  // namespace sequant::python::mbpt

--- a/python/test_sequant.py
+++ b/python/test_sequant.py
@@ -30,8 +30,10 @@ class TestSequant(unittest.TestCase):
     self.assertTrue((p+s).latex)
 
   def test_ccsd(self):
-    from _sequant.mbpt import A,H,T,t,VacuumAverage
-    ccd = VacuumAverage( A(-2) * H() * t(2) * t(2), [("h", "t")] );  # explicit list of operator connections ..
+    from _sequant.mbpt import A,H,T,t,VacuumAverage,EVOptions
+    opts = EVOptions()
+    opts.connect = [("h", "t")]
+    ccd = VacuumAverage( A(-2) * H() * t(2) * t(2), opts );  # explicit operator connections via EVOptions ..
     ccsd = VacuumAverage( A(-2) * H() * T(2) * T(2));                  # .. is not needed since H and T are connected by default
     print (ccsd.latex)
 

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -878,7 +878,7 @@ TEST_CASE("mbpt", "[mbpt][valgrind_skip]") {
         // H**T12**T12 -> R2
         SECTION("wick(H**T12**T12 -> R2)"){
             auto result = t::vac_av(t::A(nₚ(-2)) * t::H(2) * t::T(2) * t::T(2),
-                                    {{1, 2}, {1, 3}});
+                                    {.connect = {{1, 2}, {1, 3}}});
 
     //      std::wcout << "H*T12*T12 -> R2 = " << to_latex_align(result, 20)
     //                 << std::endl;
@@ -895,8 +895,8 @@ TEST_CASE("mbpt", "[mbpt][valgrind_skip]") {
 
   // H2**T3**T3 -> R4
   SECTION("wick(H2**T3**T3 -> R4)") {
-    auto result =
-        t::vac_av(t::A(nₚ(-4)) * t::h(2) * t::t(3) * t::t(3), {{1, 2}, {1, 3}});
+    auto result = t::vac_av(t::A(nₚ(-4)) * t::h(2) * t::t(3) * t::t(3),
+                            {.connect = {{1, 2}, {1, 3}}});
 
     // std::wcout << "H2**T3**T3 -> R4 = " << to_latex_align(result, 20)
     //            << std::endl;
@@ -910,7 +910,7 @@ TEST_CASE("mbpt", "[mbpt][valgrind_skip]") {
     ExprPtr ref_result;
     SECTION("wick(H2**T2**T2**T3 -> R5)") {
       ref_result = t::vac_av(t::A(-5) * t::h(2) * t::t(2) * t::t(2) * t::t(3),
-                             {{1, 2}, {1, 3}, {1, 4}});
+                             {.connect = {{1, 2}, {1, 3}, {1, 4}}});
       REQUIRE(ref_result->size() == 7);
     }
   }
@@ -946,8 +946,8 @@ SECTION("SRSO-PNO") {
 
   // H2**T2**T2 -> R2
   SECTION("wick(H2**T2**T2 -> R2)") {
-    auto result =
-        t::vac_av(t::A(nₚ(-2)) * t::h(2) * t::t(2) * t::t(2), {{1, 2}, {1, 3}});
+    auto result = t::vac_av(t::A(nₚ(-2)) * t::h(2) * t::t(2) * t::t(2),
+                            {.connect = {{1, 2}, {1, 3}}});
 
     REQUIRE(result->size() == 4);
   }
@@ -972,7 +972,8 @@ SECTION("SRSF") {
 
   // H2**T2 -> R2
   SECTION("wick(H2**T2 -> R2)") {
-    auto result = t::vac_av(t::S(-2) * t::h(2) * t::t(2), {{1, 2}});
+    auto result =
+        t::vac_av(t::S(-2) * t::h(2) * t::t(2), {.connect = {{1, 2}}});
 
     {
       // std::wcout << "H2**T2 -> R2 = " << to_latex_align(result, 0, 1)
@@ -999,10 +1000,10 @@ SECTION("MRSO") {
 
   SECTION("wick(H2**T2 -> 0)") {
     {
-      auto result = t::ref_av(t::h(2) * t::t(2), {{0, 1}});
+      auto result = t::ref_av(t::h(2) * t::t(2), {.connect = {{0, 1}}});
 
-      auto result_wo_top = t::ref_av(t::h(2) * t::t(2), {{0, 1}},
-                                     /* use_topology = */ false);
+      auto result_wo_top = t::ref_av(
+          t::h(2) * t::t(2), {.connect = {{0, 1}}, .use_topology = false});
       REQUIRE(simplify(result - result_wo_top) == ex<Constant>(0));
     }
 
@@ -1012,18 +1013,18 @@ SECTION("MRSO") {
       ctx.set(mbpt::make_mr_spaces());
       ctx.set(Vacuum::Physical);
       auto ctx_resetter = set_scoped_default_context(ctx);
-      auto result_phys = t::ref_av(t::h(2) * t::t(2), {{0, 1}});
+      auto result_phys = t::ref_av(t::h(2) * t::t(2), {.connect = {{0, 1}}});
     }
   }
 
   // H2 ** T2 ** T2 -> 0
   SECTION("wick(H2**T2**T2 -> 0)") {
     // first without use of topology
-    auto result = t::ref_av(t::h(2) * t::t(2) * t::t(2), {{0, 1}},
-                            /* use_topology = */ false);
+    auto result = t::ref_av(t::h(2) * t::t(2) * t::t(2),
+                            {.connect = {{0, 1}}, .use_topology = false});
     // now with topology use
-    auto result_top = t::ref_av(t::h(2) * t::t(2) * t ::t(2), {{0, 1}},
-                                /* use_topology = */ true);
+    auto result_top = t::ref_av(t::h(2) * t::t(2) * t ::t(2),
+                                {.connect = {{0, 1}}, .use_topology = true});
 
     REQUIRE(simplify(result - result_top) == ex<Constant>(0));
   }
@@ -1031,7 +1032,7 @@ SECTION("MRSO") {
 #if 0
     // H**T12 -> R2
     SECTION("wick(H**T2 -> R2)") {
-      auto result = t::ref_av(t::A(-2) * t::H() * t::t(2), {{1, 2}});
+      auto result = t::ref_av(t::A(-2) * t::H() * t::t(2), {.connect = {{1, 2}}});
 
       {
         std::wcout << "H*T2 -> R2 = " << to_latex_align(result, 0, 1)
@@ -1049,12 +1050,12 @@ SECTION("MRSF") {
   auto ctx_resetter = set_scoped_default_context(ctx);
 
   SECTION("wick(H2**T2 -> 0)") {
-    auto result = t::ref_av(t::h(2) * t::t(2), {{0, 1}});
+    auto result = t::ref_av(t::h(2) * t::t(2), {.connect = {{0, 1}}});
 
     {
       // make sure get same result without use of topology
-      auto result_wo_top = t::ref_av(t::h(2) * t::t(2), {{0, 1}},
-                                     /* use_topology = */ false);
+      auto result_wo_top = t::ref_av(
+          t::h(2) * t::t(2), {.connect = {{0, 1}}, .use_topology = false});
 
       REQUIRE(simplify(result - result_wo_top) == ex<Constant>(0));
     }
@@ -1167,8 +1168,8 @@ SECTION("manuscript-examples") {
                                            {L"f", antisymm_label()},
                                            {L"g", antisymm_label()}});
 
-    auto t = ref_av(P(2) * H̅(), t_connect);
-    auto λ = ref_av((1 + Λ(2)) * H̅() * P(-2), l_connect);
+    auto t = ref_av(P(2) * H̅(), {.connect = t_connect});
+    auto λ = ref_av((1 + Λ(2)) * H̅() * P(-2), {.connect = l_connect});
 
     // numer of terms are verified against srcc results
     REQUIRE(t.size() == 31);
@@ -1180,7 +1181,7 @@ SECTION("manuscript-examples") {
 
     auto θ̅ = lst(θ(1), T(N), 2);
     auto expr = (1 + Λ(N)) * θ̅ * Tʼ(N) + Λʼ(N) * θ̅;
-    auto result = ref_av(expr, OpConnections<>{{L"θ", L"t"}, {L"θ", L"t¹"}});
+    auto result = ref_av(expr, {.connect = {{L"θ", L"t"}, {L"θ", L"t¹"}}});
     // number of terms is verified against MPQC4 implementation
     REQUIRE(result.size() == 21);
   }
@@ -1197,14 +1198,18 @@ SECTION("manuscript-examples") {
                                            {L"g", antisymm_label()}});
 
     // EE
-    auto r_EE = ref_av(P(2) * H̅() * R(2), r_connect);
-    auto l_EE = ref_av(L(2) * H̅() * P(-2), l_connect);
+    auto r_EE = ref_av(P(2) * H̅() * R(2), {.connect = r_connect});
+    auto l_EE = ref_av(L(2) * H̅() * P(-2), {.connect = l_connect});
     // EA
-    auto r_EA = ref_av(P(nₚ(2), nₕ(1)) * H̅() * R(nₚ(2), nₕ(1)), r_connect);
-    auto l_EA = ref_av(L(nₚ(2), nₕ(1)) * H̅() * P(nₚ(-2), nₕ(-1)), l_connect);
+    auto r_EA =
+        ref_av(P(nₚ(2), nₕ(1)) * H̅() * R(nₚ(2), nₕ(1)), {.connect = r_connect});
+    auto l_EA = ref_av(L(nₚ(2), nₕ(1)) * H̅() * P(nₚ(-2), nₕ(-1)),
+                       {.connect = l_connect});
     // IP
-    auto r_IP = ref_av(P(nₚ(1), nₕ(2)) * H̅() * R(nₚ(1), nₕ(2)), r_connect);
-    auto l_IP = ref_av(L(nₚ(1), nₕ(2)) * H̅() * P(nₚ(-1), nₕ(-2)), l_connect);
+    auto r_IP =
+        ref_av(P(nₚ(1), nₕ(2)) * H̅() * R(nₚ(1), nₕ(2)), {.connect = r_connect});
+    auto l_IP = ref_av(L(nₚ(1), nₕ(2)) * H̅() * P(nₚ(-1), nₕ(-2)),
+                       {.connect = l_connect});
 
     // number of terms are verified against eomcc results
     REQUIRE(r_EE.size() == 53);
@@ -1234,11 +1239,12 @@ SECTION("manuscript-examples") {
                                            {L"h¹", antisymm_label()}});
 
     // perturbed t amplitudes (Eq 18 in SQ Manuscript #2)
-    auto t = ref_av(P(2) * (H̅(1) + H̅() * Tʼ(2) - "ω" * tʼ(2)), t_connect);
+    auto t = ref_av(P(2) * (H̅(1) + H̅() * Tʼ(2) - "ω" * tʼ(2)),
+                    {.connect = t_connect});
     // perturbed λ amplitudes (Eq 19 in SQ Manuscript #2)
     auto λ = ref_av(
         ((1 + Λ(2)) * (H̅(1) + H̅() * Tʼ(2)) + Λʼ(2) * H̅() + "ω" * λʼ(2)) * P(-2),
-        l_connect);
+        {.connect = l_connect});
 
     // number of terms are verified against MPQC4 implementation
     REQUIRE(t.size() == 58);

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -1180,7 +1180,7 @@ SECTION("manuscript-examples") {
 
     auto θ̅ = lst(θ(1), T(N), 2);
     auto expr = (1 + Λ(N)) * θ̅ * Tʼ(N) + Λʼ(N) * θ̅;
-    auto result = ref_av(expr, {{L"θ", L"t"}, {L"θ", L"t¹"}});
+    auto result = ref_av(expr, OpConnections<>{{L"θ", L"t"}, {L"θ", L"t¹"}});
     // number of terms is verified against MPQC4 implementation
     REQUIRE(result.size() == 21);
   }

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -1293,13 +1293,14 @@ SECTION("avoided-connections") {
 
   // h(1) * t(1): two operators, avoid the only possible contraction
   auto expr1 = tensor::h(1) * tensor::t(1);
-  auto res1 = tensor::vac_av(expr1, {.avoid = {{0, 1}}});
+  auto res1 = tensor::vac_av(expr1, {.do_not_connect = {{0, 1}}});
   REQUIRE(res1 == sequant::ex<sequant::Constant>(0));  // result should be zero
 
   // P(1) * H() * T(2): avoid connections between projector and Hamiltonian
   auto expr2 = tensor::P(1) * tensor::H() * tensor::T(2);
   auto res2_full = tensor::vac_av(expr2, {.connect = {{1, 2}}});
-  auto res2 = tensor::vac_av(expr2, {.connect = {{1, 2}}, .avoid = {{0, 1}}});
+  auto res2 =
+      tensor::vac_av(expr2, {.connect = {{1, 2}}, .do_not_connect = {{0, 1}}});
   REQUIRE(res2_full.size() == 6);
   // only one term with no A-{f,g} connection
   REQUIRE(res2.is<sequant::Product>());
@@ -1310,17 +1311,17 @@ SECTION("avoided-connections") {
   // same test as above but from Operator level and labels for connectivity
   using namespace sequant::mbpt::op;
   auto expr3 = op::P(1) * op::H(2) * op::T(2);
-  auto res3 = op::vac_av(
-      expr3, {.connect = {{L"f", L"t"}, {L"g", L"t"}},
-              .avoid = {{antisymm_label(), L"f"}, {antisymm_label(), L"g"}}});
+  auto res3 = op::vac_av(expr3, {.connect = {{L"f", L"t"}, {L"g", L"t"}},
+                                 .do_not_connect = {{antisymm_label(), L"f"},
+                                                    {antisymm_label(), L"g"}}});
   REQUIRE_THAT(sequant::simplify(res3), EquivalentTo(expected2));
 
   // projectors are never connected
   auto expr4 = op::P(1) * op::H() * op::t(2) * op::P(-1);
   auto res4_full = op::vac_av(expr4);
-  auto res4 =
-      op::vac_av(expr4, {.connect = op::default_op_connections(),
-                         .avoid = {{antisymm_label(), antisymm_label()}}});
+  auto res4 = op::vac_av(
+      expr4, {.connect = op::default_op_connections(),
+              .do_not_connect = {{antisymm_label(), antisymm_label()}}});
   REQUIRE(res4_full.size() == 4);
   REQUIRE(res4.is<sequant::Product>());  // only single term survives
   const std::wstring expected4 =

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -1323,7 +1323,6 @@ SECTION("avoided-connections") {
                          .avoid = {{antisymm_label(), antisymm_label()}}});
   REQUIRE(res4_full.size() == 4);
   REQUIRE(res4.is<sequant::Product>());  // only single term survives
-  std::wcout << sequant::serialize(simplify(res4)) << std::endl;
   const std::wstring expected4 =
       L"Â{i_1;a_2}:A-C-S Â{a_1;i_2}:A-C-S g{i_3,i_2;a_3,a_1}:A-C-S "
       L"t{a_3,a_2;i3,i_1}:A-C-S";

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -1288,17 +1288,45 @@ SECTION("manuscript-examples") {
 }  // SECTION("manuscript-examples")
 
 SECTION("avoided-connections") {
-  using namespace sequant::mbpt::op;
+  using namespace sequant::mbpt;
   using sequant::reserved::antisymm_label;
 
-  // operator-level: <P| H t t |P> with projectors on both sides
-  // avoiding projector-projector contraction
-  {
-    auto expr = P(1) * H() * T(2) * P(-1);
-    auto result = ref_av(expr);
-    auto result_avoid =
-        ref_av(expr, {.connect = default_op_connections(),
-                      .avoid = {{antisymm_label(), antisymm_label()}}});
-  }
+  // h(1) * t(1): two operators, avoid the only possible contraction
+  auto expr1 = tensor::h(1) * tensor::t(1);
+  auto res1 = tensor::vac_av(expr1, {.avoid = {{0, 1}}});
+  REQUIRE(res1 == sequant::ex<sequant::Constant>(0));  // result should be zero
+
+  // P(1) * H() * T(2): avoid connections between projector and Hamiltonian
+  auto expr2 = tensor::P(1) * tensor::H() * tensor::T(2);
+  auto res2_full = tensor::vac_av(expr2, {.connect = {{1, 2}}});
+  auto res2 = tensor::vac_av(expr2, {.connect = {{1, 2}}, .avoid = {{0, 1}}});
+  REQUIRE(res2_full.size() == 6);
+  // only one term with no A-{f,g} connection
+  REQUIRE(res2.is<sequant::Product>());
+  const std::wstring expected2 =
+      L"-1 Â{i_1;a_1}:A-C-S t{a_1,a_2;i_2,i_1}:A-C-S f{i_2;a_2}:A-C-S";
+  REQUIRE_THAT(sequant::simplify(res2), EquivalentTo(expected2));
+
+  // same test as above but from Operator level and labels for connectivity
+  using namespace sequant::mbpt::op;
+  auto expr3 = op::P(1) * op::H(2) * op::T(2);
+  auto res3 = op::vac_av(
+      expr3, {.connect = {{L"f", L"t"}, {L"g", L"t"}},
+              .avoid = {{antisymm_label(), L"f"}, {antisymm_label(), L"g"}}});
+  REQUIRE_THAT(sequant::simplify(res3), EquivalentTo(expected2));
+
+  // projectors are never connected
+  auto expr4 = op::P(1) * op::H() * op::t(2) * op::P(-1);
+  auto res4_full = op::vac_av(expr4);
+  auto res4 =
+      op::vac_av(expr4, {.connect = op::default_op_connections(),
+                         .avoid = {{antisymm_label(), antisymm_label()}}});
+  REQUIRE(res4_full.size() == 4);
+  REQUIRE(res4.is<sequant::Product>());  // only single term survives
+  std::wcout << sequant::serialize(simplify(res4)) << std::endl;
+  const std::wstring expected4 =
+      L"Â{i_1;a_2}:A-C-S Â{a_1;i_2}:A-C-S g{i_3,i_2;a_3,a_1}:A-C-S "
+      L"t{a_3,a_2;i3,i_1}:A-C-S";
+  REQUIRE_THAT(simplify(res4), EquivalentTo(expected4));
 }
 }

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -1280,4 +1280,19 @@ SECTION("manuscript-examples") {
             L"ã{i1,i2;a1,a2} ã{i3;a3,a4}"));
   }
 }  // SECTION("manuscript-examples")
+
+SECTION("avoided-connections") {
+  using namespace sequant::mbpt::op;
+  using sequant::reserved::antisymm_label;
+
+  // operator-level: <P| H t t |P> with projectors on both sides
+  // avoiding projector-projector contraction
+  {
+    auto expr = P(1) * H() * T(2) * P(-1);
+    auto result = ref_av(expr);
+    auto result_avoid =
+        ref_av(expr, {.connect = default_op_connections(),
+                      .avoid = {{antisymm_label(), antisymm_label()}}});
+  }
+}
 }

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -1325,7 +1325,7 @@ SECTION("avoided-connections") {
   REQUIRE(res4.is<sequant::Product>());  // only single term survives
   const std::wstring expected4 =
       L"Â{i_1;a_2}:A-C-S Â{a_1;i_2}:A-C-S g{i_3,i_2;a_3,a_1}:A-C-S "
-      L"t{a_3,a_2;i3,i_1}:A-C-S";
+      L"t{a_3,a_2;i_3,i_1}:A-C-S";
   REQUIRE_THAT(simplify(res4), EquivalentTo(expected4));
 }
 }


### PR DESCRIPTION
## Adds avoided connections support to `WickTheorem` and refactors MBPT expectation value methods to use `EVOptions`

### Summary
- Add `set_nop_avoided_connections` to `WickTheorem`: forbids all contractions between specified operator pairs
- Introduce `EVOptions<T>` struct to bundle expectation value parameters (connect, avoid, screen, use_topology, skip_clone). Some of the options are only valid at Operator level. 
- Refactor `ref_av/vac_av` at both tensor and operator levels to use `EVOptions`.
- **Breaking change:**  The positional-argument signatures for `ref_av/vac_av` are removed. All call sites must use `EVOptions` or designated initializers.

```C++
// Tensor level
// before
auto result = t::vac_av(expr, {{1, 2}, {1, 3}});
auto result = t::ref_av(expr, {{0, 1}}, /* use_topology = */ false);

// now
auto result = t::vac_av(expr, {.connect = {{1, 2}, {1, 3}}});
auto result = t::ref_av(expr, {.connect = {{0, 1}}, .use_topology = false});

// Operator level
// before
auto result = vac_av(expr, op_connections, use_topology, screen);

// now
auto result = vac_av(expr, {.connect = op_connections,
                             .use_topology = use_topology,
                             .screen = screen});

// new: avoided connections
auto result = ref_av(expr, {.connect = default_op_connections(),
                             .avoid = {{antisymm_label(), antisymm_label()}}});
```
- All call sites have been updated: CC, tests, benchmarks, Python bindings
- New avoided-connections tests. 

### Finer Details
-  `OpConnections<T>` is a standalone alias and is used within `EVOptions`, `default_op_connections()`, `concat()`, `CC::ref_av` parameter etc. 
-  `EVOptions` for top-level API, separated args for impl functions. The `expectation_value_impl` functions take individual parameters rather than `EVOptions` because they recurse internally and need to flip `skip_clone = true` on recursive calls. Using EVOptions would require copying and mutating the struct on each recursive call.
-  impl declarations of expectation value methods are removed from public headers. `tensor::expectation_value_impl` is removed from `op.hpp` and forward-declared in `vac_av.cpp`. 
- `CC::ref_av `takes `OpConnections`, not `EVOptions`. The CC class owns `use_topology` and `screen` as member state and callers within CC only ever vary the connections. This ensures consistent behavior across the class.
- Python bindings expose full `EVOptions`. The `VacuumAverage` overload converts options to `EVOptions<std::wstring> `internally.