### PR TITLE
eval: custom evaluator hook + batching a tensor network over a contracted index

### DIFF
--- a/SeQuant/core/eval/backends/tiledarray/result.hpp
+++ b/SeQuant/core/eval/backends/tiledarray/result.hpp
@@ -166,6 +166,37 @@ template <typename... Args>
     TA::DistArray<Args...> const& arr, std::size_t mode, std::size_t tile_lo,
     std::size_t tile_hi);
 
+/// Partition a TiledRange1 into contiguous, tile-aligned element-range batches,
+/// each covering at least \p target_batch_size elements where possible. Tiles
+/// are not uniformly sized, so batches are uneven; the last batch may be
+/// smaller, and any single tile larger than the target forms its own batch.
+/// Element ranges `[lo, hi)` are in the TiledRange1's element coordinate system
+/// (honoring a nonzero element lobound, e.g. a frozen-core offset). This is the
+/// TA realization of Result::mode_batches(): the caller requests a target batch
+/// size in *elements*, which we convert to whole-tile groups. Returns at least
+/// one batch for a non-empty mode.
+[[nodiscard]] inline container::svector<std::pair<std::size_t, std::size_t>>
+mode_batches_of_trange1(TA::TiledRange1 const& tr1,
+                        std::size_t target_batch_size) {
+  container::svector<std::pair<std::size_t, std::size_t>> batches;
+  auto const& er = tr1.elements_range();
+  if (er.second <= er.first) return batches;  // empty mode
+  std::size_t const target = std::max<std::size_t>(target_batch_size, 1);
+  std::size_t grp_lo = er.first;
+  std::size_t acc = 0;
+  std::size_t const ntiles = tr1.tile_extent();
+  for (std::size_t t = 0; t < ntiles; ++t) {
+    auto const& tr = tr1.tile(t);
+    acc += tr.second - tr.first;
+    if (acc >= target || t + 1 == ntiles) {
+      batches.emplace_back(grp_lo, tr.second);
+      grp_lo = tr.second;
+      acc = 0;
+    }
+  }
+  return batches;
+}
+
 ///
 /// \brief Result for a tensor value of TA::DistArray type.
 /// \tparam ArrayT TA::DistArray type. Tile type of ArrayT is regular tensor of
@@ -204,10 +235,21 @@ class ResultTensorTA final : public Result {
     return eval_result<this_type>(std::move(result));
   }
 
