### PR TITLE
fix(eval): make SEQUANT_EVAL_TRACE the master kill switch; add BTAS/TAPP trace parity

### DIFF
--- a/SeQuant/core/eval/backends/btas/result.hpp
+++ b/SeQuant/core/eval/backends/btas/result.hpp
@@ -151,8 +151,8 @@ class ResultTensorBTAS final : public Result {
     SEQUANT_ASSERT(other.is<ResultTensorBTAS<T>>());
     auto const a = annot_wrap{annot};
 
-    log_btas(ords_to_annot(a.lannot), " + ", ords_to_annot(a.rannot), " = ",
-             ords_to_annot(a.this_annot), "\n");
+    log_btas(ords_to_labels(a.lannot), " + ", ords_to_labels(a.rannot), " = ",
+             ords_to_labels(a.this_annot), "\n");
 
     T lres, rres;
     btas::permute(get<T>(), a.lannot, lres, a.this_annot);
@@ -167,8 +167,8 @@ class ResultTensorBTAS final : public Result {
 
     if (other.is<ResultScalar<numeric_type>>()) {
       auto const scalar = other.as<ResultScalar<numeric_type>>().value();
-      log_btas(ords_to_annot(a.lannot), " * ", scalar, " = ",
-               ords_to_annot(a.this_annot), "\n");
+      log_btas(ords_to_labels(a.lannot), " * ", scalar, " = ",
+               ords_to_labels(a.this_annot), "\n");
 
       T result;
       btas::permute(get<T>(), a.lannot, result, a.this_annot);
@@ -182,13 +182,13 @@ class ResultTensorBTAS final : public Result {
       T rres;
       btas::permute(other.get<T>(), a.rannot, rres, a.lannot);
       numeric_type const d = btas::dot(get<T>(), rres);
-      log_btas(ords_to_annot(a.lannot), " * ", ords_to_annot(a.rannot), " = ",
+      log_btas(ords_to_labels(a.lannot), " * ", ords_to_labels(a.rannot), " = ",
                d, "\n");
       return eval_result<ResultScalar<numeric_type>>(d);
     }
 
-    log_btas(ords_to_annot(a.lannot), " * ", ords_to_annot(a.rannot), " = ",
-             ords_to_annot(a.this_annot), "\n");
+    log_btas(ords_to_labels(a.lannot), " * ", ords_to_labels(a.rannot), " = ",
+             ords_to_labels(a.this_annot), "\n");
 
     T result;
     btas::contract(numeric_type{1},           //
@@ -210,7 +210,8 @@ class ResultTensorBTAS final : public Result {
     auto const pre_annot = std::any_cast<annot_t>(ann[0]);
     auto const post_annot = std::any_cast<annot_t>(ann[1]);
 
-    log_btas(ords_to_annot(pre_annot), " = ", ords_to_annot(post_annot), "\n");
+    log_btas(ords_to_labels(pre_annot), " = ", ords_to_labels(post_annot),
+             "\n");
 
     T result;
     btas::permute(get<T>(), pre_annot, result, post_annot);

--- a/SeQuant/core/eval/backends/btas/result.hpp
+++ b/SeQuant/core/eval/backends/btas/result.hpp
@@ -117,6 +117,11 @@ auto particle_antisymmetrize_btas(btas::Tensor<Args...> const& arr,
   return result;
 }
 
+template <typename... Args>
+inline void log_btas(Args const&... args) noexcept {
+  log_result("[BTAS] ", args...);
+}
+
 }  // namespace
 
 ///
@@ -146,6 +151,9 @@ class ResultTensorBTAS final : public Result {
     SEQUANT_ASSERT(other.is<ResultTensorBTAS<T>>());
     auto const a = annot_wrap{annot};
 
+    log_btas(ords_to_annot(a.lannot), " + ", ords_to_annot(a.rannot), " = ",
+             ords_to_annot(a.this_annot), "\n");
+
     T lres, rres;
     btas::permute(get<T>(), a.lannot, lres, a.this_annot);
     btas::permute(other.get<T>(), a.rannot, rres, a.this_annot);
@@ -158,9 +166,13 @@ class ResultTensorBTAS final : public Result {
     auto const a = annot_wrap{annot};
 
     if (other.is<ResultScalar<numeric_type>>()) {
+      auto const scalar = other.as<ResultScalar<numeric_type>>().value();
+      log_btas(ords_to_annot(a.lannot), " * ", scalar, " = ",
+               ords_to_annot(a.this_annot), "\n");
+
       T result;
       btas::permute(get<T>(), a.lannot, result, a.this_annot);
-      btas::scal(other.as<ResultScalar<numeric_type>>().value(), result);
+      btas::scal(scalar, result);
       return eval_result<ResultTensorBTAS<T>>(std::move(result));
     }
 
@@ -169,8 +181,14 @@ class ResultTensorBTAS final : public Result {
     if (a.this_annot.empty()) {
       T rres;
       btas::permute(other.get<T>(), a.rannot, rres, a.lannot);
-      return eval_result<ResultScalar<numeric_type>>(btas::dot(get<T>(), rres));
+      numeric_type const d = btas::dot(get<T>(), rres);
+      log_btas(ords_to_annot(a.lannot), " * ", ords_to_annot(a.rannot), " = ",
+               d, "\n");
+      return eval_result<ResultScalar<numeric_type>>(d);
     }
+
+    log_btas(ords_to_annot(a.lannot), " * ", ords_to_annot(a.rannot), " = ",
+             ords_to_annot(a.this_annot), "\n");
 
     T result;
     btas::contract(numeric_type{1},           //
@@ -191,6 +209,9 @@ class ResultTensorBTAS final : public Result {
       std::array<std::any, 2> const& ann) const override {
     auto const pre_annot = std::any_cast<annot_t>(ann[0]);
     auto const post_annot = std::any_cast<annot_t>(ann[1]);
+
+    log_btas(ords_to_annot(pre_annot), " = ", ords_to_annot(post_annot), "\n");
+
     T result;
     btas::permute(get<T>(), pre_annot, result, post_annot);
     return eval_result<ResultTensorBTAS<T>>(std::move(result));
@@ -200,6 +221,11 @@ class ResultTensorBTAS final : public Result {
     auto& t = get<T>();
     auto const& o = other.get<T>();
     SEQUANT_ASSERT(t.range() == o.range());
+
+    auto const ann = ords_to_annot(
+        ranges::views::iota(size_t{0}, static_cast<size_t>(t.rank())));
+    log_btas(ann, " += ", ann, "\n");
+
     t += o;
   }
 

--- a/SeQuant/core/eval/backends/tapp/result.hpp
+++ b/SeQuant/core/eval/backends/tapp/result.hpp
@@ -171,8 +171,8 @@ class ResultTensorTAPP final : public Result {
     SEQUANT_ASSERT(other.is<ResultTensorTAPP<T>>());
     auto const a = annot_wrap{annot};
 
-    log_tapp(ords_to_annot(a.lannot), " + ", ords_to_annot(a.rannot), " = ",
-             ords_to_annot(a.this_annot), "\n");
+    log_tapp(ords_to_labels(a.lannot), " + ", ords_to_labels(a.rannot), " = ",
+             ords_to_labels(a.this_annot), "\n");
 
     T lres, rres;
     tapp_ops::permute(get<T>(), a.lannot, lres, a.this_annot);
@@ -188,8 +188,8 @@ class ResultTensorTAPP final : public Result {
 
     if (other.is<ResultScalar<numeric_type>>()) {
       auto const scalar = other.as<ResultScalar<numeric_type>>().value();
-      log_tapp(ords_to_annot(a.lannot), " * ", scalar, " = ",
-               ords_to_annot(a.this_annot), "\n");
+      log_tapp(ords_to_labels(a.lannot), " * ", scalar, " = ",
+               ords_to_labels(a.this_annot), "\n");
 
       T result;
       tapp_ops::permute(get<T>(), a.lannot, result, a.this_annot);
@@ -204,13 +204,13 @@ class ResultTensorTAPP final : public Result {
       T rres;
       tapp_ops::permute(other.get<T>(), a.rannot, rres, a.lannot);
       numeric_type const d = tapp_ops::dot(get<T>(), rres);
-      log_tapp(ords_to_annot(a.lannot), " * ", ords_to_annot(a.rannot), " = ",
+      log_tapp(ords_to_labels(a.lannot), " * ", ords_to_labels(a.rannot), " = ",
                d, "\n");
       return eval_result<ResultScalar<numeric_type>>(d);
     }
 
-    log_tapp(ords_to_annot(a.lannot), " * ", ords_to_annot(a.rannot), " = ",
-             ords_to_annot(a.this_annot), "\n");
+    log_tapp(ords_to_labels(a.lannot), " * ", ords_to_labels(a.rannot), " = ",
+             ords_to_labels(a.this_annot), "\n");
 
     T result;
     tapp_ops::contract(numeric_type{1},           //
@@ -232,7 +232,8 @@ class ResultTensorTAPP final : public Result {
     auto const pre_annot = std::any_cast<annot_t>(ann[0]);
     auto const post_annot = std::any_cast<annot_t>(ann[1]);
 
-    log_tapp(ords_to_annot(pre_annot), " = ", ords_to_annot(post_annot), "\n");
+    log_tapp(ords_to_labels(pre_annot), " = ", ords_to_labels(post_annot),
+             "\n");
 
     T result;
     tapp_ops::permute(get<T>(), pre_annot, result, post_annot);

--- a/SeQuant/core/eval/backends/tapp/result.hpp
+++ b/SeQuant/core/eval/backends/tapp/result.hpp
@@ -138,6 +138,11 @@ auto particle_antisymmetrize_tapp(TAPPTensor<T, Alloc> const& arr,
   return result;
 }
 
+template <typename... Args>
+inline void log_tapp(Args const&... args) noexcept {
+  log_result("[TAPP] ", args...);
+}
+
 }  // namespace
 
 ///
@@ -166,6 +171,9 @@ class ResultTensorTAPP final : public Result {
     SEQUANT_ASSERT(other.is<ResultTensorTAPP<T>>());
     auto const a = annot_wrap{annot};
 
+    log_tapp(ords_to_annot(a.lannot), " + ", ords_to_annot(a.rannot), " = ",
+             ords_to_annot(a.this_annot), "\n");
+
     T lres, rres;
     tapp_ops::permute(get<T>(), a.lannot, lres, a.this_annot);
     tapp_ops::permute(other.get<T>(), a.rannot, rres, a.this_annot);
@@ -179,9 +187,13 @@ class ResultTensorTAPP final : public Result {
     auto const a = annot_wrap{annot};
 
     if (other.is<ResultScalar<numeric_type>>()) {
+      auto const scalar = other.as<ResultScalar<numeric_type>>().value();
+      log_tapp(ords_to_annot(a.lannot), " * ", scalar, " = ",
+               ords_to_annot(a.this_annot), "\n");
+
       T result;
       tapp_ops::permute(get<T>(), a.lannot, result, a.this_annot);
-      tapp_ops::scal(other.as<ResultScalar<numeric_type>>().value(), result);
+      tapp_ops::scal(scalar, result);
       return eval_result<ResultTensorTAPP<T>>(std::move(result));
     }
 
@@ -191,9 +203,14 @@ class ResultTensorTAPP final : public Result {
       // Full contraction -> scalar result (dot product)
       T rres;
       tapp_ops::permute(other.get<T>(), a.rannot, rres, a.lannot);
-      return eval_result<ResultScalar<numeric_type>>(
-          tapp_ops::dot(get<T>(), rres));
+      numeric_type const d = tapp_ops::dot(get<T>(), rres);
+      log_tapp(ords_to_annot(a.lannot), " * ", ords_to_annot(a.rannot), " = ",
+               d, "\n");
+      return eval_result<ResultScalar<numeric_type>>(d);
     }
+
+    log_tapp(ords_to_annot(a.lannot), " * ", ords_to_annot(a.rannot), " = ",
+             ords_to_annot(a.this_annot), "\n");
 
     T result;
     tapp_ops::contract(numeric_type{1},           //
@@ -214,6 +231,9 @@ class ResultTensorTAPP final : public Result {
       std::array<std::any, 2> const& ann) const override {
     auto const pre_annot = std::any_cast<annot_t>(ann[0]);
     auto const post_annot = std::any_cast<annot_t>(ann[1]);
+
+    log_tapp(ords_to_annot(pre_annot), " = ", ords_to_annot(post_annot), "\n");
+
     T result;
     tapp_ops::permute(get<T>(), pre_annot, result, post_annot);
     return eval_result<ResultTensorTAPP<T>>(std::move(result));
@@ -223,6 +243,11 @@ class ResultTensorTAPP final : public Result {
     auto& t = get<T>();
     auto const& o = other.get<T>();
     SEQUANT_ASSERT(t.extents() == o.extents());
+
+    auto const ann = ords_to_annot(
+        ranges::views::iota(size_t{0}, static_cast<size_t>(t.rank())));
+    log_tapp(ann, " += ", ann, "\n");
+
     t += o;
   }
 

--- a/SeQuant/core/eval/backends/tiledarray/result.cpp
+++ b/SeQuant/core/eval/backends/tiledarray/result.cpp
@@ -14,7 +14,7 @@ namespace sequant {
 
 void log_ta_tensor_host_memory_use([[maybe_unused]] madness::World& world,
                                    [[maybe_unused]] std::string_view label) {
-#if defined(TA_TENSOR_MEM_PROFILE)
+#if defined(SEQUANT_EVAL_TRACE) && defined(TA_TENSOR_MEM_PROFILE)
   auto logger = Logger::instance();
   if (logger.eval.level < 3) return;
   std::vector<std::uint64_t> hwsize(world.size(), 0);

--- a/SeQuant/core/eval/result.hpp
+++ b/SeQuant/core/eval/result.hpp
@@ -17,7 +17,9 @@
 #include <range/v3/view/transform.hpp>
 
 #include <any>
+#include <cstdint>
 #include <memory>
+#include <string>
 #include <utility>
 
 namespace sequant {
@@ -135,6 +137,30 @@ std::string ords_to_annot(RngOfOrdinals const& ords) {
   auto to_str = [](auto x) { return std::to_string(x); };
   return ords | transform(to_str) | intersperse(std::string{","}) | join |
          ranges::to<std::string>;
+}
+
+/// Maps an integer annot value to a short symbolic name (i0, i1, ...).
+/// BTAS/TAPP annot vectors carry index hashes rather than small ordinals,
+/// so raw values look like 6073936079388559375. The mapping is process-
+/// global and monotonic so the same hash gets the same label across log
+/// lines, which makes a trace easy to follow.
+inline std::string annot_label(std::int64_t key) noexcept {
+  static container::unordered_map<std::int64_t, std::string> labels;
+  static std::size_t next_id = 0;
+  if (auto it = labels.find(key); it != labels.end()) return it->second;
+  auto name = "i" + std::to_string(next_id++);
+  return labels.emplace(key, std::move(name)).first->second;
+}
+
+template <typename RngOfOrdinals>
+std::string ords_to_labels(RngOfOrdinals const& ords) {
+  using ranges::views::intersperse;
+  using ranges::views::join;
+  using ranges::views::transform;
+  return ords | transform([](auto x) {
+           return annot_label(static_cast<std::int64_t>(x));
+         }) |
+         intersperse(std::string{","}) | join | ranges::to<std::string>;
 }
 
 template <typename... Args>

--- a/SeQuant/core/eval/result.hpp
+++ b/SeQuant/core/eval/result.hpp
@@ -138,9 +138,11 @@ std::string ords_to_annot(RngOfOrdinals const& ords) {
 }
 
 template <typename... Args>
-inline void log_result(Args const&... args) noexcept {
+inline void log_result([[maybe_unused]] Args const&... args) noexcept {
+#ifdef SEQUANT_EVAL_TRACE
   auto& l = Logger::instance();
   if (l.eval.level > 1) write_log(l, args...);
+#endif
 }
 
 template <typename... Args>


### PR DESCRIPTION
## Summary

Three related changes to the eval-trace machinery:

1. **Fix:** `SEQUANT_EVAL_TRACE=OFF` did not fully suppress trace output. The high-level engine in `eval.hpp` is properly gated by `if constexpr (trace(EvalTrace))`, but the leaf helpers `log_result()` / `log_constant()` / `log_ta()` in `result.hpp` (and `log_ta_tensor_host_memory_use()` in the TA backend) only checked the runtime `Logger::eval.level`. So a binary built with `SEQUANT_EVAL_TRACE=OFF` still emitted `[TA]` / `[CONST]` lines whenever `Logger::eval.level > 1`. The compile-time flag is now wired into `log_result()` (which `log_ta` / `log_constant` flow through) and the TA memory-profile helper, making the flag a true master kill switch.

2. **Feat:** Mirror `log_ta`-style trace hooks in the BTAS and TAPP backends. Previously only the TA backend emitted per-op trace lines; BTAS/TAPP were silent at level ≥ 2. Adds `log_btas` / `log_tapp` (both routing through `log_result`, so they pick up the same `SEQUANT_EVAL_TRACE` gate) and emits `[BTAS]` / `[TAPP]` lines from `sum`, `prod` (incl. scalar / dot / contract), `permute`, and `add_inplace`.

3. **Feat:** Pretty-print BTAS/TAPP annot vectors. They carry Index hashes (e.g. `6073936079388559375`) rather than small ordinals, which made the new trace lines unreadable. A process-global `annot_label` / `ords_to_labels` (in `result.hpp`) assigns `i0`, `i1`, ... on first sight and reuses labels across log lines, so the same hash keeps the same name for a run. Trace output goes from

   ```
   [BTAS] 6073936079388559375,-5714762605692103436 = ...
   ```

   to

   ```
   [BTAS] i0,i1 = ...
   ```

   Labels are shared across BTAS and TAPP (single static in the shared header). `add_inplace` keeps `ords_to_annot` since its annot is a literal iota placeholder, not a hash.

## Test plan

- [x] Build with `SEQUANT_EVAL_TRACE=OFF` — `SeQuant-eval` and BTAS/TAPP unit-test objects compile clean.
- [x] Build with `SEQUANT_EVAL_TRACE=ON` — same.
- [x] Run `unit_tests-sequant '[eval_btas]'` and `'[eval_tapp]'` with `Logger::eval.level = 2`:
  - With `SEQUANT_EVAL_TRACE=ON`: lines like `[BTAS] i2,i3,i4,i5 * i0,i4,i1,i2 = i3,i0,i1,i5` are emitted.
  - With `SEQUANT_EVAL_TRACE=OFF`: zero `[BTAS]` / `[TAPP]` / `[CONST]` lines emitted (confirmed by `grep -c`).