### PR TITLE
 Support open-shell CC spintrace of energy like expressions

### DIFF
--- a/SeQuant/domain/mbpt/spin.cpp
+++ b/SeQuant/domain/mbpt/spin.cpp
@@ -1590,7 +1590,7 @@ std::vector<ExprPtr> open_shell_CC_spintrace(const ExprPtr& expr) {
   };
 
   // Expressions without a leading antisymmetrizer (e.g. CC energy) collapse
-  // to a single spin case. They are spin-traced directly, but term-by-term.
+  // to a single expression. They are spin-traced directly, but term-by-term.
   const auto A_opt = leading_antisymmetrizer(expr);
   if (!A_opt) {
     auto trace_term = [](const ExprPtr& term) -> ExprPtr {

--- a/SeQuant/domain/mbpt/spin.cpp
+++ b/SeQuant/domain/mbpt/spin.cpp
@@ -1576,9 +1576,36 @@ std::vector<ExprPtr> open_shell_spintrace(
 
 std::vector<ExprPtr> open_shell_CC_spintrace(const ExprPtr& expr) {
   SEQUANT_ASSERT(expr->is<Sum>() || expr->is<Product>());
-  Tensor A = expr.is<Sum>() ? expr->at(0)->at(0)->as<Tensor>()
-                            : expr->at(0)->as<Tensor>();
-  SEQUANT_ASSERT(A.label() == reserved::antisymm_label());
+  // Returns the leading antisymmetrizer of an expression, or nullopt
+  // when there is none
+  auto leading_antisymmetrizer = [](const ExprPtr& e) -> std::optional<Tensor> {
+    const ExprPtr& first = e->is<Sum>() ? e->as<Sum>().summand(0) : e;
+    const ExprPtr& leading_factor =
+        first->is<Product>() ? first->as<Product>().factor(0) : first;
+    if (leading_factor->is<Tensor>()) {
+      const Tensor& t = leading_factor->as<Tensor>();
+      if (t.label() == reserved::antisymm_label()) return t;
+    }
+    return std::nullopt;
+  };
+
+  // Expressions without a leading antisymmetrizer (e.g. CC energy) collapse
+  // to a single spin case. They are spin-traced directly, but term-by-term.
+  const auto A_opt = leading_antisymmetrizer(expr);
+  if (!A_opt) {
+    auto trace_term = [](const ExprPtr& term) -> ExprPtr {
+      if (term->is<Constant>() || term->is<Variable>()) return term;
+      return open_shell_spintrace(term, {}).at(0);
+    };
+    const auto terms =
+        expr.is<Sum>() ? expr->as<Sum>().summands() : Sum::summands_type{expr};
+    auto result = ex<Sum>(terms | ranges::views::transform(trace_term));
+    simplify(result);
+    return {result};
+  }
+
+  SEQUANT_ASSERT(A_opt.has_value() && "Leading antisymmetrizer not found.");
+  const Tensor& A = A_opt.value();
   size_t const i = A.rank();
   auto P_vec = open_shell_P_op_vector(A);
   auto A_vec = open_shell_A_op(A);

--- a/SeQuant/domain/mbpt/spin.cpp
+++ b/SeQuant/domain/mbpt/spin.cpp
@@ -1579,6 +1579,9 @@ std::vector<ExprPtr> open_shell_CC_spintrace(const ExprPtr& expr) {
   SEQUANT_ASSERT(expr->is<Sum>() || expr->is<Product>());
   // Pop the antisymmetrizer A off a copy of the leading term to detect and
   // retrieve it. Energy-like expressions (e.g. CC energy) have none.
+  // The input is assumed homogeneous: either every term carries a leading
+  // antisymmetrizer (residual) or none does (energy), so inspecting the
+  // leading term alone suffices to classify the whole expression.
   ExprPtr leading_term =
       (expr->is<Sum>() ? expr->as<Sum>().summand(0) : expr).clone();
   const auto A_opt = pop_tensor(leading_term, reserved::antisymm_label());

--- a/SeQuant/domain/mbpt/spin.cpp
+++ b/SeQuant/domain/mbpt/spin.cpp
@@ -13,6 +13,7 @@
 #include <SeQuant/core/space.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
 #include <SeQuant/core/tensor_network.hpp>
+#include <SeQuant/core/utility/expr.hpp>
 #include <SeQuant/core/utility/indices.hpp>
 #include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/core/utility/overloads.hpp>
@@ -1576,22 +1577,14 @@ std::vector<ExprPtr> open_shell_spintrace(
 
 std::vector<ExprPtr> open_shell_CC_spintrace(const ExprPtr& expr) {
   SEQUANT_ASSERT(expr->is<Sum>() || expr->is<Product>());
-  // Returns the leading antisymmetrizer of an expression, or nullopt
-  // when there is none
-  auto leading_antisymmetrizer = [](const ExprPtr& e) -> std::optional<Tensor> {
-    const ExprPtr& first = e->is<Sum>() ? e->as<Sum>().summand(0) : e;
-    const ExprPtr& leading_factor =
-        first->is<Product>() ? first->as<Product>().factor(0) : first;
-    if (leading_factor->is<Tensor>()) {
-      const Tensor& t = leading_factor->as<Tensor>();
-      if (t.label() == reserved::antisymm_label()) return t;
-    }
-    return std::nullopt;
-  };
+  // Pop the antisymmetrizer A off a copy of the leading term to detect and
+  // retrieve it. Energy-like expressions (e.g. CC energy) have none.
+  ExprPtr leading_term =
+      (expr->is<Sum>() ? expr->as<Sum>().summand(0) : expr).clone();
+  const auto A_opt = pop_tensor(leading_term, reserved::antisymm_label());
 
   // Expressions without a leading antisymmetrizer (e.g. CC energy) collapse
   // to a single expression. They are spin-traced directly, but term-by-term.
-  const auto A_opt = leading_antisymmetrizer(expr);
   if (!A_opt) {
     auto trace_term = [](const ExprPtr& term) -> ExprPtr {
       if (term->is<Constant>() || term->is<Variable>()) return term;
@@ -1604,8 +1597,7 @@ std::vector<ExprPtr> open_shell_CC_spintrace(const ExprPtr& expr) {
     return {result};
   }
 
-  SEQUANT_ASSERT(A_opt.has_value() && "Leading antisymmetrizer not found.");
-  const Tensor& A = A_opt.value();
+  const Tensor& A = A_opt.value()->as<Tensor>();
   size_t const i = A.rank();
   auto P_vec = open_shell_P_op_vector(A);
   auto A_vec = open_shell_A_op(A);

--- a/SeQuant/domain/mbpt/spin.hpp
+++ b/SeQuant/domain/mbpt/spin.hpp
@@ -366,10 +366,13 @@ std::vector<ExprPtr> open_shell_spintrace(
 /// the expectation value is with respect to an open-shell Fermi vacuum.
 /// Antisymmetrizer is expanded partially to produce antisymmetrizer for
 /// spin-up and spin-down columns.
+/// Expressions without a leading antisymmetrizer (e.g. a CC energy expression)
+/// collapse to a single spin case and the returned vector then contains one expression.
 /// @param expr the input expression
 /// @return vector of spin-traced expressions for each spincase
-/// @warning the "antisymmetrizer" tensor A is assumed to be at the front of each tensor
-/// network, hence must use "complete" canonicalization to produce the input expression.
+/// @warning when an "antisymmetrizer" tensor A is present it is assumed to be at the
+/// front of each tensor network, hence must use "complete" canonicalization to produce
+/// the input expression.
 // clang-format on
 std::vector<ExprPtr> open_shell_CC_spintrace(const ExprPtr& expr);
 

--- a/SeQuant/domain/mbpt/spin.hpp
+++ b/SeQuant/domain/mbpt/spin.hpp
@@ -367,7 +367,7 @@ std::vector<ExprPtr> open_shell_spintrace(
 /// Antisymmetrizer is expanded partially to produce antisymmetrizer for
 /// spin-up and spin-down columns.
 /// Expressions without a leading antisymmetrizer (e.g. a CC energy expression)
-/// collapse to a single spin case and the returned vector then contains one expression.
+/// collapse to a single expression which sums over all spin combinations
 /// @param expr the input expression
 /// @return vector of spin-traced expressions for each spincase
 /// @warning when an "antisymmetrizer" tensor A is present it is assumed to be at the

--- a/tests/unit/test_spin.cpp
+++ b/tests/unit/test_spin.cpp
@@ -1678,6 +1678,42 @@ SECTION("Open-shell spin-tracing") {
   }
 }
 
+SECTION("Open-shell CC spintrace energy") {
+  // CC energy
+  {
+    const auto input = deserialize(
+        L"f{i_1;a_1} t{a_1;i_1} "
+        L"+ 1/4 g{i_1,i_2;a_1,a_2} t{a_1,a_2;i_1,i_2} "
+        L"+ 1/2 g{i_1,i_2;a_1,a_2} t{a_1;i_1} t{a_2;i_2}",
+        {.def_perm_symm = Symmetry::Antisymm});
+    auto result = open_shell_CC_spintrace(input);
+    REQUIRE(result.size() == 1);
+    REQUIRE_THAT(
+        result[0],
+        EquivalentTo(L"f{i↑1;a↑1} t{a↑1;i↑1} "
+                     L"+ f{i↓1;a↓1} t{a↓1;i↓1} "
+                     L"+ 1/4 g{i↑1,i↑2;a↑1,a↑2}:A t{a↑1,a↑2;i↑1,i↑2}:A "
+                     L"+ 1/4 g{i↓1,i↓2;a↓1,a↓2}:A t{a↓1,a↓2;i↓1,i↓2}:A "
+                     L"+ g{i↑1,i↓1;a↑1,a↓1} t{a↑1,a↓1;i↑1,i↓1} "
+                     L"+ 1/2 g{i↑1,i↑2;a↑1,a↑2}:A t{a↑1;i↑1} t{a↑2;i↑2} "
+                     L"+ 1/2 g{i↓1,i↓2;a↓1,a↓2}:A t{a↓1;i↓1} t{a↓2;i↓2} "
+                     L"+ g{i↑1,i↓1;a↑1,a↓1} t{a↑1;i↑1} t{a↓1;i↓1}"));
+  }
+  // CCD Energy (a single Product)
+  {
+    const auto input = deserialize(L"1/4 g{i_1,i_2;a_1,a_2} t{a_1,a_2;i_1,i_2}",
+                                   {.def_perm_symm = Symmetry::Antisymm});
+    REQUIRE(input->is<Product>());
+    auto result = open_shell_CC_spintrace(input);
+    REQUIRE(result.size() == 1);
+    REQUIRE_THAT(
+        result[0],
+        EquivalentTo(L"1/4 g{i↑1,i↑2;a↑1,a↑2}:A t{a↑1,a↑2;i↑1,i↑2}:A "
+                     L"+ 1/4 g{i↓1,i↓2;a↓1,a↓2}:A t{a↓1,a↓2;i↓1,i↓2}:A "
+                     L"+ g{i↑1,i↓2;a↑1,a↓2} t{a↑1,a↓2;i↑1,i↓2}"));
+  }
+}
+
 SECTION("ResultExpr") {
   auto ctx = get_default_context();
   ctx.set(mbpt::make_mr_spaces());


### PR DESCRIPTION
Needed for the unified processing and evaluation pipeline in MPQC4. The closed-shell entry point already supports energy like expressions, and this PR restores the API symmetry. 