-  [[nodiscard]] ResultPtr slice_mode(std::size_t mode, std::size_t tile_lo,
-                                     std::size_t tile_hi) const override {
+  [[nodiscard]] ResultPtr slice_mode(std::size_t mode, std::size_t elem_lo,
+                                     std::size_t elem_hi) const override {
+    auto const& tr1 = get<ArrayT>().trange().dim(mode);
+    std::size_t const tile_lo = tr1.element_to_tile(elem_lo);
+    std::size_t const tile_hi = (elem_hi >= tr1.elements_range().second)
+                                    ? tr1.tile_extent()
+                                    : tr1.element_to_tile(elem_hi);
     return eval_result<this_type>(
         slice_array_over_mode(get<ArrayT>(), mode, tile_lo, tile_hi));
+  }
+
+  [[nodiscard]] container::svector<std::pair<std::size_t, std::size_t>>
+  mode_batches(std::size_t mode, std::size_t target_batch_size) const override {
+    return mode_batches_of_trange1(get<ArrayT>().trange().dim(mode),
+                                   target_batch_size);
   }
 
   [[nodiscard]] ResultPtr prod(Result const& other,
@@ -364,10 +406,21 @@ class ResultTensorOfTensorTA final : public Result {
     return eval_result<this_type>(std::move(result));
   }
 
-  [[nodiscard]] ResultPtr slice_mode(std::size_t mode, std::size_t tile_lo,
-                                     std::size_t tile_hi) const override {
+  [[nodiscard]] ResultPtr slice_mode(std::size_t mode, std::size_t elem_lo,
+                                     std::size_t elem_hi) const override {
+    auto const& tr1 = get<ArrayT>().trange().dim(mode);
+    std::size_t const tile_lo = tr1.element_to_tile(elem_lo);
+    std::size_t const tile_hi = (elem_hi >= tr1.elements_range().second)
+                                    ? tr1.tile_extent()
+                                    : tr1.element_to_tile(elem_hi);
     return eval_result<this_type>(
         slice_array_over_mode(get<ArrayT>(), mode, tile_lo, tile_hi));
+  }
+
+  [[nodiscard]] container::svector<std::pair<std::size_t, std::size_t>>
+  mode_batches(std::size_t mode, std::size_t target_batch_size) const override {
+    return mode_batches_of_trange1(get<ArrayT>().trange().dim(mode),
+                                   target_batch_size);
   }
 
   [[nodiscard]] ResultPtr prod(Result const& other,

--- a/SeQuant/core/eval/backends/tiledarray/result.hpp
+++ b/SeQuant/core/eval/backends/tiledarray/result.hpp
@@ -466,6 +466,37 @@ class ResultTensorOfTensorTA final : public Result {
   }
 };
 
+/// \brief Restrict a TA::DistArray to a contiguous tile range of one mode.
+///
+/// Keeps tiles `[tile_lo, tile_hi)` of mode \p mode and all tiles of every
+/// other mode; the result's `mode`-th TiledRange1 covers only those tiles
+/// (its element range is shifted to start at 0). Implemented with TA's
+/// `block()`, so block-sparse shape is preserved. Used to evaluate a tensor
+/// network in batches over a contracted index (see
+/// make_batched_custom_evaluator): slicing every leaf that carries the index
+/// to a tile range, evaluating, and summing reproduces the full contraction
+/// because `sum_K = sum_{blocks} sum_{K in block}`.
+template <typename... Args>
+[[nodiscard]] TA::DistArray<Args...> slice_array_over_mode(
+    TA::DistArray<Args...> const& arr, std::size_t mode, std::size_t tile_lo,
+    std::size_t tile_hi) {
+  using ranges::views::iota;
+  auto const rank = arr.trange().rank();
+  SEQUANT_ASSERT(mode < rank);
+  SEQUANT_ASSERT(tile_lo < tile_hi &&
+                 tile_hi <= arr.trange().dim(mode).tile_extent());
+  container::svector<std::size_t> lo(rank, 0), hi(rank);
+  for (std::size_t d = 0; d < rank; ++d)
+    hi[d] = arr.trange().dim(d).tile_extent();
+  lo[mode] = tile_lo;
+  hi[mode] = tile_hi;
+  auto const annot = ords_to_annot(iota(std::size_t{0}, rank));
+  TA::DistArray<Args...> out;
+  out(annot) = arr(annot).block(lo, hi);
+  TA::DistArray<Args...>::wait_for_lazy_cleanup(arr.world());
+  return out;
+}
+
 }  // namespace sequant
 
 #endif  // SEQUANT_HAS_TILEDARRAY

--- a/SeQuant/core/eval/backends/tiledarray/result.hpp
+++ b/SeQuant/core/eval/backends/tiledarray/result.hpp
@@ -159,6 +159,13 @@ inline void log_ta_tensor_host_memory_use() {
 #endif
 }
 
+// defined below; declared here so the result classes' slice_mode() overrides
+// can call it.
+template <typename... Args>
+[[nodiscard]] TA::DistArray<Args...> slice_array_over_mode(
+    TA::DistArray<Args...> const& arr, std::size_t mode, std::size_t tile_lo,
+    std::size_t tile_hi);
+
 ///
 /// \brief Result for a tensor value of TA::DistArray type.
 /// \tparam ArrayT TA::DistArray type. Tile type of ArrayT is regular tensor of
@@ -195,6 +202,12 @@ class ResultTensorTA final : public Result {
     decltype(result)::wait_for_lazy_cleanup(result.world());
     log_ta_tensor_host_memory_use();
     return eval_result<this_type>(std::move(result));
+  }
+
+  [[nodiscard]] ResultPtr slice_mode(std::size_t mode, std::size_t tile_lo,
+                                     std::size_t tile_hi) const override {
+    return eval_result<this_type>(
+        slice_array_over_mode(get<ArrayT>(), mode, tile_lo, tile_hi));
   }
 
   [[nodiscard]] ResultPtr prod(Result const& other,
@@ -349,6 +362,12 @@ class ResultTensorOfTensorTA final : public Result {
     decltype(result)::wait_for_lazy_cleanup(result.world());
     log_ta_tensor_host_memory_use();
     return eval_result<this_type>(std::move(result));
+  }
+
+  [[nodiscard]] ResultPtr slice_mode(std::size_t mode, std::size_t tile_lo,
+                                     std::size_t tile_hi) const override {
+    return eval_result<this_type>(
+        slice_array_over_mode(get<ArrayT>(), mode, tile_lo, tile_hi));
   }
 
   [[nodiscard]] ResultPtr prod(Result const& other,

--- a/SeQuant/core/eval/backends/tiledarray/result.hpp
+++ b/SeQuant/core/eval/backends/tiledarray/result.hpp
@@ -238,10 +238,21 @@ class ResultTensorTA final : public Result {
   [[nodiscard]] ResultPtr slice_mode(std::size_t mode, std::size_t elem_lo,
                                      std::size_t elem_hi) const override {
     auto const& tr1 = get<ArrayT>().trange().dim(mode);
+    // slice_mode takes element bounds, but a tiled backend can only cut on tile
+    // boundaries; mode_batches() returns exactly such (tile-aligned, in-range)
+    // bounds. Assert the precondition so misuse is caught rather than silently
+    // producing an over- or under-sized slice (which would break batched sums).
+    SEQUANT_ASSERT(elem_lo >= tr1.elements_range().first && elem_lo < elem_hi &&
+                   elem_hi <= tr1.elements_range().second);
     std::size_t const tile_lo = tr1.element_to_tile(elem_lo);
+    SEQUANT_ASSERT(tr1.tile(tile_lo).first ==
+                   elem_lo);  // lo on a tile boundary
     std::size_t const tile_hi = (elem_hi >= tr1.elements_range().second)
                                     ? tr1.tile_extent()
                                     : tr1.element_to_tile(elem_hi);
+    SEQUANT_ASSERT(elem_hi >= tr1.elements_range().second ||
+                   tr1.tile(tile_hi).first ==
+                       elem_hi);  // hi on a tile boundary
     return eval_result<this_type>(
         slice_array_over_mode(get<ArrayT>(), mode, tile_lo, tile_hi));
   }
@@ -409,10 +420,21 @@ class ResultTensorOfTensorTA final : public Result {
   [[nodiscard]] ResultPtr slice_mode(std::size_t mode, std::size_t elem_lo,
                                      std::size_t elem_hi) const override {
     auto const& tr1 = get<ArrayT>().trange().dim(mode);
+    // slice_mode takes element bounds, but a tiled backend can only cut on tile
+    // boundaries; mode_batches() returns exactly such (tile-aligned, in-range)
+    // bounds. Assert the precondition so misuse is caught rather than silently
+    // producing an over- or under-sized slice (which would break batched sums).
+    SEQUANT_ASSERT(elem_lo >= tr1.elements_range().first && elem_lo < elem_hi &&
+                   elem_hi <= tr1.elements_range().second);
     std::size_t const tile_lo = tr1.element_to_tile(elem_lo);
+    SEQUANT_ASSERT(tr1.tile(tile_lo).first ==
+                   elem_lo);  // lo on a tile boundary
     std::size_t const tile_hi = (elem_hi >= tr1.elements_range().second)
                                     ? tr1.tile_extent()
                                     : tr1.element_to_tile(elem_hi);
+    SEQUANT_ASSERT(elem_hi >= tr1.elements_range().second ||
+                   tr1.tile(tile_hi).first ==
+                       elem_hi);  // hi on a tile boundary
     return eval_result<this_type>(
         slice_array_over_mode(get<ArrayT>(), mode, tile_lo, tile_hi));
   }

--- a/SeQuant/core/eval/cache_manager.hpp
+++ b/SeQuant/core/eval/cache_manager.hpp
@@ -15,6 +15,7 @@
 #include <range/v3/view/transform.hpp>
 
 #include <algorithm>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -33,6 +34,21 @@ template <typename TreeNode, bool force_hash_collisions>
 class CacheManager {
  public:
   using key_type = TreeNode;
+
+  /// A custom evaluator type. `evaluate()` consults the cache's custom
+  /// evaluator (if set) before applying its standard recursive scheme to each
+  /// *non-leaf* node, invoking it as `custom_evaluator(node, cache)`:
+  ///   - a non-null `ResultPtr` means "I evaluated this subtree myself" (e.g.
+  ///     blocked over a contracted index to bound peak memory) and is used (and
+  ///     cached) as-is;
+  ///   - a null result means "decline", and the standard scheme evaluates the
+  ///     node (its children are in turn consulted via the threaded cache).
+  /// The leaf evaluator is captured by the callable. A custom evaluator that
+  /// (re)evaluates the subtree by the standard scheme on a transformed operand
+  /// set should do so on a *scratch* cache (e.g. `CacheManager::empty()`) to
+  /// avoid both re-interception and polluting this cache with partial results.
+  using custom_evaluator_type =
+      std::function<ResultPtr(key_type const&, CacheManager&)>;
 
  private:
   using hasher_type = TreeNodeHasher<TreeNode, force_hash_collisions>;
@@ -92,7 +108,21 @@ class CacheManager {
   /// evaluation of one term and is naturally reset between terms.
   size_t working_set_hwmark_ = 0;
 
+  /// Optional custom evaluator consulted by evaluate() (see
+  /// custom_evaluator_type). Empty => always defer to the standard scheme.
+  custom_evaluator_type custom_evaluator_{};
+
  public:
+  /// Sets the custom evaluator (see custom_evaluator_type). Pass an empty
+  /// std::function to clear it.
+  void set_custom_evaluator(custom_evaluator_type fn) noexcept {
+    custom_evaluator_ = std::move(fn);
+  }
+
+  /// \return the custom evaluator (empty if none is set).
+  [[nodiscard]] custom_evaluator_type const& custom_evaluator() const noexcept {
+    return custom_evaluator_;
+  }
   template <typename Iterable>
     requires(!std::same_as<std::remove_cvref_t<Iterable>, CacheManager>)
   explicit CacheManager(Iterable&& decaying) noexcept {

--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -16,6 +16,7 @@
 
 #include <range/v3/range/operations.hpp>
 
+#include <algorithm>
 #include <any>
 #include <chrono>
 #include <iostream>
@@ -361,6 +362,48 @@ static_assert(Trace::Default == Trace::On || Trace::Default == Trace::Off);
 namespace {
 [[nodiscard]] consteval bool trace(Trace t) noexcept { return t == Trace::On; }
 }  // namespace
+
+/// \brief The indices contracted at a binary evaluation node.
+///
+/// These are the indices present in *both* children's (canonical) result
+/// indices but absent from the node's own result indices -- i.e. the indices
+/// summed over by this node's product. Empty for leaves, for sums, and for
+/// products with no contracted index (e.g. a pure outer/Hadamard product).
+///
+/// Each such index `K` is a valid axis to evaluate the subtree rooted at
+/// `node` in batches: the node computes `R = sum_K f(K)`, so
+/// `R = sum_{blocks b} sum_{K in b} f(K)` -- evaluating per-block and summing
+/// bounds the peak memory of `K`-carrying intermediates in the subtree. A
+/// custom evaluator (see CacheManager::custom_evaluator_type) can use this to
+/// implement batched evaluation.
+[[nodiscard]] inline Index::index_vector contracted_indices(
+    meta::eval_node auto const& node) {
+  Index::index_vector result;
+  if (node.leaf() || !node->is_product()) return result;
+  auto const& l = node.left()->canon_indices();
+  auto const& r = node.right()->canon_indices();
+  auto const& c = node->canon_indices();
+  auto contains = [](auto const& vec, Index const& ix) {
+    return std::find(vec.begin(), vec.end(), ix) != vec.end();
+  };
+  for (Index const& ix : l)
+    if (contains(r, ix) && !contains(c, ix)) result.push_back(ix);
+  return result;
+}
+
+/// \brief A default axis to batch the subtree at \p node over: the contracted
+/// index (see contracted_indices) with the largest IndexSpace approximate
+/// size -- typically the auxiliary/RI index, whose elimination most reduces the
+/// peak intermediate. \return nullopt if the node has no contracted index.
+[[nodiscard]] inline std::optional<Index> batch_axis(
+    meta::eval_node auto const& node) {
+  auto const contracted = contracted_indices(node);
+  if (contracted.empty()) return std::nullopt;
+  return *std::max_element(
+      contracted.begin(), contracted.end(), [](Index const& a, Index const& b) {
+        return a.space().approximate_size() < b.space().approximate_size();
+      });
+}
 
 ///
 /// \tparam EvalTrace If Trace::On, trace is written to the logger's stream.

--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -857,15 +857,39 @@ ResultPtr evaluate_antisymm(Args&&... args) {
 ///        possible.
 /// \param accept predicate selecting which contracted indices may be batched
 ///        (e.g. only those in the auxiliary/RI IndexSpace). Defaults to any.
+/// \param make_scope_guard factory, called with the batch count, returning an
+///        RAII object held for the duration of the batched partial
+///        contractions; a backend may use it to relax block-sparse screening
+///        (scaled by the batch count) so per-batch screening does not drop
+///        small contributions that are significant once summed over the full
+///        batch axis. Defaults to a no-op (make_no_scope_guard).
 struct accept_any_index {
   bool operator()(Index const&) const noexcept { return true; }
 };
 
-template <typename F, typename IndexPredicate = accept_any_index>
-[[nodiscard]] auto make_batched_custom_evaluator(F le,
-                                                 std::size_t target_batch_size,
-                                                 IndexPredicate accept = {}) {
-  return [le = std::move(le), target_batch_size, accept](
+/// Default scope-guard factory for make_batched_custom_evaluator: produces a
+/// no-op guard. A backend may supply a factory whose returned RAII object
+/// relaxes block-sparse screening for the duration of the batched partial
+/// contractions, so that a result block whose norm clears the screening
+/// threshold over the *full* batch axis is not dropped in every individual
+/// batch (which would lose its contribution to the sum). The factory is called
+/// with the batch count, so the backend can scale the relaxation accordingly
+/// (e.g. divide a Cauchy-Schwarz norm-product screening threshold by n_batches:
+/// the bound for a sub-sum over 1/n of the batch axis is ~1/n of the full
+/// bound). See make_batched_custom_evaluator's \p make_scope_guard parameter.
+struct no_scope_guard {};
+struct make_no_scope_guard {
+  no_scope_guard operator()(std::size_t /*n_batches*/) const noexcept {
+    return {};
+  }
+};
+
+template <typename F, typename IndexPredicate = accept_any_index,
+          typename ScopeGuardFactory = make_no_scope_guard>
+[[nodiscard]] auto make_batched_custom_evaluator(
+    F le, std::size_t target_batch_size, IndexPredicate accept = {},
+    ScopeGuardFactory make_scope_guard = {}) {
+  return [le = std::move(le), target_batch_size, accept, make_scope_guard](
              auto const& node, auto& cache) -> ResultPtr {
     using cache_t = std::remove_reference_t<decltype(cache)>;
 
@@ -879,6 +903,13 @@ template <typename F, typename IndexPredicate = accept_any_index>
 
     if (batches.size() <= 1)
       return nullptr;  // nothing to gain (or unbatchable)
+
+    // RAII scope for the batched partial contractions; a backend-supplied
+    // factory may relax block-sparse screening here (scaled by the batch count)
+    // so per-batch screening does not drop contributions that survive over the
+    // full batch axis.
+    auto const scope_guard = make_scope_guard(batches.size());
+    (void)scope_guard;
 
     ResultPtr acc;
     for (auto const& [e_lo, e_hi] : batches) {

--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -419,6 +419,31 @@ template <typename IndexPredicate>
   return batch_axis(node, [](Index const&) { return true; });
 }
 
+/// \return the position of index \p ix in \p node's canonical result indices
+///         (i.e. the corresponding tensor mode), or nullopt if absent.
+[[nodiscard]] inline std::optional<std::size_t> index_position(
+    meta::eval_node auto const& node, Index const& ix) {
+  auto const& idxs = node->canon_indices();
+  for (std::size_t p = 0; p < idxs.size(); ++p)
+    if (idxs[p] == ix) return p;
+  return std::nullopt;
+}
+
+/// \return the first leaf in the subtree rooted at \p node whose canonical
+///         indices contain \p ix, paired with the position of \p ix there; or
+///         nullopt if no such leaf. Used to learn \p ix's tile structure from
+///         a tensor that carries it.
+template <typename Node>
+[[nodiscard]] std::optional<std::pair<Node, std::size_t>> find_leaf_carrying(
+    Node const& node, Index const& ix) {
+  if (node.leaf()) {
+    if (auto const p = index_position(node, ix)) return std::pair{node, *p};
+    return std::nullopt;
+  }
+  if (auto found = find_leaf_carrying(node.left(), ix)) return found;
+  return find_leaf_carrying(node.right(), ix);
+}
+
 ///
 /// \tparam EvalTrace If Trace::On, trace is written to the logger's stream.
 ///                   Default is to follow Trace::Default, which is itself
@@ -807,6 +832,79 @@ ResultPtr evaluate_antisymm(Args&&... args) {
     log::eval(stat, n0->label());
   }
   return result;
+}
+
+/// \brief Builds a custom evaluator (see CacheManager::custom_evaluator_type)
+/// that evaluates a subtree in batches over a contracted index, to bound the
+/// peak memory of intermediates that carry that index.
+///
+/// For each node it is consulted on, the returned evaluator chooses a batch
+/// axis \c K via `batch_axis(node, accept)` (declining if none). It asks the
+/// backend to partition \c K into contiguous element-range batches of about
+/// \p target_batch_size elements each (Result::mode_batches); if that yields at
+/// most one batch it declines (so small / unselected indices are left to the
+/// standard scheme). Otherwise, for each batch it evaluates the subtree by the
+/// standard scheme on a fresh scratch cache, with every leaf carrying \c K
+/// sliced to the batch's element range, and sums the partial results. This is
+/// exact because `sum_K = sum_{batches} sum_{K in batch}`, and never
+/// materializes the whole \c K extent of any intermediate at once.
+///
+/// \param le the leaf evaluator (captured).
+/// \param target_batch_size the desired size of each batch *in elements* (a
+///        user knob; no memory model is assumed). Backend-neutral: a tiled
+///        backend rounds batch boundaries to tile boundaries, so realized
+///        batches are uneven and each covers at least this many elements where
+///        possible.
+/// \param accept predicate selecting which contracted indices may be batched
+///        (e.g. only those in the auxiliary/RI IndexSpace). Defaults to any.
+struct accept_any_index {
+  bool operator()(Index const&) const noexcept { return true; }
+};
+
+template <typename F, typename IndexPredicate = accept_any_index>
+[[nodiscard]] auto make_batched_custom_evaluator(F le,
+                                                 std::size_t target_batch_size,
+                                                 IndexPredicate accept = {}) {
+  return [le = std::move(le), target_batch_size, accept](
+             auto const& node, auto& cache) -> ResultPtr {
+    using cache_t = std::remove_reference_t<decltype(cache)>;
+
+    auto const K = batch_axis(node, accept);
+    if (!K) return nullptr;
+
+    auto const leaf = find_leaf_carrying(node, *K);
+    if (!leaf) return nullptr;
+    auto const batches =
+        le(leaf->first)->mode_batches(leaf->second, target_batch_size);
+
+    if (batches.size() <= 1)
+      return nullptr;  // nothing to gain (or unbatchable)
+
+    ResultPtr acc;
+    for (auto const& [e_lo, e_hi] : batches) {
+      if (e_lo == e_hi) continue;
+
+      // leaf evaluator that slices every leaf carrying K to this element batch;
+      // others pass through unchanged.
+      auto le_g = [&le, &K, e_lo = e_lo,
+                   e_hi = e_hi](auto const& leaf_node) -> ResultPtr {
+        ResultPtr r = le(leaf_node);
+        if (auto const p = index_position(leaf_node, *K))
+          return r->slice_mode(*p, e_lo, e_hi);
+        return r;
+      };
+
+      // standard scheme on a fresh scratch cache: no re-interception, and the
+      // (partial, sliced) intermediates do not pollute the real cache.
+      auto scratch = cache_t::empty();
+      ResultPtr part = evaluate(node, le_g, scratch);
+      if (!acc)
+        acc = std::move(part);
+      else
+        acc->add_inplace(*part);
+    }
+    return acc;
+  };
 }
 
 }  // namespace sequant

--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -429,6 +429,31 @@ ResultPtr evaluate(Node const& node,  //
 
   log::Duration time;
 
+  // Custom-evaluator interception: before the standard scheme, a non-leaf node
+  // may be evaluated by the cache's custom evaluator (e.g. blocked over a
+  // contracted index to bound peak memory). A non-null result is used (and
+  // cached by the Checked wrapper) as-is; null declines to the standard scheme
+  // below. See CacheManager::custom_evaluator_type.
+  if (!node.leaf()) {
+    if (auto const& custom_eval = cache.custom_evaluator(); custom_eval) {
+      ResultPtr intercepted;
+      time =
+          timed_eval_inplace([&]() { intercepted = custom_eval(node, cache); });
+      if (intercepted) {
+        if constexpr (trace(EvalTrace)) {
+          log::eval(log::EvalStat{.mode = log::eval_mode(node),
+                                  .time = time,
+                                  .mem_result = log::bytes(intercepted),
+                                  .mem_alloc = log::bytes(intercepted),
+                                  .mem_hwmark = {cache.note_working_set(
+                                      log::bytes(cache, intercepted).value)}},
+                    log::label(node));
+        }
+        return intercepted;
+      }
+    }
+  }
+
   if (node.leaf()) {
     time = timed_eval_inplace([&]() { result = le(node); });
   } else {

--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -392,17 +392,31 @@ namespace {
 }
 
 /// \brief A default axis to batch the subtree at \p node over: the contracted
-/// index (see contracted_indices) with the largest IndexSpace approximate
-/// size -- typically the auxiliary/RI index, whose elimination most reduces the
-/// peak intermediate. \return nullopt if the node has no contracted index.
+/// index (see contracted_indices) that satisfies \p accept, choosing the one
+/// with the largest IndexSpace approximate size -- typically the auxiliary/RI
+/// index, whose elimination most reduces the peak intermediate.
+///
+/// \param accept a predicate `bool(Index const&)` selecting which contracted
+///        indices are eligible to batch over (e.g. only those in a given
+///        IndexSpace). This lets a caller scope batching to specific modes.
+/// \return nullopt if no contracted index satisfies \p accept.
+template <typename IndexPredicate>
+[[nodiscard]] inline std::optional<Index> batch_axis(
+    meta::eval_node auto const& node, IndexPredicate const& accept) {
+  std::optional<Index> best;
+  for (Index const& ix : contracted_indices(node)) {
+    if (!accept(ix)) continue;
+    if (!best ||
+        best->space().approximate_size() < ix.space().approximate_size())
+      best = ix;
+  }
+  return best;
+}
+
+/// \overload Batches over any contracted index (largest approximate size).
 [[nodiscard]] inline std::optional<Index> batch_axis(
     meta::eval_node auto const& node) {
-  auto const contracted = contracted_indices(node);
-  if (contracted.empty()) return std::nullopt;
-  return *std::max_element(
-      contracted.begin(), contracted.end(), [](Index const& a, Index const& b) {
-        return a.space().approximate_size() < b.space().approximate_size();
-      });
+  return batch_axis(node, [](Index const&) { return true; });
 }
 
 ///

--- a/SeQuant/core/eval/result.hpp
+++ b/SeQuant/core/eval/result.hpp
@@ -277,6 +277,22 @@ class Result {
       std::array<std::any, 2> const&) const = 0;
 
   ///
+  /// \brief Restrict this result to a contiguous tile range of one mode.
+  ///
+  /// Keeps tiles `[tile_lo, tile_hi)` of mode \p mode and all tiles of every
+  /// other mode. Used to evaluate a tensor network in batches over a
+  /// contracted index (see make_batched_custom_evaluator): slicing every leaf
+  /// that carries the index, evaluating, and summing reproduces the full
+  /// contraction. Not a pure virtual: only tensor-backed results need it;
+  /// the default throws.
+  ///
+  [[nodiscard]] virtual ResultPtr slice_mode(std::size_t /*mode*/,
+                                             std::size_t /*tile_lo*/,
+                                             std::size_t /*tile_hi*/) const {
+    throw unimplemented_method("slice_mode");
+  }
+
+  ///
   /// \brief Add other Result object into this object.
   ///
   virtual void add_inplace(Result const&) = 0;

--- a/SeQuant/core/eval/result.hpp
+++ b/SeQuant/core/eval/result.hpp
@@ -277,19 +277,40 @@ class Result {
       std::array<std::any, 2> const&) const = 0;
 
   ///
-  /// \brief Restrict this result to a contiguous tile range of one mode.
+  /// \brief Restrict this result to a contiguous *element* range of one mode.
   ///
-  /// Keeps tiles `[tile_lo, tile_hi)` of mode \p mode and all tiles of every
-  /// other mode. Used to evaluate a tensor network in batches over a
-  /// contracted index (see make_batched_custom_evaluator): slicing every leaf
-  /// that carries the index, evaluating, and summing reproduces the full
-  /// contraction. Not a pure virtual: only tensor-backed results need it;
-  /// the default throws.
+  /// Keeps elements `[elem_lo, elem_hi)` of mode \p mode and all elements of
+  /// every other mode. Element semantics keep this backend-neutral (no notion
+  /// of tiles); a tiled backend may require `[elem_lo, elem_hi)` to fall on
+  /// tile boundaries (mode_batches() returns such ranges). Used to evaluate a
+  /// tensor network in batches over a contracted index (see
+  /// make_batched_custom_evaluator): slicing every leaf that carries the index,
+  /// evaluating, and summing reproduces the full contraction. Not a pure
+  /// virtual: only tensor-backed results need it; the default throws.
   ///
   [[nodiscard]] virtual ResultPtr slice_mode(std::size_t /*mode*/,
-                                             std::size_t /*tile_lo*/,
-                                             std::size_t /*tile_hi*/) const {
+                                             std::size_t /*elem_lo*/,
+                                             std::size_t /*elem_hi*/) const {
     throw unimplemented_method("slice_mode");
+  }
+
+  ///
+  /// \brief Partition mode \p mode into contiguous element-range batches, each
+  /// covering about \p target_batch_size elements.
+  ///
+  /// \return a list of `[elem_lo, elem_hi)` element ranges that tile the mode's
+  ///         full extent without overlap or gap. The partition is chosen by the
+  ///         backend at its storage granularity: a tiled backend snaps batch
+  ///         boundaries to tile boundaries (so batches are uneven and each
+  ///         covers at least \p target_batch_size elements where possible), a
+  ///         dense backend may split evenly. A single returned batch means the
+  ///         mode is not worth (or cannot be) split. Backend-neutral: the
+  ///         target is expressed in elements, not tiles. Default: not
+  ///         supported.
+  ///
+  [[nodiscard]] virtual container::svector<std::pair<std::size_t, std::size_t>>
+  mode_batches(std::size_t /*mode*/, std::size_t /*target_batch_size*/) const {
+    throw unimplemented_method("mode_batches");
   }
 
   ///

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -1210,3 +1210,44 @@ TEST_CASE("eval_custom_evaluator", "[eval]") {
     REQUIRE(consulted == 1);
   }
 }
+
+TEST_CASE("eval_batch_axis", "[eval]") {
+  using sequant::batch_axis;
+  using sequant::contracted_indices;
+
+  auto node_of = [](std::wstring_view xpr) {
+    return eval_node(sequant::deserialize<sequant::ExprPtr>(xpr));
+  };
+
+  SECTION("single contracted index") {
+    // R_{a1}^{i1,i3} * f_{i3}^{i2} sums over i3.
+    auto const node = node_of(L"R_{a1}^{i1,i3} * f_{i3}^{i2}");
+    auto const c = contracted_indices(node);
+    REQUIRE(c.size() == 1);
+    auto const axis = batch_axis(node);
+    REQUIRE(axis.has_value());
+    REQUIRE(axis.value() == c.front());
+  }
+
+  SECTION("two contracted indices") {
+    // g_{i1,i2}^{a1,a2} * t_{a1,a2}^{i3,i4} sums over a1,a2.
+    auto const node = node_of(L"g_{i1,i2}^{a1,a2} * t_{a1,a2}^{i3,i4}");
+    auto const c = contracted_indices(node);
+    REQUIRE(c.size() == 2);
+    auto const axis = batch_axis(node);
+    REQUIRE(axis.has_value());
+    REQUIRE(ranges::contains(c, axis.value()));
+  }
+
+  SECTION("leaf has no contracted index") {
+    auto const node = node_of(L"f_{i1}^{a1}");
+    REQUIRE(contracted_indices(node).empty());
+    REQUIRE_FALSE(batch_axis(node).has_value());
+  }
+
+  SECTION("a sum is not a contraction") {
+    auto const node = node_of(L"f_{i1}^{a1} + t_{a1}^{i1}");
+    REQUIRE(contracted_indices(node).empty());
+    REQUIRE_FALSE(batch_axis(node).has_value());
+  }
+}

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -1250,4 +1250,33 @@ TEST_CASE("eval_batch_axis", "[eval]") {
     REQUIRE(contracted_indices(node).empty());
     REQUIRE_FALSE(batch_axis(node).has_value());
   }
+
+  SECTION("predicate scopes the batch axis") {
+    // contracts a1,a2 (unoccupied)
+    auto const node = node_of(L"g_{i1,i2}^{a1,a2} * t_{a1,a2}^{i3,i4}");
+    auto const c = contracted_indices(node);
+    REQUIRE(c.size() == 2);
+
+    // accept exactly one contracted index -> batch_axis returns it
+    auto const only_first = [&c](sequant::Index const& ix) {
+      return ix == c.front();
+    };
+    REQUIRE(batch_axis(node, only_first) == c.front());
+
+    // accept none -> nullopt
+    REQUIRE_FALSE(batch_axis(node, [](sequant::Index const&) {
+                    return false;
+                  }).has_value());
+
+    // scope batching to a specific IndexSpace
+    auto const unocc = c.front().space();
+    auto const in_unocc = [&unocc](sequant::Index const& ix) {
+      return ix.space() == unocc;
+    };
+    REQUIRE(batch_axis(node, in_unocc).has_value());
+
+    // a node whose only contracted index is in a different (occupied) space
+    auto const node_occ = node_of(L"R_{a1}^{i1,i3} * f_{i3}^{i2}");  // sums i3
+    REQUIRE_FALSE(batch_axis(node_occ, in_unocc).has_value());
+  }
 }

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -177,10 +177,16 @@ class rand_tensor_yield {
   size_t nocc_;
   size_t nvirt_;
   size_t naux_;
+  // max tile size along each mode; the default (~0) makes a single tile per
+  // mode (the original behavior). Set smaller to produce multi-tile arrays.
+  size_t max_tile_ = ~size_t{0};
   mutable sequant::container::map<std::wstring, sequant::ResultPtr>
       label_to_er_;
 
  public:
+  /// Produce arrays whose modes are tiled in blocks of at most \p n.
+  void set_max_tile(size_t n) { max_tile_ = n; }
+
   using array_type = TA::DistArray<TA::Tensor<NumericT>, TAPolicyT>;
   using array_tot_type =
       TA::DistArray<TA::Tensor<TA::Tensor<NumericT>>, TAPolicyT>;
@@ -271,10 +277,16 @@ class rand_tensor_yield {
 
     auto const outer_extent = make_extents(nested.outer);
 
-    auto const outer_tr = [&outer_extent]() {
+    auto const outer_tr = [&outer_extent, this]() {
+      auto make_tr1 = [this](size_t e) {
+        container::svector<size_t> b;
+        for (size_t x = 0; x < e; x += max_tile_) b.push_back(x);
+        b.push_back(e);
+        return TA::TiledRange1(b.begin(), b.end());
+      };
       container::vector<TA::TiledRange1> tr1s;
       tr1s.reserve(outer_extent.size());
-      for (auto e : outer_extent) tr1s.emplace_back(TA::TiledRange1(0, e));
+      for (auto e : outer_extent) tr1s.emplace_back(make_tr1(e));
       return TA::TiledRange(tr1s.begin(), tr1s.end());
     }();
 
@@ -1320,11 +1332,65 @@ TEST_CASE("eval_slice_array_over_mode", "[eval]") {
     REQUIRE(equal_tarrays(summed, full));
   }
 
-  SECTION("Result::slice_mode dispatches through the type-erased ResultPtr") {
+  SECTION("Result::slice_mode takes element bounds, snaps to tiles") {
+    // mode 1 (b) tiles {0,3,6,9}; element range [3,9) is tiles [1,3).
     sequant::ResultPtr const r =
         sequant::eval_result<sequant::ResultTensorTA<TA::TArrayD>>(arr);
-    auto const via_result = r->slice_mode(1, 1, 3)->get<TA::TArrayD>();
+    auto const via_result = r->slice_mode(1, 3, 9)->get<TA::TArrayD>();
     auto const direct = slice_array_over_mode(arr, 1, 1, 3);
     REQUIRE(equal_tarrays(via_result, direct));
+  }
+
+  SECTION("Result::mode_batches partitions a mode into element ranges") {
+    using batches_t = sequant::container::svector<std::pair<size_t, size_t>>;
+    sequant::ResultPtr const r =
+        sequant::eval_result<sequant::ResultTensorTA<TA::TArrayD>>(arr);
+    // mode 1 (b) has 3 tiles of 3 elements each (extent 9).
+    // (extra parens: compare as a single bool so Catch2 needn't stringify
+    // pairs) target larger than the extent -> a single batch (caller declines).
+    REQUIRE((r->mode_batches(1, 100) == batches_t{{0, 9}}));
+    // target 4: tile0 (3<4) + tile1 reaches 6>=4 -> [0,6); remainder [6,9).
+    REQUIRE((r->mode_batches(1, 4) == batches_t{{0, 6}, {6, 9}}));
+    // target 1: every tile is its own batch.
+    REQUIRE((r->mode_batches(1, 1) == batches_t{{0, 3}, {3, 6}, {6, 9}}));
+  }
+}
+
+TEST_CASE("eval_batched_custom_evaluator", "[eval]") {
+  using sequant::evaluate;
+  using sequant::make_batched_custom_evaluator;
+  using TA::TArrayD;
+  using node_t = sequant::FullBinaryNode<sequant::EvalExprTA>;
+  using cache_t = sequant::CacheManager<node_t>;
+
+  auto& world = TA::get_default_world();
+  // multi-tile arrays so batching over a contracted index actually engages:
+  // unoccupied extent 12 in tiles of <=4 -> 3 tiles.
+  rand_tensor_yield<double, TA::DensePolicy> yield_{world, 4, 12};
+  yield_.set_max_tile(4);
+
+  // contracts a1,a2 (unoccupied) -> batch axis is an unoccupied index (3 tiles)
+  auto const expr = sequant::deserialize<sequant::ExprPtr>(
+      L"g_{i1,i2}^{a1,a2} * t_{a1,a2}^{i3,i4}");
+  std::string const target = "i_1,i_2,i_3,i_4";
+  auto const node = eval_node(expr);
+
+  // Reference first, so yield_'s (random) leaf arrays are generated and cached;
+  // the batched evaluator below copies yield_ and thus reuses the same arrays.
+  auto const ref = evaluate(node, target, yield_)->get<TArrayD>();
+
+  // Batched evaluation must reproduce the reference for any target batch size,
+  // since sum_K = sum_{batches} sum_{K in batch}. The batch axis is unoccupied
+  // (extent 12, tiles of 4 -> 3 tiles). target_batch_size is in *elements*:
+  // 100 -> 1 batch (no-op), 8 -> 2 batches ([0,8),[8,12)), 4 -> 3 batches, and
+  // 1 -> 3 batches (each tile its own batch).
+  for (std::size_t target_batch_size :
+       {std::size_t{100}, std::size_t{8}, std::size_t{4}, std::size_t{1}}) {
+    auto cache = cache_t::empty();
+    cache.set_custom_evaluator(
+        make_batched_custom_evaluator(yield_, target_batch_size));
+    auto const res = evaluate(node, target, yield_, cache)->get<TArrayD>();
+    // batched summation reorders the contraction, so allow a looser FP margin
+    REQUIRE(equal_tarrays<Loose>(res, ref));
   }
 }

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -185,7 +185,11 @@ class rand_tensor_yield {
 
  public:
   /// Produce arrays whose modes are tiled in blocks of at most \p n.
-  void set_max_tile(size_t n) { max_tile_ = n; }
+  /// \p n must be positive (0 would make the tiling loop in make_tr1 spin).
+  void set_max_tile(size_t n) {
+    REQUIRE(n > 0);
+    max_tile_ = n;
+  }
 
   using array_type = TA::DistArray<TA::Tensor<NumericT>, TAPolicyT>;
   using array_tot_type =
@@ -1332,8 +1336,9 @@ TEST_CASE("eval_slice_array_over_mode", "[eval]") {
     REQUIRE(equal_tarrays(summed, full));
   }
 
-  SECTION("Result::slice_mode takes element bounds, snaps to tiles") {
-    // mode 1 (b) tiles {0,3,6,9}; element range [3,9) is tiles [1,3).
+  SECTION("Result::slice_mode takes tile-aligned element bounds") {
+    // mode 1 (b) tiles {0,3,6,9}; element range [3,9) (tile-aligned, as
+    // mode_batches produces) corresponds to tiles [1,3).
     sequant::ResultPtr const r =
         sequant::eval_result<sequant::ResultTensorTA<TA::TArrayD>>(arr);
     auto const via_result = r->slice_mode(1, 3, 9)->get<TA::TArrayD>();

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -1155,3 +1155,58 @@ TEST_CASE("eval_with_tiledarray", "[eval]") {
     }
   }
 }
+
+TEST_CASE("eval_custom_evaluator", "[eval]") {
+  using sequant::evaluate;
+  using sequant::ResultPtr;
+  using TA::TArrayD;
+  using node_t = sequant::FullBinaryNode<sequant::EvalExprTA>;
+  using cache_t = sequant::CacheManager<node_t>;
+
+  auto& world = TA::get_default_world();
+  const size_t nocc = 2, nvirt = 20;
+  auto yield_ = rand_tensor_yield<double, TA::DensePolicy>{world, nocc, nvirt};
+
+  // a multi-product expression: several non-leaf nodes in the eval tree.
+  auto const expr = sequant::deserialize<sequant::ExprPtr>(
+      L"-1/4 * g_{i3,i4}^{a3,a4} * t_{a2,a4}^{i1,i2} * t_{a1,a3}^{i3,i4}",
+      {.def_perm_symm = sequant::Symmetry::Antisymm});
+  std::string const target = "a_1,a_2,i_1,i_2";
+  auto const node = eval_node(expr);
+
+  // standard-scheme reference (no custom evaluator)
+  auto const ref = evaluate(node, target, yield_)->get<TArrayD>();
+
+  SECTION("declining evaluator defers to the standard scheme") {
+    // A custom evaluator that always returns null is consulted at every
+    // non-leaf node and the standard scheme produces the result.
+    int consulted = 0;
+    auto cache = cache_t::empty();
+    cache.set_custom_evaluator(
+        [&consulted](node_t const&, cache_t&) -> ResultPtr {
+          ++consulted;
+          return nullptr;
+        });
+    auto const res = evaluate(node, target, yield_, cache)->get<TArrayD>();
+    REQUIRE(equal_tarrays(res, ref));
+    REQUIRE(consulted > 1);  // multiple non-leaf nodes, all declined
+  }
+
+  SECTION("intercepting evaluator takes over a subtree") {
+    // A custom evaluator that takes over the first (root) node it is consulted
+    // on -- here by re-evaluating that subtree via the standard scheme on a
+    // scratch cache. The result must still match, and the non-null return must
+    // short-circuit the recursion, so the evaluator fires exactly once.
+    int consulted = 0;
+    auto cache = cache_t::empty();
+    cache.set_custom_evaluator(
+        [&consulted, &yield_](node_t const& n, cache_t&) -> ResultPtr {
+          ++consulted;
+          auto scratch = cache_t::empty();
+          return evaluate(n, yield_, scratch);
+        });
+    auto const res = evaluate(node, target, yield_, cache)->get<TArrayD>();
+    REQUIRE(equal_tarrays(res, ref));
+    REQUIRE(consulted == 1);
+  }
+}

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -1319,4 +1319,12 @@ TEST_CASE("eval_slice_array_over_mode", "[eval]") {
 
     REQUIRE(equal_tarrays(summed, full));
   }
+
+  SECTION("Result::slice_mode dispatches through the type-erased ResultPtr") {
+    sequant::ResultPtr const r =
+        sequant::eval_result<sequant::ResultTensorTA<TA::TArrayD>>(arr);
+    auto const via_result = r->slice_mode(1, 1, 3)->get<TA::TArrayD>();
+    auto const direct = slice_array_over_mode(arr, 1, 1, 3);
+    REQUIRE(equal_tarrays(via_result, direct));
+  }
 }

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -1280,3 +1280,43 @@ TEST_CASE("eval_batch_axis", "[eval]") {
     REQUIRE_FALSE(batch_axis(node_occ, in_unocc).has_value());
   }
 }
+
+TEST_CASE("eval_slice_array_over_mode", "[eval]") {
+  using sequant::slice_array_over_mode;
+  auto& world = TA::get_default_world();
+
+  // arr: a(2 tiles), b(3 tiles), c(1 tile); bb shares b's TiledRange1.
+  TA::TArrayD arr(world, TA::TiledRange{{0, 2, 4}, {0, 3, 6, 9}, {0, 5}});
+  TA::TArrayD bb(world, TA::TiledRange{{0, 3, 6, 9}, {0, 7}});
+  arr.fill_random();
+  bb.fill_random();
+  world.gop.fence();
+
+  SECTION("trange of the sliced mode") {
+    auto const s = slice_array_over_mode(arr, 1, 1, 3);  // b-tiles [1,3)
+    REQUIRE(s.trange().dim(1).tile_extent() == 2);
+    REQUIRE(s.trange().dim(0).tile_extent() ==
+            arr.trange().dim(0).tile_extent());
+    REQUIRE(s.trange().dim(2).tile_extent() ==
+            arr.trange().dim(2).tile_extent());
+  }
+
+  SECTION(
+      "blocked contraction over the sliced mode reconstructs the full one") {
+    // full contraction over b
+    TA::TArrayD full;
+    full("a,c,d") = arr("a,b,c") * bb("b,d");
+
+    // split b's 3 tiles into [0,1) and [1,3), contract each, sum
+    auto const a0 = slice_array_over_mode(arr, 1, 0, 1);
+    auto const a1 = slice_array_over_mode(arr, 1, 1, 3);
+    auto const b0 = slice_array_over_mode(bb, 0, 0, 1);
+    auto const b1 = slice_array_over_mode(bb, 0, 1, 3);
+    TA::TArrayD p0, p1, summed;
+    p0("a,c,d") = a0("a,b,c") * b0("b,d");
+    p1("a,c,d") = a1("a,b,c") * b1("b,d");
+    summed("a,c,d") = p0("a,c,d") + p1("a,c,d");
+
+    REQUIRE(equal_tarrays(summed, full));
+  }
+}


### PR DESCRIPTION
## Summary

Adds a mechanism to the eval engine for a user-provided **custom evaluator** to intercept subtree evaluation once the concrete backend result type is resolved, and builds on it a **batched evaluator** that evaluates a tensor network in batches over a contracted index to bound the peak memory of intermediates carrying that index (e.g. an RI/auxiliary index Κ).

### Mechanism
- `CacheManager` carries an optional `custom_evaluator` (`std::function<ResultPtr(node, CacheManager&)>`); `evaluate()` consults it for every non-leaf node before the standard scheme. A non-null return takes over the subtree; null defers.
- Detectors: `contracted_indices(node)`, `batch_axis(node, accept)` (largest accepted contracted index; `accept` predicate scopes which indices may be batched, e.g. only the auxiliary space), `index_position`, `find_leaf_carrying`.

### Batched evaluation (backend-neutral, in *elements*)
- `make_batched_custom_evaluator(le, target_batch_size, accept, make_scope_guard)`: splits the batch axis into element-range batches and sums the partial contractions (`sum_K = sum_{batches} sum_{K in batch}`), so intermediates carrying the axis are built one batch at a time.
- The batching API is expressed in **elements**, not tiles: `Result::mode_batches(mode, target_batch_size)` partitions a mode into contiguous element ranges at the backend's storage granularity (the TA backend snaps to tile boundaries → uneven batches), and `Result::slice_mode(mode, elem_lo, elem_hi)` restricts a mode to an element range.
- Optional `make_scope_guard(n_batches)` hook: a backend can relax block-sparse screening for the duration of the batched partials (the Cauchy–Schwarz norm bound for a sub-sum over 1/n of the singly-contracted axis is ~1/n of the full bound), so blocks that survive over the full axis aren't dropped in every batch.

### Tests
New Catch2 cases in `tests/unit/test_eval_ta.cpp`: `eval_custom_evaluator`, `eval_batch_axis` (incl. predicate scoping), `eval_slice_array_over_mode` (incl. `slice_mode` element bounds + `mode_batches`), `eval_batched_custom_evaluator` (batched == standard for several batch counts, exact for dense). All green.