### PR TITLE
More optimization related changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,6 +446,7 @@ set(SeQuant_eval_src
 # Optimize sources (depends on eval)
 set(SeQuant_optimize_src
         SeQuant/core/optimize/common_subexpression_elimination.hpp
+        SeQuant/core/optimize/extract_subtrees.hpp
         SeQuant/core/optimize/fusion.cpp
         SeQuant/core/optimize/fusion.hpp
         SeQuant/core/optimize/options.hpp

--- a/SeQuant/core/eval/eval_expr.hpp
+++ b/SeQuant/core/eval/eval_expr.hpp
@@ -272,6 +272,7 @@ class EvalExpr {
 
 struct EvalOpSetter {
   void set(EvalExpr& expr, EvalOp op) { expr.op_type_ = op; }
+  void reset(EvalExpr& expr) { expr.op_type_ = std::nullopt; }
 };
 
 namespace meta {

--- a/SeQuant/core/optimize/extract_subtrees.hpp
+++ b/SeQuant/core/optimize/extract_subtrees.hpp
@@ -16,7 +16,11 @@ namespace detail {
 template <meta::eval_node Node, typename ResultSet>
 void capture(Node& n, ResultSet& result) {
   result.insert(n);  // FullBinaryNode copy ctor is deep
-  n = Node{*n};      // collapse to a leaf carrying a copy of n's payload
+  // collapse to a leaf carrying a copy of n's payload with op_type nulled
+  // so the synthetic leaf reads as a primary expression
+  auto leaf_payload = *n;
+  EvalOpSetter{}.reset(static_cast<EvalExpr&>(leaf_payload));
+  n = Node{std::move(leaf_payload)};
 }
 
 template <meta::eval_node Node, typename Pred, typename ResultSet>
@@ -39,17 +43,16 @@ bool extract_subtrees_visit(Node& n, Pred& pred, ResultSet& result) {
 
 ///
 /// Extract maximal `pred`-matching subtrees from a forest of EvalNodes,
-/// replacing each match in place with a leaf carrying a verbatim copy of
-/// the original payload (expr, hash, canon_indices, phase, connectivity,
-/// op_type).
+/// replacing each match in place with a leaf carrying a copy of the
+/// original payload (expr, hash, canon_indices, phase, connectivity)
+/// with `op_type_` reset to null so the synthetic leaf reads as a
+/// primary expression.
 ///
 /// `pred(n, pl, pr) -> bool` is tested in post-order; `pl`/`pr` are the
 /// predicate values of `n`'s children (both `false` if `n` is a leaf).
 /// A node `n` is captured iff `pred(n) ∧ (n is a root ∨ ¬pred(parent(n)))`.
 /// Nested pred-positive descendants of a captured subtree are inlined,
-/// not re-extracted. The synthetic leaf retains the original payload's
-/// `op_type_`; consumers should treat the FullBinaryNode shape as
-/// authoritative rather than branching on the payload's `op_type_`.
+/// not re-extracted.
 ///
 /// Example — extract intermediates that don't involve any tensor with
 /// label "t". `pred(leaf) = false` keeps bare leaves out of the result

--- a/SeQuant/core/optimize/extract_subtrees.hpp
+++ b/SeQuant/core/optimize/extract_subtrees.hpp
@@ -1,0 +1,88 @@
+#ifndef SEQUANT_OPTIMIZE_EXTRACT_SUBTREES_HPP
+#define SEQUANT_OPTIMIZE_EXTRACT_SUBTREES_HPP
+
+#include <SeQuant/core/binary_node.hpp>
+#include <SeQuant/core/eval/eval_expr.hpp>
+#include <SeQuant/core/eval/eval_node_compare.hpp>
+
+#include <concepts>
+#include <ranges>
+#include <unordered_set>
+
+namespace sequant::opt {
+
+namespace detail {
+
+template <meta::eval_node Node, typename ResultSet>
+void capture(Node& n, ResultSet& result) {
+  result.insert(n);  // FullBinaryNode copy ctor is deep
+  n = Node{*n};      // collapse to a leaf carrying a copy of n's payload
+}
+
+template <meta::eval_node Node, typename Pred, typename ResultSet>
+bool extract_subtrees_visit(Node& n, Pred& pred, ResultSet& result) {
+  bool pl = false;
+  bool pr = false;
+  if (!n.leaf()) {
+    pl = extract_subtrees_visit(n.left(), pred, result);
+    pr = extract_subtrees_visit(n.right(), pred, result);
+  }
+  const bool pn = pred(static_cast<Node const&>(n), pl, pr);
+  if (!pn) {
+    if (pl) capture<Node>(n.left(), result);
+    if (pr) capture<Node>(n.right(), result);
+  }
+  return pn;
+}
+
+}  // namespace detail
+
+///
+/// Extract maximal `pred`-matching subtrees from a forest of EvalNodes,
+/// replacing each match in place with a leaf carrying a verbatim copy of
+/// the original payload (expr, hash, canon_indices, phase, connectivity,
+/// op_type).
+///
+/// `pred(n, pl, pr) -> bool` is tested in post-order; `pl`/`pr` are the
+/// predicate values of `n`'s children (both `false` if `n` is a leaf).
+/// A node `n` is captured iff `pred(n) ∧ (n is a root ∨ ¬pred(parent(n)))`.
+/// Nested pred-positive descendants of a captured subtree are inlined,
+/// not re-extracted. The synthetic leaf retains the original payload's
+/// `op_type_`; consumers should treat the FullBinaryNode shape as
+/// authoritative rather than branching on the payload's `op_type_`.
+///
+/// Example — extract intermediates that don't involve any tensor with
+/// label "t". `pred(leaf) = false` keeps bare leaves out of the result
+/// (and prevents whole-tree root collapse); the per-leaf test is folded
+/// into the parent's check via `child_ok`:
+///
+///   auto pred = [](EvalNode<EvalExpr> const& n, bool pl, bool pr) -> bool {
+///     if (n.leaf()) return false;
+///     auto child_ok = [](EvalNode<EvalExpr> const& c, bool pc) {
+///       return c.leaf() ? c->is_tensor() && c->as_tensor().label() != L"t"
+///                       : pc;
+///     };
+///     return child_ok(n.left(), pl) && child_ok(n.right(), pr);
+///   };
+///   auto intermediates = sequant::opt::extract_subtrees(forest, pred);
+///
+template <meta::eval_node_range Range, typename Pred>
+  requires std::indirectly_writable<std::ranges::iterator_t<Range>,
+                                    std::ranges::range_value_t<Range>> &&
+           std::predicate<Pred&, std::ranges::range_value_t<Range> const&, bool,
+                          bool>
+auto extract_subtrees(Range& nodes, Pred pred) {
+  using Node = std::ranges::range_value_t<Range>;
+  using ResultSet = std::unordered_set<Node, TreeNodeHasher<Node>,
+                                       TreeNodeEqualityComparator<Node>>;
+  ResultSet result;
+  for (auto& node : nodes) {
+    if (detail::extract_subtrees_visit(node, pred, result))
+      detail::capture<Node>(node, result);
+  }
+  return result;
+}
+
+}  // namespace sequant::opt
+
+#endif  // SEQUANT_OPTIMIZE_EXTRACT_SUBTREES_HPP

--- a/SeQuant/core/optimize/optimize.cpp
+++ b/SeQuant/core/optimize/optimize.cpp
@@ -32,12 +32,14 @@ index_to_extent_t default_idx_to_size() {
 }
 
 /// Optimize a Product that contains only Tensor and scalar factors.
-ExprPtr opt_pure_product(Product const& prod, index_to_extent_t const& idx2size,
-                         OptFor opt_for) {
-  if (opt_for == OptFor::Flops)
-    return opt::single_term_opt<OptFor::Flops>(prod, idx2size);
-  SEQUANT_ASSERT(opt_for == OptFor::Memsize);
-  return opt::single_term_opt<OptFor::Memsize>(prod, idx2size);
+ExprPtr opt_pure_product(Product const& prod, OptimizeOptions const& opts) {
+  bool const subnet_cse = opts.subnet_cse == SubnetCSE::Enable;
+  if (opts.opt_for == OptFor::Flops)
+    return opt::single_term_opt<OptFor::Flops>(prod, opts.idx_to_extent,
+                                               subnet_cse);
+  SEQUANT_ASSERT(opts.opt_for == OptFor::Memsize);
+  return opt::single_term_opt<OptFor::Memsize>(prod, opts.idx_to_extent,
+                                               subnet_cse);
 }
 
 /// Deliberately non-identifier label prefix used to stand in for non-Tensor,
@@ -48,8 +50,7 @@ inline constexpr std::wstring_view placeholder_label_prefix = L"@__opt_";
 /// Optimize a Product that contains some non-Tensor, non-scalar factors by
 /// substituting placeholder tensors with target indices, optimizing the
 /// resulting tensor-only product, then swapping the originals back in.
-ExprPtr opt_mixed_product(Product const& prod,
-                          index_to_extent_t const& idx2size, OptFor opt_for) {
+ExprPtr opt_mixed_product(Product const& prod, OptimizeOptions const& opts) {
   container::svector<ExprPtr> non_tensors(prod.size());
   container::svector<ExprPtr> new_factors;
   new_factors.reserve(prod.size());
@@ -68,8 +69,7 @@ ExprPtr opt_mixed_product(Product const& prod,
   }
 
   auto result = opt_pure_product(
-      Product{prod.scalar(), new_factors, Product::Flatten::No}, idx2size,
-      opt_for);
+      Product{prod.scalar(), new_factors, Product::Flatten::No}, opts);
 
   auto replacer = [&non_tensors](ExprPtr& out) {
     if (!out->is<Tensor>()) return;
@@ -97,15 +97,14 @@ ExprPtr opt_mixed_product(Product const& prod,
 /// Recursive workhorse. \p parallel_outer controls whether the (single)
 /// outermost Sum's summands are processed in parallel; nested recursive
 /// calls always run sequentially to avoid `sequant::for_each` oversubscription.
-ExprPtr optimize_impl(ExprPtr const& expr, index_to_extent_t const& idx2size,
-                      OptFor opt_for, bool reorder, bool parallel_outer) {
+ExprPtr optimize_impl(ExprPtr const& expr, OptimizeOptions const& opts,
+                      bool reorder, bool parallel_outer) {
   if (expr->is<Product>()) {
     auto const& prod = expr->as<Product>();
     bool pure = ranges::all_of(prod, [](auto&& x) {
       return x->template is<Tensor>() || x->is_scalar();
     });
-    return pure ? opt_pure_product(prod, idx2size, opt_for)
-                : opt_mixed_product(prod, idx2size, opt_for);
+    return pure ? opt_pure_product(prod, opts) : opt_mixed_product(prod, opts);
   }
 
   if (expr->is<Sum>()) {
@@ -113,9 +112,9 @@ ExprPtr optimize_impl(ExprPtr const& expr, index_to_extent_t const& idx2size,
     Sum::summands_type new_smands(in_sum.size());
 
     auto do_term = [&](std::size_t i) {
-      new_smands[i] =
-          optimize_impl(in_sum.summand(i), idx2size, opt_for,
-                        /*reorder=*/false, /*parallel_outer=*/false);
+      new_smands[i] = optimize_impl(in_sum.summand(i), opts,
+                                    /*reorder=*/false,
+                                    /*parallel_outer=*/false);
     };
 
     // Thread-safety of the parallel branch rests on two invariants; do NOT
@@ -159,10 +158,8 @@ ExprPtr optimize_impl(ExprPtr const& expr, index_to_extent_t const& idx2size,
 }  // namespace
 
 ExprPtr optimize(ExprPtr const& expr, OptimizeOptions opts) {
-  auto idx2size = opts.idx_to_extent ? std::move(opts.idx_to_extent)
-                                     : default_idx_to_size();
-  return optimize_impl(expr, idx2size, opts.opt_for,
-                       opts.reorder == ReorderSum::Reorder,
+  if (!opts.idx_to_extent) opts.idx_to_extent = default_idx_to_size();
+  return optimize_impl(expr, opts, opts.reorder == ReorderSum::Reorder,
                        /*parallel_outer=*/true);
 }
 

--- a/SeQuant/core/optimize/options.hpp
+++ b/SeQuant/core/optimize/options.hpp
@@ -15,6 +15,11 @@ enum class OptFor { Flops, Memsize };
 /// closer to each other.
 enum class ReorderSum { Reorder, NoReorder };
 
+/// Whether single-term optimization should recognize equivalent subnetworks
+/// while searching for an evaluation order, trading extra search time for
+/// potentially lower op counts.
+enum class SubnetCSE { Enable, Disable };
+
 /// A type-erased provider mapping an Index to its extent. Used by the public
 /// optimize() API. Callers reaching for the templated opt::single_term_opt
 /// overloads (constrained by \ref opt::has_index_extent) should pass the
@@ -31,6 +36,11 @@ struct OptimizeOptions {
   /// Whether to reorder summands so terms with shared intermediates appear
   /// closer to each other.
   ReorderSum reorder = ReorderSum::Reorder;
+
+  /// Whether single-term optimization should perform subnetwork
+  /// common-subexpression recognition. Disabled by default; enabling can
+  /// reduce op counts at the cost of additional optimization time.
+  SubnetCSE subnet_cse = SubnetCSE::Disable;
 
   /// Caller-supplied Index to extent provider. If empty, defaults to
   /// \c IndexSpace::approximate_size().

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -54,6 +54,7 @@ target_compile_definitions(unit_tests-sequant-eval-obj PRIVATE
 # OBJECT library: Optimize tests (SeQuant-optimize)
 ##########################
 set(optimize_test_sources
+    "test_extract_subtrees.cpp"
     "test_fusion.cpp"
     "test_optimize.cpp"
 )

--- a/tests/unit/test_extract_subtrees.cpp
+++ b/tests/unit/test_extract_subtrees.cpp
@@ -1,0 +1,106 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "catch2_sequant.hpp"
+
+#include <SeQuant/core/attr.hpp>
+#include <SeQuant/core/binary_node.hpp>
+#include <SeQuant/core/eval/eval_expr.hpp>
+#include <SeQuant/core/eval/eval_node.hpp>
+#include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/io/shorthands.hpp>
+#include <SeQuant/core/optimize/extract_subtrees.hpp>
+
+#include <vector>
+
+namespace {
+
+using Node = sequant::EvalNode<sequant::EvalExpr>;
+
+Node bin(std::wstring_view s) {
+  using namespace sequant;
+  return binarize(deserialize(s, {.def_perm_symm = Symmetry::Antisymm}));
+}
+
+// Example predicate from the header docs: capture maximal internal
+// subtrees whose leaves are all non-"t" tensors.
+auto non_t_intermediate_pred = [](Node const& n, bool pl, bool pr) -> bool {
+  if (n.leaf()) return false;
+  auto child_ok = [](Node const& c, bool pc) {
+    return c.leaf() ? c->is_tensor() && c->as_tensor().label() != L"t" : pc;
+  };
+  return child_ok(n.left(), pl) && child_ok(n.right(), pr);
+};
+
+}  // namespace
+
+TEST_CASE("opt::extract_subtrees", "[optimize][extract_subtrees]") {
+  using namespace sequant;
+
+  SECTION("empty forest yields empty result set") {
+    std::vector<Node> forest;
+    auto extracted = opt::extract_subtrees(
+        forest, [](Node const&, bool, bool) { return true; });
+    REQUIRE(extracted.empty());
+  }
+
+  SECTION("never-true predicate leaves the forest untouched") {
+    std::vector<Node> forest;
+    forest.emplace_back(bin(L"g{a1,a2;i1,i2} * t{i1,i2;a1,a2}"));
+    REQUIRE_FALSE(forest[0].leaf());
+
+    auto extracted = opt::extract_subtrees(
+        forest, [](Node const&, bool, bool) { return false; });
+    REQUIRE(extracted.empty());
+    REQUIRE_FALSE(forest[0].leaf());
+  }
+
+  SECTION("always-true predicate captures each root, collapsing forest items") {
+    std::vector<Node> forest;
+    forest.emplace_back(bin(L"g{a1;i1} * t{i1;a1}"));
+    forest.emplace_back(bin(L"f{a1;a2} * g{a2;a1}"));
+    REQUIRE_FALSE(forest[0].leaf());
+    REQUIRE_FALSE(forest[1].leaf());
+
+    auto extracted = opt::extract_subtrees(
+        forest, [](Node const&, bool, bool) { return true; });
+    REQUIRE(extracted.size() == 2);
+    REQUIRE(forest[0].leaf());
+    REQUIRE(forest[1].leaf());
+  }
+
+  SECTION("non-t pred: pure-non-t root collapses, mixed root is pruned") {
+    std::vector<Node> forest;
+    // mixed: contains a "t" leaf, so the top-level pred is false and
+    // the lone non-t sibling is itself a leaf (also pred-false) — nothing
+    // gets extracted from this item.
+    forest.emplace_back(bin(L"g{a1,a2;i1,i2} * t{i1,i2;a1,a2}"));
+    // pure non-t: pred bubbles true to the root → root-capture.
+    forest.emplace_back(bin(L"f{a1;a2} * g{a2;a1}"));
+
+    auto extracted = opt::extract_subtrees(forest, non_t_intermediate_pred);
+
+    REQUIRE(extracted.size() == 1);
+    REQUIRE_FALSE(forest[0].leaf());  // mixed item retains its internal shape
+    REQUIRE(forest[1].leaf());        // pure-non-t root collapsed
+  }
+
+  SECTION(
+      "captured subtrees under the example pred are always internal nodes") {
+    std::vector<Node> forest;
+    forest.emplace_back(bin(L"f{a1;a2} * g{a2;a1}"));
+    auto extracted = opt::extract_subtrees(forest, non_t_intermediate_pred);
+    REQUIRE(extracted.size() == 1);
+    REQUIRE_FALSE(extracted.begin()->leaf());
+  }
+
+  SECTION(
+      "no-recurse: nested positives inside a captured subtree stay inlined") {
+    // All-non-t 3-factor product: regardless of how binarize shapes it,
+    // every internal node is pred-positive (no "t" anywhere). Only the
+    // root is captured; the internal grandchild is *not* a separate entry.
+    std::vector<Node> forest;
+    forest.emplace_back(bin(L"g{a1;a2} * g{a2;a3} * f{a3;a4}"));
+    auto extracted = opt::extract_subtrees(forest, non_t_intermediate_pred);
+    REQUIRE(extracted.size() == 1);
+  }
+}

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -479,6 +479,53 @@ TEST_CASE("optimize", "[optimize]") {
           (res_no_cse->at(0)->is<Tensor>() || res_no_cse->at(1)->is<Tensor>());
       REQUIRE(is_unbalanced);
     }
+
+    SECTION("subnet_cse flows through OptimizeOptions") {
+      auto ctx_resetter =
+          set_scoped_default_context(get_default_context().clone());
+      auto reg = get_default_context().mutable_index_space_registry();
+      // Same sizing trick as the section above: CSE prefers balanced,
+      // no-CSE prefers unbalanced.
+      reg->retrieve_ptr(L"i")->approximate_size(12);
+      reg->retrieve_ptr(L"a")->approximate_size(10);
+
+      auto idx_to_extent = [](Index const& ix) -> std::size_t {
+        return ix.nonnull() ? ix.space().approximate_size() : 1;
+      };
+
+      auto prod =
+          deserialize(L"X{i1;a1} Y{a1;i2} X{i2;a2} Y{a2;i3}")->as<Product>();
+      auto expr = ex<Product>(prod);
+
+      auto res_cse =
+          optimize(expr, OptimizeOptions{.subnet_cse = SubnetCSE::Enable,
+                                         .idx_to_extent = idx_to_extent});
+      auto res_no_cse =
+          optimize(expr, OptimizeOptions{.subnet_cse = SubnetCSE::Disable,
+                                         .idx_to_extent = idx_to_extent});
+
+      // With CSE: balanced tree -- both children are Products.
+      REQUIRE(res_cse->is<Product>());
+      REQUIRE(res_cse->as<Product>().factors().size() == 2);
+      REQUIRE(res_cse->at(0)->is<Product>());
+      REQUIRE(res_cse->at(1)->is<Product>());
+
+      // Without CSE: unbalanced tree -- at least one child is a bare Tensor.
+      REQUIRE(res_no_cse->is<Product>());
+      REQUIRE(res_no_cse->as<Product>().factors().size() == 2);
+      bool is_unbalanced =
+          res_no_cse->at(0)->is<Tensor>() || res_no_cse->at(1)->is<Tensor>();
+      REQUIRE(is_unbalanced);
+
+      // Default OptimizeOptions => subnet_cse Disable => same as no-CSE shape.
+      auto res_default =
+          optimize(expr, OptimizeOptions{.idx_to_extent = idx_to_extent});
+      REQUIRE(res_default->is<Product>());
+      REQUIRE(res_default->as<Product>().factors().size() == 2);
+      bool default_is_unbalanced =
+          res_default->at(0)->is<Tensor>() || res_default->at(1)->is<Tensor>();
+      REQUIRE(default_is_unbalanced);
+    }
   }
 
   /// verify that space changes did not leak


### PR DESCRIPTION
- Add a SubnetCSE enum and OptimizeOptions::subnet_cse field so callers of sequant::optimize() can toggle subnetwork CSE recognition during single-term optimization.
- extract_subtrees walks a forest of EvalNodes in post-order and captures the maximal pred-matching subtrees: a node n is collected iff pred(n) ∧ (n is a root ∨ ¬pred(parent(n)))