### PR TITLE
core/eval: explicit Adjoint IR op for adjoint-marked tensor leaves

### DIFF
--- a/SeQuant/core/eval/backends/tiledarray/result.hpp
+++ b/SeQuant/core/eval/backends/tiledarray/result.hpp
@@ -367,6 +367,29 @@ class ResultTensorTA final : public Result {
     return eval_result<this_type>(std::move(result));
   }
 
+  [[nodiscard]] ResultPtr adjoint(
+      std::array<std::any, 2> const& ann) const override {
+    // T†{a;i} = conj(T{i;a}) — bra/ket-swapped layout (annotation rewrite
+    // baked into ann by the IR: operand annot in ann[0], adjoint annot in
+    // ann[1]) plus elementwise conjugation. For real numeric_type, conj is
+    // a no-op; elide it so the TA expression doesn't carry a ConjTsrExpr
+    // wrapper unnecessarily.
+    auto const pre_annot = std::any_cast<std::string>(ann[0]);
+    auto const post_annot = std::any_cast<std::string>(ann[1]);
+
+    log_ta(post_annot, " = adjoint(", pre_annot, ")\n");
+
+    ArrayT result;
+    if constexpr (TA::detail::is_complex_v<numeric_type>) {
+      result(post_annot) = get<ArrayT>()(pre_annot).conj();
+    } else {
+      result(post_annot) = get<ArrayT>()(pre_annot);
+    }
+    ArrayT::wait_for_lazy_cleanup(result.world());
+    log_ta_tensor_host_memory_use();
+    return eval_result<this_type>(std::move(result));
+  }
+
   void add_inplace(Result const& other) override {
     SEQUANT_ASSERT(other.is<this_type>());
 
@@ -552,6 +575,30 @@ class ResultTensorOfTensorTA final : public Result {
 
     ArrayT result;
     result(post_annot) = get<ArrayT>()(pre_annot);
+    ArrayT::wait_for_lazy_cleanup(result.world());
+    log_ta_tensor_host_memory_use();
+    return eval_result<this_type>(std::move(result));
+  }
+
+  [[nodiscard]] ResultPtr adjoint(
+      std::array<std::any, 2> const& ann) const override {
+    // ToT adjoint: bra/ket-swapped layout (operand annot in ann[0], adjoint
+    // annot in ann[1]) plus elementwise conj (no-op for real numeric_type).
+    // .conj() on a ToT array currently fails to compile in TA — no inner
+    // conj overload for Tensor<Tensor<complex>>. For now bail at runtime
+    // for complex ToT; real ToT falls through to a pure permute.
+    auto const pre_annot = std::any_cast<std::string>(ann[0]);
+    auto const post_annot = std::any_cast<std::string>(ann[1]);
+
+    log_ta(post_annot, " = adjoint(", pre_annot, ")\n");
+
+    ArrayT result;
+    if constexpr (TA::detail::is_complex_v<numeric_type>) {
+      throw unimplemented_method(
+          "adjoint of tensor-of-tensors with complex numeric_type");
+    } else {
+      result(post_annot) = get<ArrayT>()(pre_annot);
+    }
     ArrayT::wait_for_lazy_cleanup(result.world());
     log_ta_tensor_host_memory_use();
     return eval_result<this_type>(std::move(result));

--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -55,7 +55,15 @@ struct Bytes {
 template <typename T, typename... Ts>
 [[nodiscard]] inline auto bytes(T const& arg, Ts const&... args) {
   auto one = [](auto const& a) -> size_t {
-    if constexpr (requires { a->size_in_bytes(); })
+    if constexpr (requires {
+                    static_cast<bool>(a);
+                    a->size_in_bytes();
+                  }) {
+      // Smart-pointer-like operand: tolerate null so callers (e.g. the
+      // EvalOp::Adjoint dispatcher, which leaves `right` unevaluated) can
+      // pass an empty ResultPtr without an external guard.
+      return a ? a->size_in_bytes() : size_t{0};
+    } else if constexpr (requires { a->size_in_bytes(); })
       return a->size_in_bytes();
     else
       return a.size_in_bytes();
@@ -150,9 +158,10 @@ enum struct EvalMode {
            : node->is_tensor()   ? EvalMode::Tensor
                                  : EvalMode::Unknown;
   } else {
-    return node->is_product() ? EvalMode::Product
-           : node->is_sum()   ? EvalMode::Sum
-                              : EvalMode::Unknown;
+    return node->is_product()   ? EvalMode::Product
+           : node->is_sum()     ? EvalMode::Sum
+           : node->is_adjoint() ? EvalMode::Permute
+                                : EvalMode::Unknown;
   }
 }
 
@@ -563,6 +572,16 @@ ResultPtr evaluate(Node const& node,  //
 
   if (node.leaf()) {
     time = timed_eval_inplace([&]() { result = le(node); });
+  } else if (node->op_type() == EvalOp::Adjoint) {
+    // Unary IR op: dispatch on left operand only; right is the Constant(1)
+    // sentinel kept around to preserve FullBinaryNode's invariant. We
+    // intentionally skip evaluating the sentinel — leaf evaluators that
+    // can't manufacture scalar constants (rare in practice but possible)
+    // would otherwise be invoked needlessly.
+    left = evaluate<EvalTrace>(node.left(), le, cache);
+    SEQUANT_ASSERT(left);
+    std::array<std::any, 2> const adj_ann{node.left()->annot(), node->annot()};
+    time = timed_eval_inplace([&]() { result = left->adjoint(adj_ann); });
   } else {
     left = evaluate<EvalTrace>(node.left(), le, cache);
     right = evaluate<EvalTrace>(node.right(), le, cache);
@@ -601,10 +620,14 @@ ResultPtr evaluate(Node const& node,  //
       // canon_phase != 1, because mult_by_phase allocates a fresh buffer
       // while the cache still holds the pre-phase data. So only skip the
       // local's bytes when the cache aliases the same buffer (phase == 1).
+      // Adjoint nodes evaluate only the left operand (the right child is the
+      // sentinel Constant(1) — see the Adjoint branch above), so `right` is
+      // null; log::bytes() tolerates a null shared_ptr for that reason.
       size_t hwmark = log::bytes(cache, result).value;
       if (!cache.alive(node.left()) || node.left()->canon_phase() != 1)
         hwmark += log::bytes(left).value;
-      if (!cache.alive(node.right()) || node.right()->canon_phase() != 1)
+      if (right &&
+          (!cache.alive(node.right()) || node.right()->canon_phase() != 1))
         hwmark += log::bytes(right).value;
       log::eval(log::EvalStat{.mode = log::eval_mode(node),
                               .time = time,

--- a/SeQuant/core/eval/eval_expr.cpp
+++ b/SeQuant/core/eval/eval_expr.cpp
@@ -235,6 +235,10 @@ bool EvalExpr::is_product() const noexcept {
   return op_type() == EvalOp::Product;
 }
 
+bool EvalExpr::is_adjoint() const noexcept {
+  return op_type() == EvalOp::Adjoint;
+}
+
 Tensor const& EvalExpr::as_tensor() const { return expr().as<Tensor>(); }
 
 Constant const& EvalExpr::as_constant() const { return expr().as<Constant>(); }
@@ -349,7 +353,12 @@ void collect_tensor_factors(EvalExprNode const& node,  //
   static_assert(std::is_same_v<ranges::range_value_t<Rng>, ExprWithHash>);
 
   if (auto op = node->op_type();
-      node->is_tensor() && (!op || *op == EvalOp::Sum))
+      node->is_tensor() &&
+      (!op || *op == EvalOp::Sum || *op == EvalOp::Adjoint))
+    // Treat Adjoint the same as Sum here: it produces a tensor result that
+    // enters a parent Product as a single factor — the parent shouldn't
+    // try to recurse past the Adjoint boundary, just collect the adjointed
+    // tensor (held in node->expr()) and move on.
     collect.emplace_back(
         ExprWithHash{.expr = node->expr(), .hash = node->hash_value()});
   else if (node->op_type() == EvalOp::Product && !node.leaf()) {
@@ -364,7 +373,48 @@ EvalExprNode binarize(Variable const& v) { return EvalExprNode{EvalExpr{v}}; }
 
 EvalExprNode binarize(Power const& p) { return EvalExprNode{EvalExpr{p}}; }
 
-EvalExprNode binarize(Tensor const& t) { return EvalExprNode{EvalExpr{t}}; }
+EvalExprNode binarize(Tensor const& t) {
+  // Detect adjoint-marked tensor leaves (label ending in U+207A '⁺'). These
+  // arise when the user wrote an adjoint of a BraKetSymmetry::Nonsymm tensor,
+  // see Tensor::adjoint() in expressions/tensor.cpp. We surface the adjoint
+  // as an explicit IR op (EvalOp::Adjoint) wrapping the bare-label operand,
+  // so backends can serve T† by conjugating + permuting the cached T result.
+  //
+  // IR shape: Adjoint(Tensor{<bare>}, Constant{1})
+  // The Constant(1) right child is a sentinel — present so the FullBinaryNode
+  // invariant ("every non-leaf has two children") holds; evaluate ignores it
+  // for EvalOp::Adjoint dispatch.
+  if (!t.label().empty() && t.label().back() == adjoint_label) {
+    // The Adjoint node carries the *adjointed* tensor (so its canon_indices
+    // reflect the slot order parents see).
+
+    // Build the bare-label operand: copy and call adjoint() to toggle the
+    // marker off and swap bra/ket back to natural orientation.
+    Tensor bare{t};
+    bare.adjoint();
+    SEQUANT_ASSERT(bare.label().empty() ||
+                   bare.label().back() != adjoint_label);
+    EvalExprNode bare_leaf{EvalExpr{bare}};
+
+    // Sentinel right child.
+    EvalExprNode sentinel{EvalExpr{Constant{1}}};
+
+    // Build the Adjoint EvalExpr. Hash differs from the bare leaf so cache
+    // lookups don't collide.
+    auto h = bare_leaf->hash_value();
+    hash::combine(h, static_cast<size_t>(EvalOp::Adjoint));
+    EvalExpr adj{EvalOp::Adjoint,                                   //
+                 ResultType::Tensor,                                //
+                 t.clone(),                                         //
+                 t.indices() | ranges::to<EvalExpr::index_vector>,  //
+                 1,                                                 //
+                 h,                                                 //
+                 nullptr};
+    return EvalExprNode{std::move(adj), std::move(bare_leaf),
+                        std::move(sentinel)};
+  }
+  return EvalExprNode{EvalExpr{t}};
+}
 
 EvalExprNode binarize(Sum const& sum, IndexSet const& uncontract) {
   using ranges::views::move;

--- a/SeQuant/core/eval/eval_expr.hpp
+++ b/SeQuant/core/eval/eval_expr.hpp
@@ -34,7 +34,18 @@ enum class EvalOp {
   ///        times a tensor, a constant times a constant, or a tensor times a
   ///        constant
   ///        (in either order).
-  Product
+  Product,
+
+  ///
+  /// \brief Represents the adjoint (conjugate transpose) of one EvalExpr
+  ///        object. The result equals the bra/ket-swapped, complex-conjugated
+  ///        operand. The IR representation is "structurally binary, lexically
+  ///        unary": an Adjoint node holds the bare-label operand as its left
+  ///        child and a Constant(1) sentinel as its right child (so the
+  ///        FullBinaryNode invariant — every non-leaf has both children —
+  ///        is preserved). Evaluate dispatches on this op_type and only uses
+  ///        the left operand; the right is ignored.
+  Adjoint
 };
 
 ///
@@ -183,6 +194,11 @@ class EvalExpr {
   /// \return True if this expression is a sum.
   ///
   [[nodiscard]] bool is_sum() const noexcept;
+
+  ///
+  /// \return True if this expression is an adjoint (unary) node.
+  ///
+  [[nodiscard]] bool is_adjoint() const noexcept;
 
   ///
   /// \brief Calls to<Tensor>() on ExprPtr held by this object.
@@ -479,6 +495,11 @@ ExprPtr to_expr(meta::eval_node auto const& node) {
   auto const& evxpr = *node;
 
   if (node.leaf()) return evxpr.expr();
+
+  // Adjoint is unary and stores the marker-bearing tensor directly in its
+  // own ExprPtr; the bare-leaf left child and Constant(1) right child are
+  // structural plumbing for the IR, not part of the symbolic form.
+  if (op == EvalOp::Adjoint) return evxpr.expr();
 
   if (op == EvalOp::Product) {
     auto prod = Product{};

--- a/SeQuant/core/eval/eval_node.hpp
+++ b/SeQuant/core/eval/eval_node.hpp
@@ -20,6 +20,11 @@ template <meta::eval_node Node>
 ExprPtr linearize_eval_node(Node const& node) {
   if (node.leaf()) return to_expr(node);
 
+  // Adjoint is unary: round-trip back to the marker-bearing tensor stored in
+  // the node's own ExprPtr — that's the symbolic form a Sum/Product parent
+  // would see — and ignore the Constant(1) sentinel right child.
+  if (node->op_type() == EvalOp::Adjoint) return to_expr(node);
+
   ExprPtr lres = linearize_eval_node(node.left());
   ExprPtr rres = linearize_eval_node(node.right());
 
@@ -152,6 +157,14 @@ struct Memory {
                                   : AsyCost::zero();
     };
 
+    // Adjoint is unary — the right child is the Constant(1) sentinel and
+    // the bare-leaf left holds the same indices as the node itself, so the
+    // memory requirement is just one tensor's worth.
+    if (n->op_type() == EvalOp::Adjoint) {
+      add_cost(n->expr());
+      return result;
+    }
+
     add_cost(n.left()->expr());
     add_cost(n.right()->expr());
     add_cost(n->expr());
@@ -169,9 +182,12 @@ struct Memory {
 struct FlopsWithSymm {
   [[nodiscard]] AsyCost operator()(meta::eval_node auto const& n) const {
     auto cost = Flops{}(n);
-    if (n.leaf() || !(n->is_tensor()            //
-                      && n.left()->is_tensor()  //
-                      && n.right()->is_tensor()))
+    // Adjoint is unary (right is Constant(1) sentinel) and does no
+    // symmetry-driven reduction — return Flops's permute-style cost as-is.
+    if (n.leaf() || n->op_type() == EvalOp::Adjoint ||
+        !(n->is_tensor()            //
+          && n.left()->is_tensor()  //
+          && n.right()->is_tensor()))
       return cost;
 
     // confirmed:

--- a/SeQuant/core/eval/eval_node.hpp
+++ b/SeQuant/core/eval/eval_node.hpp
@@ -157,10 +157,12 @@ struct Memory {
                                   : AsyCost::zero();
     };
 
-    // Adjoint is unary — the right child is the Constant(1) sentinel and
-    // the bare-leaf left holds the same indices as the node itself, so the
-    // memory requirement is just one tensor's worth.
+    // Adjoint is unary — the right child is the Constant(1) sentinel (zero
+    // cost). But the backend materializes the permuted/conjugated result into
+    // a fresh array, so the bare-leaf operand (left) and the adjoint result
+    // (node) are both live at peak — two tensors' worth, not one.
     if (n->op_type() == EvalOp::Adjoint) {
+      add_cost(n.left()->expr());
       add_cost(n->expr());
       return result;
     }

--- a/SeQuant/core/eval/result.hpp
+++ b/SeQuant/core/eval/result.hpp
@@ -277,6 +277,22 @@ class Result {
       std::array<std::any, 2> const&) const = 0;
 
   ///
+  /// \brief Take the adjoint (complex-conjugate transpose) of this result.
+  ///
+  /// Used to evaluate the EvalOp::Adjoint IR node — the unary op that holds a
+  /// bare-label operand and emits T† = conj(T) permuted into the adjoint slot
+  /// order. \p ann is [operand_annot, result_annot] (bra/ket swapped relative
+  /// to the operand); backends with a real numeric type implement this as a
+  /// pure permutation (conj is a no-op) and complex backends apply conj as
+  /// well. Not a pure virtual: only tensor-backed results need it; the
+  /// default throws. Mirrors the slice_mode precedent.
+  ///
+  [[nodiscard]] virtual ResultPtr adjoint(
+      std::array<std::any, 2> const& /*ann*/) const {
+    throw unimplemented_method("adjoint");
+  }
+
+  ///
   /// \brief Restrict this result to a contiguous *element* range of one mode.
   ///
   /// Keeps elements `[elem_lo, elem_hi)` of mode \p mode and all elements of

--- a/SeQuant/core/export/export.hpp
+++ b/SeQuant/core/export/export.hpp
@@ -199,11 +199,14 @@ class GenerationVisitor {
                         Product::Flatten::No));
         break;
       case EvalOp::Adjoint:
-        // Unary IR op — the marker-bearing tensor lives in node->expr(); the
-        // bare-leaf left child and Constant(1) right child are structural
-        // plumbing for in-memory evaluation, not part of the symbolic form
-        // a code generator should be handed.
-        expressions.push_back(node->expr());
+        // Unary IR op. The adjoint result (node->expr(), the marker-bearing
+        // tensor) is the assignment target node->as_tensor(); the right child
+        // is the Constant(1) sentinel. Emitting node->expr() here would yield a
+        // self-referential `result = result` that never reads the operand.
+        // Instead hand the code generator the bare-leaf operand (node.left()),
+        // whose bra/ket order is swapped relative to the result — that index
+        // reordering is exactly the transpose the adjoint must materialize.
+        expressions.push_back(node.left()->expr());
         break;
       case EvalOp::Sum: {
         switch (node->compute_selection()) {

--- a/SeQuant/core/export/export.hpp
+++ b/SeQuant/core/export/export.hpp
@@ -198,6 +198,13 @@ class GenerationVisitor {
             ex<Product>(ExprPtrList{node.left()->expr(), node.right()->expr()},
                         Product::Flatten::No));
         break;
+      case EvalOp::Adjoint:
+        // Unary IR op — the marker-bearing tensor lives in node->expr(); the
+        // bare-leaf left child and Constant(1) right child are structural
+        // plumbing for in-memory evaluation, not part of the symbolic form
+        // a code generator should be handed.
+        expressions.push_back(node->expr());
+        break;
       case EvalOp::Sum: {
         switch (node->compute_selection()) {
           case ComputeSelection::None:

--- a/tests/unit/test_eval_expr.cpp
+++ b/tests/unit/test_eval_expr.cpp
@@ -197,6 +197,83 @@ TEST_CASE("eval_expr", "[EvalExpr]") {
                                              ket(IndexList{L"a_1"})));
   }
 
+  SECTION("Adjoint op") {
+    // A Nonsymm-braket tensor's adjoint() relabels its label with U+207A '⁺'
+    // (Tensor::adjoint() at expressions/tensor.cpp:25-41). When that leaf
+    // reaches binarize, the resulting eval-tree should expose the adjoint as
+    // a first-class IR op (EvalOp::Adjoint) holding the bare-label tensor as
+    // its single operand — not as a leaf with the marker still in the label.
+    Tensor t(L"t", bra{L"a_1"}, ket{L"i_1"}, Symmetry::Nonsymm,
+             BraKetSymmetry::Nonsymm, ColumnSymmetry::Nonsymm);
+    REQUIRE(t.label() == L"t");
+    Tensor t_adj = t;
+    t_adj.adjoint();
+    REQUIRE(t_adj.label() == L"t⁺");
+    REQUIRE(t_adj.bra().at(0).label() == L"i_1");
+    REQUIRE(t_adj.ket().at(0).label() == L"a_1");
+
+    SEQUANT_PRAGMA_IGNORE_DEPRECATED_BEGIN
+    auto tree = binarize(ex<Tensor>(t_adj));
+    SEQUANT_PRAGMA_IGNORE_DEPRECATED_END
+
+    // The tree should NOT be a leaf — the adjoint marker on the leaf label is
+    // a structural property the IR should surface as a unary op.
+    REQUIRE_FALSE(tree.leaf());
+    REQUIRE(tree->op_type() == EvalOp::Adjoint);
+    REQUIRE(tree->is_tensor());  // adjoint of a tensor is still a tensor
+
+    // Left child: the bare-label leaf with the marker stripped and bra/ket
+    // swapped back to the operand's natural orientation.
+    REQUIRE(tree.left().leaf());
+    REQUIRE(tree.left()->is_tensor());
+    REQUIRE(tree.left()->as_tensor().label() == L"t");
+    REQUIRE(tree.left()->as_tensor().bra().at(0).label() == L"a_1");
+    REQUIRE(tree.left()->as_tensor().ket().at(0).label() == L"i_1");
+
+    // Right child: a Constant(1) sentinel — present so the full-binary-tree
+    // invariant holds (every non-leaf has both children); ignored by
+    // evaluate's Adjoint-case dispatch.
+    REQUIRE(tree.right().leaf());
+    REQUIRE(tree.right()->is_constant());
+    REQUIRE(tree.right()->as_constant().value() == Constant::scalar_type{1});
+
+    // The Adjoint node's canon_indices are the *original* (marker-bearing)
+    // tensor's index order — that's what a downstream Sum/Product parent
+    // sees as the operand's slot order.
+    auto const& adj_canon = tree->canon_indices();
+    REQUIRE(adj_canon.size() == 2);
+    REQUIRE(adj_canon[0].label() == L"i_1");
+    REQUIRE(adj_canon[1].label() == L"a_1");
+
+    // The bare-leaf operand's canon_indices are the swapped order.
+    auto const& bare_canon = tree.left()->canon_indices();
+    REQUIRE(bare_canon.size() == 2);
+    REQUIRE(bare_canon[0].label() == L"a_1");
+    REQUIRE(bare_canon[1].label() == L"i_1");
+
+    // Hash uniqueness: Adjoint(t) and the bare t leaf must have distinct
+    // hashes (else cache collisions). And Adjoint(Adjoint(t)) ≡ t.
+    auto bare_leaf = ex<Tensor>(t);
+    SEQUANT_PRAGMA_IGNORE_DEPRECATED_BEGIN
+    auto bare_tree = binarize(bare_leaf);
+    SEQUANT_PRAGMA_IGNORE_DEPRECATED_END
+    REQUIRE(bare_tree.leaf());
+    REQUIRE(bare_tree->hash_value() != tree->hash_value());
+
+    // Hermitian (BraKetSymmetry::Conjugate/Symm) tensors don't carry the
+    // marker — Tensor::adjoint() guards the relabel on Nonsymm only — so
+    // binarize gives a plain leaf (no Adjoint op).
+    Tensor g(L"g", bra{L"p_1", L"p_2"}, ket{L"p_3", L"p_4"}, Symmetry::Nonsymm,
+             BraKetSymmetry::Conjugate, ColumnSymmetry::Symm);
+    Tensor g_adj = g;
+    g_adj.adjoint();
+    REQUIRE(g_adj.label() == L"g");  // no marker added for Conjugate
+    SEQUANT_PRAGMA_IGNORE_DEPRECATED_BEGIN
+    auto g_tree = binarize(ex<Tensor>(g_adj));
+    SEQUANT_PRAGMA_IGNORE_DEPRECATED_END
+    REQUIRE(g_tree.leaf());  // no Adjoint wrapper
+  }
+
   SECTION("external hyperindices") {
     // t{i1,i2;a1,a3} T2{a2,a3;i1,i2}: i1,i2 appear in bra of t and ket of
     // T2 (multiply-appearing), a3 also multiply-appearing


### PR DESCRIPTION
## Summary

`Tensor::adjoint()` relabels a `BraKetSymmetry::Nonsymm` tensor's label with U+207A ('⁺'). Until this PR, those marked leaves bubbled all the way to backend leaf evaluators, forcing each backend to recognise the marker, strip it, swap bra/ket, and conjugate by hand — driving e.g. mpqc4's `cck_so_response.ipp` to extend `is_pert_tensor` / `eval_so_response_tensor` with adjoint-aware lookups.

This PR adds a first-class `EvalOp::Adjoint` IR node so the eval tree itself carries the unary semantics:

```
Adjoint(Tensor{<bare>}, Constant{1})
```

The `Constant(1)` right child is a **sentinel** — present so the `FullBinaryNode` invariant (every non-leaf has both children) holds without introducing a true unary node and reworking the iterator. The evaluate dispatcher only walks the left operand for Adjoint nodes; `linearize_eval_node` and `to_expr` round-trip back to the marker-bearing tensor stored in the Adjoint node's `ExprPtr`.

## Why a sentinel, not a unary node

The eval IR has exactly one tree node type — `FullBinaryNode<EvalExpr>`. There is no `FullUnaryNode` to reach for; a 'true unary' Adjoint isn't a sibling class, it's a modification of `FullBinaryNode` itself. The choice was between two changes of very different blast radii:

- **Relax `FullBinaryNode`'s two-children-or-none invariant.** Touches the iterator's "came from left → go right" branch (which would need a "leaf-or-right-null → go up" fork); the move-ctor and copy assignment's unconditional `right_->parent_ = this` fixups; `leaf()`'s definition; and every existing tree visitor in the project (`cache_manager`'s volatility/persistence walker, `linearize_eval_node`, `to_expr`, `transform_node`, `peak_cache`, `PreprocessVisitor::release_used_terms`, the export preprocessing visitors, …), each of which currently assumes both children exist on a non-leaf and would need an audit.

- **Keep `FullBinaryNode` exactly as it is and put a `Constant{1}` in the right slot.** Every existing walker treats the sentinel as just another constant leaf — code they already handle. The only place that knows the sentinel is special is the Adjoint case in `evaluate`, which skips evaluating it.

I picked the sentinel. Honest costs it imposes, for the record:

- One wasted `EvalExpr` per Adjoint (tiny, but real).
- It's a unary op lexically pretending to be binary — structure misleading to anyone reading the IR cold.
- **Implicit null contract for `right` in the Adjoint dispatcher**, which is what produced the `log::bytes` bug below. With a true unary node the type system would distinguish unary-vs-binary at compile time and you couldn't accidentally feed a null `right` to a binary-op code path. With the sentinel approach you have to remember not to deref `right` when `op_type == Adjoint`, even though the *structural* invariant says right always exists.

If `EvalOp::Adjoint` proves it pulls its weight and we add more genuinely-unary IR ops later (a Conjugate-without-permute, a Scale, an Antisymmetrize), the sentinel approach scales badly — you'd accumulate `op_type`-keyed special cases in every walker. At that point it's worth biting the bullet and making `FullBinaryNode` tolerate unary children. For one-off Adjoint, the sentinel was the smaller change.

## What's in the IR

- `EvalOp::Adjoint` enum value + `EvalExpr::is_adjoint()`.
- `binarize(Tensor const&)` intercepts leaves whose label ends in the adjoint marker, builds the bare-label operand via `Tensor::adjoint()` (toggles marker off + swaps bra/ket back), and wraps it in an Adjoint `EvalExpr` whose `canon_indices` match the t⁺ slot order — so a Sum/Product parent sees the operand at the slot order it expects.
- `Result::adjoint(ann)` virtual on the Result base, defaulting to throw (mirrors `slice_mode` precedent).
- `ResultTensorTA::adjoint` implements it as a permutation + elementwise conj guarded by `is_complex_v<numeric_type>` (elided for real). `ResultTensorOfTensorTA` implements the real case; complex ToT throws because TA lacks a `conj` overload for the inner `Tensor<Tensor<complex>>`.
- evaluate dispatcher gains an Adjoint case that calls `left->adjoint(adj_ann)` and skips evaluating the right sentinel.
- Eleven other dispatch sites (`linearize_eval_node`, `to_expr`, `Memory`, `FlopsWithSymm`, eval-mode logging, export.hpp's `process_computation`) gained their Adjoint cases.

## Two bugs I found while wiring this up

**collect_tensor_factors silently dropping Adjoint factors.** The function previously treated only `is_tensor && (no op || op == Sum)` as a single factor and `op == Product` as a recurse-into case — everything else fell through to a no-op. An Adjoint subtree thus contributed *nothing* to the parent Product's `TensorNetwork` canonicalization, corrupting the parent's `canon_indices` / result layout. Fixed by extending the leaf-like branch to also accept `EvalOp::Adjoint` (it produces a tensor result whose ExprPtr is the marker-bearing tensor — exactly what the parent Product needs as a single factor).

**log::bytes deref'd a null shared_ptr.** The evaluate logging path calls `log::bytes(right)` on every non-leaf to populate `EvalStat::mem_right`, but for Adjoint nodes `right` is null (we skip evaluating the sentinel). Trace is on by default in mpqc4's release+debug builds (`-DSEQUANT_EVAL_TRACE=1`), so this fired in both. Fixed inside `log::bytes` itself — the smart-pointer-like-arg branch now tolerates null (`a ? a->size_in_bytes() : 0`), so any future caller passing an empty `ResultPtr` is handled without an external guard.

## Tests

TDD section `'Adjoint op'` in `test_eval_expr` pins the IR shape:
- `op_type() == EvalOp::Adjoint`
- left = bare leaf with bra/ket swapped and marker stripped
- right = `Constant(1)` sentinel
- canon_indices match t⁺ (so the parent sees the marker-orientation)
- hash distinct from bare leaf
- `Conjugate`/`Symm` tensors don't trigger the op (no marker added by `Tensor::adjoint()` in those cases)

All 59 unit test cases pass (6725 assertions).

## mpqc4 integration

Validated end-to-end against mpqc4 `evaleev/feature/sequant-scalar-field`:

- All 12 `h2o-lr-cck-2-so` validation tests pass with the mpqc-side adjoint-marker workarounds **removed** (see mpqc4 commit `5b48ae4651` 'cc/cck: drop lr stopgap — SeQuant Adjoint IR strips ⁺ markers before leaves').
- `h2o-eom-cck-2-2h2p-so-x2c-631g-np2`, `ne-hbar-mp2-apvdz-apvdzf12-np1`, `lih-hbar-ccsd-pvdz-pvdzf12-np1` all still pass. These keep separate Field::Complex stopgaps that are **not** about leaf-side adjoint markers — the hbar f12 path has custom processing that assumes the bra/ket structure is preserved exactly (so Field::Real canonicalization, which can collapse bra↔ket-swapped real integrals, breaks it); the eom-cck Field::Real failure mode is not yet diagnosed.

## Limitations

- ToT (tensor-of-tensors) adjoint with complex `numeric_type` throws at runtime — `TA::DistArray<TA::Tensor<TA::Tensor<complex>>>` lacks an inner `conj` overload. Real-ToT adjoint works (pure permutation).
- The sentinel `Constant{1}` right child uses ~negligible memory but does occupy a `FullBinaryNode` slot in every tree containing an Adjoint. If the FullBinaryNode invariant is ever relaxed to allow true unary children, the sentinel can go away cleanly.
