### PR TITLE
eval/ta: emit ToT annotations in batched-eval array ops

### DIFF
--- a/SeQuant/core/eval/backends/tiledarray/result.hpp
+++ b/SeQuant/core/eval/backends/tiledarray/result.hpp
@@ -166,6 +166,38 @@ template <typename... Args>
     TA::DistArray<Args...> const& arr, std::size_t mode, std::size_t tile_lo,
     std::size_t tile_hi);
 
+/// Inner-tensor mode count of a tensor-of-tensor DistArray (0 for a regular,
+/// non-nested array). The outer trange carries no inner information, so the
+/// inner rank is read from the first local non-empty inner tile and reduced
+/// (max) across the world -- this makes it well-defined on ranks holding no
+/// local data (or only empty inner tiles), as long as some rank holds a
+/// non-empty inner tile. Needed to build a ToT-valid annotation ("outer;inner")
+/// in the annotation-free array operations (add_inplace,
+/// slice_array_over_mode), since a flat annotation trips DistArray's
+/// is_tot_index() check.
+template <typename ArrayT>
+[[nodiscard]] std::size_t tot_inner_rank(ArrayT const& arr) {
+  std::size_t r = 0;
+  if constexpr (TA::detail::is_tensor_of_tensor_v<
+                    typename ArrayT::value_type>) {
+    // Inner tensors carry the rank; an outer tile may hold null/empty inner
+    // views (e.g. a screened pair), so skip those -- calling range() on an
+    // empty view asserts (ArenaTensor) or is UB (TA::Tensor).
+    for (auto it = arr.begin(); it != arr.end() && r == 0; ++it) {
+      auto const& outer_tile = it->get();
+      for (auto const& inner : outer_tile) {
+        if (inner.empty()) continue;
+        if (inner.range().rank() > 0) {
+          r = inner.range().rank();
+          break;
+        }
+      }
+    }
+    arr.world().gop.max(r);
+  }
+  return r;
+}
+
 /// Partition a TiledRange1 into contiguous, tile-aligned element-range batches,
 /// each covering at least \p target_batch_size elements where possible. Tiles
 /// are not uniformly sized, so batches are uneven; the last batch may be
@@ -532,7 +564,12 @@ class ResultTensorOfTensorTA final : public Result {
     auto const& o = other.get<ArrayT>();
 
     SEQUANT_ASSERT(t.trange() == o.trange());
-    auto ann = TA::detail::dummy_annotation(t.trange().rank());
+    // ToT array: the annotation must carry an inner block ("outer;inner") or
+    // DistArray::operator() rejects it (is_tot_index). dummy_annotation's
+    // second argument is the inner-mode count, read from the array's inner
+    // tiles.
+    auto ann =
+        TA::detail::dummy_annotation(t.trange().rank(), tot_inner_rank(t));
 
     log_ta(ann, " += ", ann, "\n");
 
@@ -584,7 +621,18 @@ template <typename... Args>
     hi[d] = arr.trange().dim(d).tile_extent();
   lo[mode] = tile_lo;
   hi[mode] = tile_hi;
-  auto const annot = ords_to_annot(iota(std::size_t{0}, rank));
+  // For a tensor-of-tensor array the annotation must label an inner block
+  // ("outer;inner"); a flat annotation trips DistArray's is_tot_index() check.
+  // The block() is over outer modes only, so both sides share one annotation.
+  using value_type = typename TA::DistArray<Args...>::value_type;
+  std::string annot;
+  if constexpr (TA::detail::is_tensor_of_tensor_v<value_type>) {
+    annot = TA::detail::dummy_annotation(
+        static_cast<unsigned int>(rank),
+        static_cast<unsigned int>(tot_inner_rank(arr)));
+  } else {
+    annot = ords_to_annot(iota(std::size_t{0}, rank));
+  }
   TA::DistArray<Args...> out;
   out(annot) = arr(annot).block(lo, hi);
   TA::DistArray<Args...>::wait_for_lazy_cleanup(arr.world());

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -1399,3 +1399,58 @@ TEST_CASE("eval_batched_custom_evaluator", "[eval]") {
     REQUIRE(equal_tarrays<Loose>(res, ref));
   }
 }
