### PR TITLE
eval: persistent (P) cache entries with volatility-derived classification

### DIFF
--- a/SeQuant/core/eval/cache_manager.hpp
+++ b/SeQuant/core/eval/cache_manager.hpp
@@ -63,6 +63,15 @@ class CacheManager {
 
     ResultPtr data_p;
 
+    /// Lazily-computed, memoized data_p->size_in_bytes(): disengaged until the
+    /// size is first queried, then computed once and cached until data_p is
+    /// replaced or released. size_in_bytes() walks the DistArray's tiles, which
+    /// is expensive; it is only queried to populate the eval trace's memory
+    /// diagnostics, so for held data we compute it at most once and never when
+    /// it is not asked for. mutable so size_in_bytes() can stay const (the
+    /// classic lazy-memoization pattern).
+    mutable std::optional<size_t> size_bytes_;
+
     /// Persistent (P) entries are never drained on access and survive reset(),
     /// so their data lives across multiple evaluations (e.g. CC iterations);
     /// non-persistent (NP) entries are released after their last use and
@@ -79,14 +88,25 @@ class CacheManager {
     [[nodiscard]] ResultPtr access() noexcept {
       if (!data_p) return nullptr;
       if (persistent_) return data_p;  // never drain a persistent entry
-      return decay() == 0 ? std::move(data_p) : data_p;
+      if (decay() == 0) {              // last use: release the data
+        size_bytes_.reset();
+        return std::move(data_p);
+      }
+      return data_p;
     }
 
-    void store(ResultPtr&& data) noexcept { data_p = std::move(data); }
+    void store(ResultPtr&& data) noexcept {
+      data_p = std::move(data);
+      size_bytes_
+          .reset();  // (re)computed lazily on demand; see size_in_bytes()
+    }
 
     void reset() noexcept {
       life_c = max_life;
-      if (!persistent_) data_p = nullptr;  // persistent data survives reset()
+      if (!persistent_) {  // persistent data (and its size) survives reset()
+        data_p = nullptr;
+        size_bytes_.reset();
+      }
     }
 
     [[nodiscard]] bool persistent() const noexcept { return persistent_; }
@@ -96,7 +116,10 @@ class CacheManager {
     [[nodiscard]] size_t max_life_count() const noexcept { return max_life; }
 
     [[nodiscard]] size_t size_in_bytes() const noexcept {
-      return data_p ? data_p->size_in_bytes() : 0;
+      if (!data_p) return 0;
+      if (!size_bytes_)
+        size_bytes_ = data_p->size_in_bytes();  // lazy, memoized
+      return *size_bytes_;
     }
 
     [[nodiscard]] bool alive() const noexcept { return data_p ? true : false; }

--- a/SeQuant/core/eval/cache_manager.hpp
+++ b/SeQuant/core/eval/cache_manager.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace sequant {
 
@@ -62,12 +63,22 @@ class CacheManager {
 
     ResultPtr data_p;
 
+    /// Persistent (P) entries are never drained on access and survive reset(),
+    /// so their data lives across multiple evaluations (e.g. CC iterations);
+    /// non-persistent (NP) entries are released after their last use and
+    /// cleared by reset() (the default, and historical, behavior).
+    bool persistent_;
+
    public:
-    explicit entry(size_t count) noexcept
-        : max_life{count}, life_c{count}, data_p{nullptr} {}
+    explicit entry(size_t count, bool persistent = false) noexcept
+        : max_life{count},
+          life_c{count},
+          data_p{nullptr},
+          persistent_{persistent} {}
 
     [[nodiscard]] ResultPtr access() noexcept {
       if (!data_p) return nullptr;
+      if (persistent_) return data_p;  // never drain a persistent entry
       return decay() == 0 ? std::move(data_p) : data_p;
     }
 
@@ -75,8 +86,10 @@ class CacheManager {
 
     void reset() noexcept {
       life_c = max_life;
-      data_p = nullptr;
+      if (!persistent_) data_p = nullptr;  // persistent data survives reset()
     }
+
+    [[nodiscard]] bool persistent() const noexcept { return persistent_; }
 
     [[nodiscard]] size_t life_count() const noexcept { return life_c; }
 
@@ -123,10 +136,25 @@ class CacheManager {
   [[nodiscard]] custom_evaluator_type const& custom_evaluator() const noexcept {
     return custom_evaluator_;
   }
-  template <typename Iterable>
+  /// Default persistence classifier: every entry is non-persistent (NP).
+  struct all_non_persistent {
+    bool operator()(key_type const&) const noexcept { return false; }
+  };
+
+  /// \param decaying iterable of (node, use-count) pairs to register for
+  ///        caching.
+  /// \param is_persistent predicate classifying each node as persistent (P,
+  ///        never released on access, survives reset()) or non-persistent (NP,
+  ///        released after its last use and by reset()). Defaults to all-NP.
+  /// \note P nodes should be registered with whatever use-count is convenient
+  ///       (it is not consulted for P entries) and may have a count of 1 even
+  ///       though NP caching only registers nodes repeated min_repeats times.
+  template <typename Iterable, typename PersistencePred = all_non_persistent>
     requires(!std::same_as<std::remove_cvref_t<Iterable>, CacheManager>)
-  explicit CacheManager(Iterable&& decaying) noexcept {
-    for (auto&& [k, c] : decaying) cache_map_.try_emplace(k, entry{c});
+  explicit CacheManager(Iterable&& decaying,
+                        PersistencePred is_persistent = {}) noexcept {
+    for (auto&& [k, c] : decaying)
+      cache_map_.try_emplace(k, entry{c, is_persistent(k)});
   }
 
   ///
@@ -206,6 +234,13 @@ class CacheManager {
   [[nodiscard]] bool alive(key_type const& key) const noexcept {
     auto iter = cache_map_.find(key);
     return iter != cache_map_.end() && iter->second.alive();
+  }
+
+  /// \return true iff the key is registered for caching and classified
+  ///         persistent (P: never released on access, survives reset()).
+  [[nodiscard]] bool persistent(key_type const& key) const noexcept {
+    auto iter = cache_map_.find(key);
+    return iter != cache_map_.end() && iter->second.persistent();
   }
 
   /// \return size in bytes of the data currently held for @p key, or 0 if
@@ -299,6 +334,91 @@ auto cache_manager(meta::eval_node_range auto const& nodes,
   }
 
   return CacheManager<TreeNode, force_hash_collisions>{std::move(filtered)};
+}
+
+///
+/// \brief Make a cache manager that distinguishes persistent (P) from
+///        non-persistent (NP) intermediates, deriving persistence from a
+///        solver-supplied volatility predicate and the evaluation DAG.
+///
+/// A node is *volatile* (V) if its value changes between evaluations (e.g. it
+/// depends on the amplitudes being solved). \p is_volatile flags intrinsically
+/// volatile nodes (typically the amplitude leaves); volatility is then
+/// propagated up the DAG (a node is V iff it is intrinsically volatile or any
+/// child is V). Persistence is derived from volatility and the consumer
+/// (parent) relationship:
+///
+///   - V node                       -> NP (released after last use)
+///   - NV node with >=1 V consumer   -> P  (the NV/V frontier: constant data
+///                                          feeding per-iteration work; kept
+///                                          across evaluations)
+///   - NV node with no V consumer    -> NP (only feeds other NV nodes, so it is
+///                                          absorbed into them and not needed
+///                                          across evaluations)
+///
+/// Only *internal* (non-leaf) nodes are cached: NP nodes that repeat at least
+/// \p min_repeats times (the usual CSE rule), plus *all* P nodes regardless of
+/// repeat count (a P node is reused across evaluations even if used once each).
+///
+/// \param nodes the evaluation forest.
+/// \param is_volatile `bool(TreeNode const&)`: true if the node is
+///        intrinsically volatile. Only its value on leaves matters in practice
+///        (volatility propagates up), but it is consulted on every node.
+/// \param min_repeats minimum NP repeats to cache (default 2).
+/// \see CacheManager, cache_manager
+template <bool force_hash_collisions = false>
+auto cache_manager(meta::eval_node_range auto const& nodes, auto&& is_volatile,
+                   size_t min_repeats = 2)
+  requires requires(
+      std::ranges::range_value_t<std::remove_cvref_t<decltype(nodes)>> const&
+          n) {
+    { is_volatile(n) } -> std::convertible_to<bool>;
+  }
+{
+  using TreeNode =
+      std::ranges::range_value_t<std::remove_cvref_t<decltype(nodes)>>;
+  using Hasher = TreeNodeHasher<TreeNode, force_hash_collisions>;
+  using Comp = TreeNodeEqualityComparator<TreeNode>;
+
+  std::unordered_map<TreeNode, size_t, Hasher, Comp> counts;  // internal uses
+  std::unordered_map<TreeNode, bool, Hasher, Comp> volatile_of;  // memoized
+  std::unordered_set<TreeNode, Hasher, Comp> persistent;  // NV/V frontier
+
+  // Single DAG walk: count internal-node uses (CSE), memoize volatility
+  // bottom-up, and mark the NV/V frontier. Every (parent, child) edge is
+  // visited exactly once (children are recursed only on a node's first visit),
+  // so a child is marked persistent iff some volatile parent consumes it.
+  auto visit = [&](auto&& self, TreeNode const& n) -> bool {
+    bool const first = !volatile_of.contains(n);
+    if (!n.leaf()) ++counts[n];  // count this use of an internal node
+    if (!first) return volatile_of.at(n);
+    bool v;
+    if (n.leaf()) {
+      v = is_volatile(n);
+    } else {
+      bool const vl = self(self, n.left());
+      bool const vr = self(self, n.right());
+      v = is_volatile(n) || vl || vr;
+      if (v) {  // n is a volatile consumer => its NV internal children are P
+        if (!vl && !n.left().leaf()) persistent.insert(n.left());
+        if (!vr && !n.right().leaf()) persistent.insert(n.right());
+      }
+    }
+    volatile_of.emplace(n, v);
+    return v;
+  };
+  for (auto&& tree : nodes) visit(visit, tree);
+
+  // Cache NP repeats + every P node; persistence = membership in `persistent`.
+  std::unordered_map<TreeNode, size_t, Hasher, Comp> filtered;
+  for (auto&& [n, c] : counts)
+    if (c >= min_repeats || persistent.contains(n)) filtered.emplace(n, c);
+
+  auto is_persistent = [persistent = std::move(persistent)](TreeNode const& n) {
+    return persistent.contains(n);
+  };
+  return CacheManager<TreeNode, force_hash_collisions>{
+      std::move(filtered), std::move(is_persistent)};
 }
 
 ///

--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -42,6 +42,16 @@ struct Bytes {
   size_t value;
 };
 
+/// \return whether the eval trace is being printed (logger level > 0). The
+/// eval engine's per-op memory diagnostics (the hwmark working set and the
+/// cache total) feed only the trace output, so the standalone functions that
+/// compute them -- the cache-aware bytes() overload below and eval()/cache()
+/// -- short-circuit when this is false, and are thus computed only when a
+/// trace line will actually be emitted.
+[[nodiscard]] inline bool printing() noexcept {
+  return Logger::instance().eval.level > 0;
+}
+
 template <typename T, typename... Ts>
 [[nodiscard]] inline auto bytes(T const& arg, Ts const&... args) {
   auto one = [](auto const& a) -> size_t {
@@ -51,6 +61,19 @@ template <typename T, typename... Ts>
       return a.size_in_bytes();
   };
   return Bytes{(one(arg) + ... + one(args))};
+}
+
+/// Cache-aware bytes(): bytes(cache) + bytes(args...), where bytes(cache) sums
+/// the (lazily memoized) sizes of the cache's alive entries. This is the
+/// working-set/total walk used only to populate the trace's hwmark/total
+/// fields, so it short-circuits to 0 when no trace line will be printed --
+/// avoiding the per-op walk of every alive entry, which with persistent
+/// entries is otherwise paid on every op of every iteration.
+template <typename N, bool F, typename... Ts>
+[[nodiscard]] inline Bytes bytes(CacheManager<N, F> const& cache,
+                                 Ts const&... args) {
+  if (!printing()) return Bytes{0};
+  return Bytes{cache.size_in_bytes() + (size_t{0} + ... + bytes(args).value)};
 }
 
 [[nodiscard]] inline auto to_string(Bytes bs) noexcept {
@@ -236,6 +259,7 @@ void log(Arg const& arg, Args const&... args) {
 
 template <typename... Args>
 auto eval(EvalStat const& stat, Args const&... args) {
+  if (!printing()) return;  // nothing to format/emit; skip rss() and formatting
   auto const result_s = std::format("result={}", to_string(stat.mem_result));
   auto const alloc_s = std::format("alloc={}", to_string(stat.mem_alloc));
   auto const hw_s = std::format("hw={}", to_string(stat.mem_hwmark));
@@ -271,6 +295,7 @@ auto cache(CacheStat const& stat, Args const&... args) {
 
 template <typename N, bool F, typename... Args>
 auto cache(N const& node, CacheManager<N, F>& cm, Args const&... args) {
+  if (!printing()) return;  // skip the entry/total size walks and formatting
   using CacheMode::Access;
   using CacheMode::Release;
   using CacheMode::Store;

--- a/tests/unit/test_cache_manager.cpp
+++ b/tests/unit/test_cache_manager.cpp
@@ -204,3 +204,74 @@ TEST_CASE("cache_manager", "[cache_manager]") {
     REQUIRE(accessed2->get<int>() == 99);
   }
 }
+
+TEST_CASE("cache_manager_persistent", "[cache_manager]") {
+  using hasher_t = sequant::TreeNodeHasher<node_type>;
+  using comp_t = sequant::TreeNodeEqualityComparator<node_type>;
+  auto eval_result = [](int x) {
+    return sequant::eval_result<sequant::ResultScalar<int>>(x);
+  };
+
+  auto const np = make_node(L"R{a1;i1} = f{a1;i1}");  // non-persistent
+  auto const p = make_node(L"R{a1;i1} = g{a1;i1}");   // persistent
+
+  std::unordered_map<node_type, size_t, hasher_t, comp_t> counts;
+  counts.emplace(np, 2);  // NP, drained after 2 accesses
+  counts.emplace(p, 1);   // P, count irrelevant (registered once)
+
+  comp_t eq;
+  auto is_persistent = [&p, &eq](node_type const& k) { return eq(k, p); };
+  auto man = manager_type(std::move(counts), is_persistent);
+
+  // A persistent entry is never drained: arbitrarily many accesses all return
+  // the stored data (unlike an NP entry, whose data is released after its
+  // max_life-th access).
+  man.store(p, eval_result(20));
+  for (int i = 0; i < 10; ++i) {
+    auto r = man.access(p);
+    REQUIRE(r);
+    REQUIRE(r->get<int>() == 20);
+  }
+  REQUIRE(man.alive(p));
+
+  // reset() clears the non-persistent entry but keeps the persistent one, so
+  // the latter's data survives across evaluations (e.g. CC iterations).
+  man.store(np, eval_result(10));
+  man.reset();
+  REQUIRE(man.access(np) == nullptr);  // NP cleared by reset
+  auto rp = man.access(p);             // P survives reset
+  REQUIRE(rp);
+  REQUIRE(rp->get<int>() == 20);
+  REQUIRE(man.alive(p));
+}
+
+TEST_CASE("cache_manager_volatility_frontier", "[cache_manager]") {
+  // R = f * g * t : f,g constant (NV), t the amplitude (intrinsically V).
+  auto const node = make_node(L"R{a1;i1} = f{a1;a2} * g{a2;a3} * t{a3;i1}");
+
+  auto is_volatile = [](node_type const& n) {
+    return n.leaf() && n->is_tensor() && n->as_tensor().label() == L"t";
+  };
+  std::function<bool(node_type const&)> has_t =
+      [&](node_type const& n) -> bool {
+    return n.leaf() ? is_volatile(n) : (has_t(n.left()) || has_t(n.right()));
+  };
+
+  auto man = sequant::cache_manager(std::array{node}, is_volatile);
+
+  // For every internal node, the factory's persistence must match the rule:
+  // persistent  <=>  node is NV  AND  its parent is V.
+  bool saw_persistent = false;
+  std::function<void(node_type const&, bool)> check =
+      [&](node_type const& n, bool parent_volatile) {
+        if (n.leaf()) return;
+        bool const node_volatile = has_t(n);
+        bool const want_p = !node_volatile && parent_volatile;
+        REQUIRE(man.persistent(n) == want_p);
+        if (want_p) saw_persistent = true;
+        check(n.left(), node_volatile);
+        check(n.right(), node_volatile);
+      };
+  check(node, /*parent_volatile=*/false);  // root has no (volatile) consumer
+  REQUIRE(saw_persistent);  // the NV product feeding the volatile root is P
+}


### PR DESCRIPTION
## Summary

Adds support for **persistent** cache entries in `CacheManager`, so an intermediate that does not depend on the amplitudes being solved can be computed once and reused across iterations (e.g. CC), rather than recomputed every iteration — while everything else keeps the historical non-persistent (release-after-last-use, cleared-by-`reset()`) behavior.

### 1. Persistent (P) vs non-persistent (NP) entries + volatility frontier (`882b69882`)
- `CacheManager::entry` gains a `persistent_` flag: P entries are never drained on `access()` and survive `reset()`; NP entries behave as before.
- New `cache_manager(nodes, is_volatile, min_repeats)` factory: the **caller supplies only an intrinsic `is_volatile(node)` predicate** (e.g. "this leaf is the `t` amplitude"); SeQuant derives the non-volatile/volatile frontier from the predicate **and the eval DAG** (a node is volatile iff intrinsically volatile or any child is). A non-volatile node that feeds volatile work is registered as persistent; volatile nodes stay NP.
- Tests: `cache_manager_persistent` (P never drains, survives `reset()`; NP cleared) and `cache_manager_volatility_frontier` (frontier matches the V/NV-derived persistence on a small tensor network).

### 2. Lazy-memoized entry sizes + trace size walks only when printing (`e2233b222`)
The per-op working-set high-water mark (`EvalStat.mem_hwmark`) and cache `total=` (`CacheStat.total_memory`) summed every alive entry's `size_in_bytes()` — a per-tile `DistArray` walk — on **every op**. Those blocks are `if constexpr (trace(EvalTrace))`, and `Trace::Default == On` whenever `SEQUANT_EVAL_TRACE` is defined, so the walk ran even with the trace stream off (the only runtime gate is inside `log()`, after the expensive argument is already evaluated). It has **no functional consumer** — it only feeds the trace's `hw=`/`total=` fields.
- `entry::size_in_bytes()` is now lazily computed and memoized (`mutable std::optional<size_t>`), invalidated on store/release/reset → a held entry is walked at most once, never when not asked for.
- `log::printing()` + a cache-aware `bytes(CacheManager, …)` overload that short-circuits to 0 unless a trace line will be printed, plus early-outs atop `log::eval`/`log::cache`. The hwmark/total are now computed only when the trace is actually emitted.

This is a latent bug independent of the persistence feature (the walk was wasted work whenever tracing was off, for all eval paths) — it just becomes severe with persistent entries, which stay alive across every op of every iteration.

## Testing
Local (`cmake-build-debug`): `[cache_manager]` (148 assertions / 3 cases), `[eval]` (88/5), `[eval_btas]`, `[eval_tapp]`, `[EvalExpr]`, `[EvalNode]` all pass.

Validated end-to-end in MPQC (CSV-CCSD): with the volatility predicate marking `t`-dependent intermediates volatile, the amplitude-free transforms become persistent and are reused across iterations — **persistence reduces the per-iteration time from ~9 s (non-persistent: recomputed every iteration) to ~5 s**. Separately, the size-walk fix removes a per-op whole-cache `size_in_bytes()` walk that, with persistent entries held alive across every op, would otherwise inflate the persistent path to ~75 s/iter and serialize it to ~1 core; the fix has no effect on results and restores normal multi-core utilization.