### PR TITLE
fix: `external_indices` supports unequal bra and ket

### DIFF
--- a/SeQuant/core/utility/indices.hpp
+++ b/SeQuant/core/utility/indices.hpp
@@ -485,13 +485,29 @@ Container<Group<SlottedIndex>> external_indices(const Expr& expr) {
       cont.at(i + num_braket).emplace_back(tensor.aux()[i], SlotType::Aux);
     }
 
-    if (tensor.label() == reserved::symm_label() ||
-        tensor.label() == reserved::antisymm_label()) {
+    const bool is_symm = tensor.label() == reserved::symm_label();
+    if (is_symm || tensor.label() == reserved::antisymm_label()) {
       // Note: In tensors representing symmetrization operators, bra and ket
       // indices are conjugated (reversed). Hence, we have to swap the
       // determined bra and ket indices.
+      // For a number-non-conserving antisymmetrizer (bra_rank != ket_rank),
+      // an unpaired index at a position has no partner to swap with, so flip
+      // its slot type instead to preserve the bra<->ket conjugation.
       for (std::size_t i = 0; i < num_braket; ++i) {
-        std::swap(cont.at(i).at(0).index(), cont.at(i).at(1).index());
+        auto& group = cont.at(i);
+        if (group.size() == 2) {
+          std::swap(group.at(0).index(), group.at(1).index());
+        } else if (is_symm) {
+          throw Exception(
+              "external_indices: column symmetrizer requires paired "
+              "bra/ket indices");
+        } else {
+          SEQUANT_ASSERT(group.size() == 1);
+          group.at(0) = SlottedIndex(group.at(0).index(),
+                                     group.at(0).slot_type() == SlotType::Bra
+                                         ? SlotType::Ket
+                                         : SlotType::Bra);
+        }
       }
     }
 

--- a/tests/unit/test_utilities.cpp
+++ b/tests/unit/test_utilities.cpp
@@ -591,6 +591,18 @@ TEST_CASE("utilities", "[utilities]") {
                {{L"i_2", SlotType::Bra}, {L"a_2", SlotType::Ket}}}},
              {L"Â{a1;i1}",
               {{{L"i_1", SlotType::Bra}, {L"a_1", SlotType::Ket}}}},
+             // For number-non-conserving antisymmetrizer (bra_rank !=
+             // ket_rank), which appears in EOM-IP / EOM-EA expressions, the
+             // bra<->ket conjugation must still hold and unpaired indices get
+             // their slot type flipped.
+             {L"Â{i1,i2;a1}",
+              {{{L"a_1", SlotType::Bra}, {L"i_1", SlotType::Ket}},
+               {{L"i_2", SlotType::Ket}}}},
+             {L"Â{a1;i1,i2}",
+              {{{L"i_1", SlotType::Bra}, {L"a_1", SlotType::Ket}},
+               {{L"i_2", SlotType::Bra}}}},
+             {L"Â{i1,i2;} R{;i1,i2}",
+              {{{L"i_1", SlotType::Ket}}, {{L"i_2", SlotType::Ket}}}},
          }) {
       CAPTURE(toUtf8(input));
 


### PR DESCRIPTION
Fix external_indices crash on antisymmetrizer with unequal bra/ket rank
Related to issue #523