+
+TEST_CASE("eval_batched_custom_evaluator_tot", "[eval]") {
+  using sequant::evaluate;
+  using sequant::make_batched_custom_evaluator;
+  using node_t = sequant::FullBinaryNode<sequant::EvalExprTA>;
+  using cache_t = sequant::CacheManager<node_t>;
+
+  auto& world = TA::get_default_world();
+  // Multi-tile the occupied space so the contracted occupied index i3 spans
+  // more than one tile and batching over it actually engages: extent 8 in
+  // tiles of <=4 -> 2 tiles. The inner (virtual) space is left single-tiled.
+  rand_tensor_yield<double> yield{world, /*nocc=*/8, /*nvirt=*/3};
+  yield.set_max_tile(4);
+
+  using ArrayToT = typename decltype(yield)::array_tot_type;
+
+  // ToT * ToT -> ToT (the same expression as the "tot" section above). The
+  // contracted indices are the occupied i3 (an *outer* mode of both leaves)
+  // and the inner virtual a4. Scoping the batch axis to the occupied space
+  // selects i3, so the batched partials slice ToT leaves over i3
+  // (slice_array_over_mode) and sum ToT partials (add_inplace) -- the two
+  // annotation-free ToT array operations that must emit an "outer;inner"
+  // annotation rather than a flat one (else DistArray's is_tot_index() trips).
+  auto const expr = sequant::deserialize<sequant::ExprPtr>(
+      L"I{a4<i2,i3>,a1<i1,i2>;i1,i2} * s{a2<i1,i2>;a4<i2,i3>}");
+  std::string const target = "i_2,i_1;a_1i_1i_2,a_2i_1i_2";
+  auto const node = eval_node(expr);
+
+  // Reference first (non-batched), so yield's random leaf arrays are generated
+  // and cached; the batched evaluator reuses the same arrays.
+  auto const ref = evaluate(node, target, yield)->get<ArrayToT>();
+
+  auto const occ =
+      sequant::get_default_context().index_space_registry()->retrieve(L"i");
+  auto accept_occ = [occ](sequant::Index const& ix) {
+    return ix.space() == occ;
+  };
+
+  // TA::norm2 is unsupported for tensor-of-tensor tiles, so compare via the
+  // self-dot of each array (a scalar norm^2); reordering the contraction over
+  // i3 must not change it.
+  auto self_dot = [](auto const& arr) {
+    return arr("i,j;a,b").dot(arr("i,j;a,b"));
+  };
+  auto const ref_dot = self_dot(ref);
+
+  for (std::size_t target_batch_size :
+       {std::size_t{100}, std::size_t{4}, std::size_t{1}}) {
+    auto cache = cache_t::empty();
+    cache.set_custom_evaluator(
+        make_batched_custom_evaluator(yield, target_batch_size, accept_occ));
+    auto const res = evaluate(node, target, yield, cache)->get<ArrayToT>();
+    REQUIRE(self_dot(res) == Catch::Approx(ref_dot));
+  }
+}


### PR DESCRIPTION
## Problem

The batched custom evaluator (`make_batched_custom_evaluator`) accumulates per-batch partials with `Result::add_inplace` and slices batch-axis leaves with `slice_array_over_mode`. Both built a **flat** annotation (`dummy_annotation(rank)` / `ords_to_annot`) and applied it to the array via `DistArray::operator()`. For a **tensor-of-tensor** array that trips `DistArray::check_str_index`'s `is_tot_index(vars)` assertion, since a ToT array requires an `"outer;inner"` annotation:

```
dist_array.h:1861: TA_ASSERT failed: detail::is_tot_index(vars)
```

This went unnoticed because the only in-tree coverage of the batched evaluator (`eval_batched_custom_evaluator`) used regular (non-nested) arrays. It surfaced as soon as a batched ToT residual hit `add_inplace` — concretely, mpqc's CSV-CCk batched over the DF index (mpqc PR #762, test `he10-csv-cck-2-pao-batched-...`).

## Fix

- Add `tot_inner_rank()`, which reads the inner-tensor mode count from the first local non-empty inner tile and max-reduces it across the world (well-defined on ranks holding no/empty local data, as long as some rank holds a non-empty inner tile). Empty inner views are skipped — calling `range()` on a null `ArenaTensor` view asserts.
- `add_inplace` and `slice_array_over_mode` now pass that inner rank to `dummy_annotation` for ToT arrays, producing a valid `"outer;inner"` annotation. The regular (non-ToT) path is unchanged.

## Test

Adds `eval_batched_custom_evaluator_tot` to `test_eval_ta.cpp`: batches a `ToT*ToT->ToT` contraction over a multi-tiled outer index, exercising both the slice and `add_inplace` ToT paths. Verified it fails with the exact `is_tot_index` assertion without the fix and passes with it; the existing `eval_batched_custom_evaluator` and `eval_with_tiledarray` tests still pass.

Validated end-to-end against mpqc's `he10-csv-cck-2-pao-batched-pvdz-tpno-1e-7-tosv-1e-9` validation test (passes within tolerance).