### PR TITLE
Generalize `AsyCost`

### DIFF
--- a/SeQuant/core/asy_cost.cpp
+++ b/SeQuant/core/asy_cost.cpp
@@ -129,15 +129,28 @@ bool AsyCost::AsyCostEntry::operator<(const AsyCost::AsyCostEntry &rhs) const {
   // The max() sentinel is the greatest entry.
   if (is_max_ != rhs.is_max_) return !is_max_;
 
-  // Order by exponents, space by space, from the greatest IndexSpace (highest
-  // priority) down to the least, using IndexSpace's own ordering. The first
-  // space whose exponents differ decides: a larger exponent on a higher-
-  // priority space makes the entry larger. Entries with identical exponents
-  // on every space are equivalent.
+  // Order primarily by the sum of all exponents, i.e. the overall polynomial
+  // degree (worst-case scaling). When two entries share the same total degree,
+  // break the tie by comparing exponents space by space, from the greatest
+  // IndexSpace (highest priority) down to the least, using IndexSpace's own
+  // ordering: the first space whose exponents differ decides, and a larger
+  // exponent on a higher-priority space makes the entry larger. Entries with
+  // identical exponents on every space are equivalent.
   auto exp_for = [](ExponentMap const &m, IndexSpace const &s) {
     auto it = m.find(s);
     return it == m.end() ? std::size_t{0} : it->second;
   };
+
+  auto total_degree = [](ExponentMap const &m) {
+    std::size_t sum = 0;
+    for (auto const &kv : m) sum += kv.second;
+    return sum;
+  };
+  {
+    auto const l = total_degree(exponents_);
+    auto const r = total_degree(rhs.exponents_);
+    if (l != r) return l < r;
+  }
 
   container::set<IndexSpace> spaces;
   for (auto const &kv : exponents_) spaces.insert(kv.first);

--- a/SeQuant/core/asy_cost.cpp
+++ b/SeQuant/core/asy_cost.cpp
@@ -2,7 +2,6 @@
 #include <SeQuant/core/container.hpp>
 #include <SeQuant/core/meta.hpp>
 #include <SeQuant/core/rational.hpp>
-#include <SeQuant/core/utility/exception.hpp>
 #include <SeQuant/core/utility/string.hpp>
 
 #include <boost/numeric/conversion/cast.hpp>
@@ -190,11 +189,9 @@ double AsyCost::ops(ExtentMap const &extents) const {
     double temp = 1;
     for (auto const &[space, exp] : c.exponents()) {
       auto it = extents.find(space);
-      if (it == extents.end())
-        throw Exception("AsyCost::ops: no extent provided for index space '" +
-                        toUtf8(space.base_key()) + "'");
-      temp *=
-          std::pow(static_cast<double>(it->second), static_cast<double>(exp));
+      auto const extent =
+          it != extents.end() ? it->second : space.approximate_size();
+      temp *= std::pow(static_cast<double>(extent), static_cast<double>(exp));
     }
     total += boost::numeric_cast<double>(c.prefactor()) * temp;
   }

--- a/SeQuant/core/asy_cost.cpp
+++ b/SeQuant/core/asy_cost.cpp
@@ -18,26 +18,26 @@
 namespace sequant {
 
 AsyCost::AsyCostEntry::AsyCostEntry()
-    : exponents_{}, count_{0}, is_max_{false} {}
+    : exponents_{}, prefactor_{0}, is_max_{false} {}
 
-AsyCost::AsyCostEntry::AsyCostEntry(ExponentMap exponents, rational count)
-    : exponents_{std::move(exponents)}, count_{count}, is_max_{false} {
+AsyCost::AsyCostEntry::AsyCostEntry(ExponentMap exponents, rational prefactor)
+    : exponents_{std::move(exponents)}, prefactor_{prefactor}, is_max_{false} {
   for (auto it = exponents_.begin(); it != exponents_.end();) {
     if (it->second == 0)
       it = exponents_.erase(it);
     else
       ++it;
   }
-  if (count_ == 0 || exponents_.empty()) {
+  if (prefactor_ == 0 || exponents_.empty()) {
     exponents_.clear();
-    count_ = 0;
+    prefactor_ = 0;
   }
 }
 
 AsyCost::AsyCostEntry AsyCost::AsyCostEntry::max() {
   AsyCostEntry e;
   e.is_max_ = true;
-  e.count_ = std::numeric_limits<intmax_t>::max();
+  e.prefactor_ = std::numeric_limits<intmax_t>::max();
   return e;
 }
 
@@ -50,12 +50,12 @@ AsyCost::ExponentMap const &AsyCost::AsyCostEntry::exponents() const {
   return exponents_;
 }
 
-rational AsyCost::AsyCostEntry::count() const { return count_; }
+rational AsyCost::AsyCostEntry::prefactor() const { return prefactor_; }
 
-void AsyCost::AsyCostEntry::set_count(rational n) const { count_ = n; }
+void AsyCost::AsyCostEntry::set_prefactor(rational n) const { prefactor_ = n; }
 
 bool AsyCost::AsyCostEntry::is_zero() const {
-  return !is_max_ && exponents_.empty() && count_ == 0;
+  return !is_max_ && exponents_.empty() && prefactor_ == 0;
 }
 
 bool AsyCost::AsyCostEntry::is_max() const { return is_max_; }
@@ -78,8 +78,8 @@ std::string AsyCost::AsyCostEntry::text() const {
   } else if (is_zero()) {
     oss << "zero";
   } else {
-    auto abs_c = abs(count_);
-    oss << (count_ < abs_c ? "- " : "");
+    auto abs_c = abs(prefactor_);
+    oss << (prefactor_ < abs_c ? "- " : "");
     if (abs_c == 1) {
       // do nothing
     } else {
@@ -106,15 +106,15 @@ std::string AsyCost::AsyCostEntry::to_latex() const {
   } else if (is_zero()) {
     oss << "\\texttt{zero}";
   } else {
-    auto abs_c = abs(count_);
-    oss << (count_ < abs_c ? "- " : "");
-    bool frac_mode = abs(denominator(count_)) != 1;
-    if (!frac_mode && (abs_c != 1)) oss << numerator(count_);
+    auto abs_c = abs(prefactor_);
+    oss << (prefactor_ < abs_c ? "- " : "");
+    bool frac_mode = abs(denominator(prefactor_)) != 1;
+    if (!frac_mode && (abs_c != 1)) oss << numerator(prefactor_);
     if (frac_mode) {
-      oss << "\\frac{"               //
-          << abs(numerator(count_))  //
-          << "}{"                    //
-          << denominator(count_) << "}";
+      oss << "\\frac{"                   //
+          << abs(numerator(prefactor_))  //
+          << "}{"                        //
+          << denominator(prefactor_) << "}";
     }
     for (auto const &[space, exp] : exponents_) {
       if (exp == 0) continue;
@@ -180,8 +180,8 @@ AsyCost::AsyCost(AsyCostEntry c) {
 
 AsyCost::AsyCost() : AsyCost{AsyCostEntry::zero()} {}
 
-AsyCost::AsyCost(ExponentMap exponents, rational count)
-    : AsyCost{AsyCostEntry{std::move(exponents), count}} {}
+AsyCost::AsyCost(ExponentMap exponents, rational prefactor)
+    : AsyCost{AsyCostEntry{std::move(exponents), prefactor}} {}
 
 double AsyCost::ops(ExtentMap const &extents) const {
   double total = 0;
@@ -196,7 +196,7 @@ double AsyCost::ops(ExtentMap const &extents) const {
       temp *=
           std::pow(static_cast<double>(it->second), static_cast<double>(exp));
     }
-    total += boost::numeric_cast<double>(c.count()) * temp;
+    total += boost::numeric_cast<double>(c.prefactor()) * temp;
   }
   return total;
 }
@@ -226,8 +226,8 @@ AsyCost operator+(AsyCost const &lhs, AsyCost const &rhs) {
   auto &data = sum.cost_;
   for (auto const &c : rhs.cost_) {
     if (auto found = data.find(c); found != data.end()) {
-      found->set_count(found->count() + c.count());
-      if (found->count() == 0) data.erase(found);
+      found->set_prefactor(found->prefactor() + c.prefactor());
+      if (found->prefactor() == 0) data.erase(found);
     } else {
       data.emplace(c);
     }
@@ -241,7 +241,7 @@ AsyCost operator-(AsyCost const &lhs, AsyCost const &rhs) {
 
 AsyCost operator*(AsyCost const &cost, rational scale) {
   auto ac = cost;
-  for (auto &c : ac.cost_) c.set_count(c.count() * scale);
+  for (auto &c : ac.cost_) c.set_prefactor(c.prefactor() * scale);
   return ac;
 }
 
@@ -259,9 +259,9 @@ bool operator<(AsyCost const &lhs, AsyCost const &rhs) {
     if (c1 < c2)
       return true;
     else if (c1 == c2) {
-      if (c1.count() < c2.count())
+      if (c1.prefactor() < c2.prefactor())
         return true;
-      else if (c1.count() > c2.count())
+      else if (c1.prefactor() > c2.prefactor())
         return false;
     } else
       return false;

--- a/SeQuant/core/asy_cost.cpp
+++ b/SeQuant/core/asy_cost.cpp
@@ -2,6 +2,7 @@
 #include <SeQuant/core/container.hpp>
 #include <SeQuant/core/meta.hpp>
 #include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/utility/exception.hpp>
 #include <SeQuant/core/utility/string.hpp>
 
 #include <boost/numeric/conversion/cast.hpp>
@@ -85,7 +86,8 @@ std::string AsyCost::AsyCostEntry::text() const {
       AsyCostEntry::stream_out_rational(oss, abs_c);
       oss << "*";
     }
-    // Spaces print in IndexSpace order (by attr, then base_key).
+    // Spaces print in IndexSpace order (primarily by attr; base_key only
+    // breaks ties between reserved-attr spaces).
     for (auto const &[space, exp] : exponents_) {
       if (exp == 0) continue;
       oss << toUtf8(space.base_key());
@@ -188,8 +190,11 @@ double AsyCost::ops(ExtentMap const &extents) const {
     double temp = 1;
     for (auto const &[space, exp] : c.exponents()) {
       auto it = extents.find(space);
-      std::size_t const extent = (it != extents.end()) ? it->second : 1;
-      temp *= std::pow(static_cast<double>(extent), static_cast<double>(exp));
+      if (it == extents.end())
+        throw Exception("AsyCost::ops: no extent provided for index space '" +
+                        toUtf8(space.base_key()) + "'");
+      temp *=
+          std::pow(static_cast<double>(it->second), static_cast<double>(exp));
     }
     total += boost::numeric_cast<double>(c.count()) * temp;
   }

--- a/SeQuant/core/asy_cost.cpp
+++ b/SeQuant/core/asy_cost.cpp
@@ -16,33 +16,48 @@
 
 namespace sequant {
 
-AsyCost::AsyCostEntry::AsyCostEntry(size_t nocc, size_t nvirt, rational count)
-    : occ_{nocc}, virt_{nvirt}, count_{count} {
-  if (count_ == 0 || (occ_ == 0 && virt_ == 0)) {
-    occ_ = 0;
-    virt_ = 0;
+AsyCost::AsyCostEntry::AsyCostEntry()
+    : exponents_{}, count_{0}, is_max_{false} {}
+
+AsyCost::AsyCostEntry::AsyCostEntry(ExponentMap exponents, rational count)
+    : exponents_{std::move(exponents)}, count_{count}, is_max_{false} {
+  for (auto it = exponents_.begin(); it != exponents_.end();) {
+    if (it->second == 0)
+      it = exponents_.erase(it);
+    else
+      ++it;
+  }
+  if (count_ == 0 || exponents_.empty()) {
+    exponents_.clear();
     count_ = 0;
   }
 }
 
 AsyCost::AsyCostEntry AsyCost::AsyCostEntry::max() {
-  return AsyCostEntry{std::numeric_limits<size_t>::max(),
-                      std::numeric_limits<size_t>::max(),
-                      std::numeric_limits<intmax_t>::max()};
+  AsyCostEntry e;
+  e.is_max_ = true;
+  e.count_ = std::numeric_limits<intmax_t>::max();
+  return e;
 }
 
 AsyCost::AsyCostEntry const &AsyCost::AsyCostEntry::zero() {
-  static AsyCostEntry const zero_cost = AsyCostEntry{0, 0, 0};
+  static AsyCostEntry const zero_cost{};
   return zero_cost;
 }
 
-size_t AsyCost::AsyCostEntry::occ() const { return occ_; }
-
-size_t AsyCost::AsyCostEntry::virt() const { return virt_; }
+AsyCost::ExponentMap const &AsyCost::AsyCostEntry::exponents() const {
+  return exponents_;
+}
 
 rational AsyCost::AsyCostEntry::count() const { return count_; }
 
 void AsyCost::AsyCostEntry::set_count(rational n) const { count_ = n; }
+
+bool AsyCost::AsyCostEntry::is_zero() const {
+  return !is_max_ && exponents_.empty() && count_ == 0;
+}
+
+bool AsyCost::AsyCostEntry::is_max() const { return is_max_; }
 
 std::ostream &AsyCost::AsyCostEntry::stream_out_rational(std::ostream &os,
                                                          rational const &r) {
@@ -57,9 +72,9 @@ std::ostream &AsyCost::AsyCostEntry::stream_out_rational(std::ostream &os,
 std::string AsyCost::AsyCostEntry::text() const {
   auto oss = std::ostringstream{};
 
-  if (*this == AsyCostEntry::max()) {
+  if (is_max_) {
     oss << "max";
-  } else if (*this == AsyCostEntry::zero()) {
+  } else if (is_zero()) {
     oss << "zero";
   } else {
     auto abs_c = abs(count_);
@@ -70,11 +85,12 @@ std::string AsyCost::AsyCostEntry::text() const {
       AsyCostEntry::stream_out_rational(oss, abs_c);
       oss << "*";
     }
-    oss << (occ_ > 0 ? "O" : "");
-    if (occ_ > 1) oss << "^" << occ_;
-
-    oss << (virt_ > 0 ? "V" : "");
-    if (virt_ > 1) oss << "^" << virt_;
+    // Spaces print in IndexSpace order (by attr, then base_key).
+    for (auto const &[space, exp] : exponents_) {
+      if (exp == 0) continue;
+      oss << toUtf8(space.base_key());
+      if (exp > 1) oss << "^" << exp;
+    }
   }
 
   return oss.str();
@@ -83,9 +99,9 @@ std::string AsyCost::AsyCostEntry::text() const {
 std::string AsyCost::AsyCostEntry::to_latex() const {
   auto oss = std::ostringstream{};
 
-  if (*this == AsyCostEntry::max()) {
+  if (is_max_) {
     oss << "\\texttt{max}";
-  } else if (*this == AsyCostEntry::zero()) {
+  } else if (is_zero()) {
     oss << "\\texttt{zero}";
   } else {
     auto abs_c = abs(count_);
@@ -98,24 +114,45 @@ std::string AsyCost::AsyCostEntry::to_latex() const {
           << "}{"                    //
           << denominator(count_) << "}";
     }
-    oss << (occ_ > 0 ? "O" : "");
-    if (occ_ > 1) {
-      oss << "^{" << occ_ << "}";
-    }
-    oss << (virt_ > 0 ? "V" : "");
-    if (virt_ > 1) {
-      oss << "^{" << virt_ << "}";
+    for (auto const &[space, exp] : exponents_) {
+      if (exp == 0) continue;
+      oss << toUtf8(space.base_key());
+      if (exp > 1) {
+        oss << "^{" << exp << "}";
+      }
     }
   }
   return oss.str();
 }
 
 bool AsyCost::AsyCostEntry::operator<(const AsyCost::AsyCostEntry &rhs) const {
-  return virt() < rhs.virt() || (virt() == rhs.virt() && occ() < rhs.occ());
+  // The max() sentinel is the greatest entry.
+  if (is_max_ != rhs.is_max_) return !is_max_;
+
+  // Order by exponents, space by space, from the greatest IndexSpace (highest
+  // priority) down to the least, using IndexSpace's own ordering. The first
+  // space whose exponents differ decides: a larger exponent on a higher-
+  // priority space makes the entry larger. Entries with identical exponents
+  // on every space are equivalent.
+  auto exp_for = [](ExponentMap const &m, IndexSpace const &s) {
+    auto it = m.find(s);
+    return it == m.end() ? std::size_t{0} : it->second;
+  };
+
+  container::set<IndexSpace> spaces;
+  for (auto const &kv : exponents_) spaces.insert(kv.first);
+  for (auto const &kv : rhs.exponents_) spaces.insert(kv.first);
+
+  for (auto it = spaces.rbegin(); it != spaces.rend(); ++it) {
+    auto const l = exp_for(exponents_, *it);
+    auto const r = exp_for(rhs.exponents_, *it);
+    if (l != r) return l < r;
+  }
+  return false;
 }
 
 bool AsyCost::AsyCostEntry::operator==(const AsyCost::AsyCostEntry &rhs) const {
-  return occ() == rhs.occ() && virt() == rhs.virt();
+  return is_max_ == rhs.is_max_ && exponents_ == rhs.exponents_;
 }
 
 bool AsyCost::AsyCostEntry::operator!=(const AsyCost::AsyCostEntry &rhs) const {
@@ -123,38 +160,37 @@ bool AsyCost::AsyCostEntry::operator!=(const AsyCost::AsyCostEntry &rhs) const {
 }
 
 AsyCost::AsyCost(AsyCostEntry c) {
-  if (c != AsyCostEntry::zero()) cost_.emplace(c);
+  if (!c.is_zero()) cost_.emplace(std::move(c));
 }
 
 AsyCost::AsyCost() : AsyCost{AsyCostEntry::zero()} {}
 
-AsyCost::AsyCost(rational count, size_t nocc, size_t nvirt)
-    : AsyCost{AsyCostEntry{nocc, nvirt, count}} {}
+AsyCost::AsyCost(ExponentMap exponents, rational count)
+    : AsyCost{AsyCostEntry{std::move(exponents), count}} {}
 
-AsyCost::AsyCost(size_t nocc, size_t nvirt) : AsyCost{1, nocc, nvirt} {}
-
-AsyCost::AsyCost(std::pair<size_t, size_t> const &ov)
-    : AsyCost{ov.first, ov.second} {}
-
-double AsyCost::ops(size_t nocc, size_t nvirt) const {
+double AsyCost::ops(ExtentMap const &extents) const {
   double total = 0;
-  for (auto &&c : cost_) {
+  for (auto const &c : cost_) {
+    if (c.is_max()) return std::numeric_limits<double>::infinity();
     double temp = 1;
-    temp *= std::pow(nocc, c.occ());
-    temp *= std::pow(nvirt, c.virt());
-    total += temp > 1 ? boost::numeric_cast<double>(c.count()) * temp : 0;
+    for (auto const &[space, exp] : c.exponents()) {
+      auto it = extents.find(space);
+      std::size_t const extent = (it != extents.end()) ? it->second : 1;
+      temp *= std::pow(static_cast<double>(extent), static_cast<double>(exp));
+    }
+    total += boost::numeric_cast<double>(c.count()) * temp;
   }
   return total;
 }
 
 AsyCost const &AsyCost::max() {
-  static const AsyCost max = AsyCost{AsyCostEntry::max()};
-  return max;
+  static const AsyCost m = AsyCost{AsyCostEntry::max()};
+  return m;
 }
 
 AsyCost const &AsyCost::zero() {
-  static const AsyCost zero = AsyCost{AsyCostEntry::zero()};
-  return zero;
+  static const AsyCost z = AsyCost{AsyCostEntry::zero()};
+  return z;
 }
 
 AsyCost &AsyCost::operator+=(AsyCost const &other) {

--- a/SeQuant/core/asy_cost.hpp
+++ b/SeQuant/core/asy_cost.hpp
@@ -13,10 +13,10 @@ namespace sequant {
 ///
 /// Represents a symbolic asymptotic cost as a polynomial in the sizes of
 /// index spaces. A cost is a sum of terms, each of which is a rational
-/// multiplier times a product of space sizes raised to integer powers.
-/// Spaces are identified by `IndexSpace`; `AsyCost` orders and prints them
-/// using `IndexSpace`'s own ordering and `base_key()`, and never consults an
-/// `IndexSpaceRegistry`.
+/// multiplier times a product of space sizes raised to non-negative integer
+/// powers. Spaces are identified by `IndexSpace`; `AsyCost` orders and prints
+/// them using `IndexSpace`'s own ordering and `base_key()`, and never consults
+/// an `IndexSpaceRegistry`.
 ///
 /// Examples (with `I`, `A` denoting two index spaces):
 ///   - `AsyCost({{I, 2}, {A, 4}})` represents $I^2 A^4$.

--- a/SeQuant/core/asy_cost.hpp
+++ b/SeQuant/core/asy_cost.hpp
@@ -110,9 +110,10 @@ class AsyCost {
 
   ///
   /// Substitute each space in this cost by an extent and evaluate.
-  /// \param extents Map from index space to extent (size). Any space appearing
-  ///                in this cost but missing from `extents` is treated as
-  ///                extent 1 (i.e. contributes a factor of 1).
+  /// \param extents Map from index space to extent (size). Every space
+  ///                appearing in this cost must be present in `extents`.
+  /// \throw sequant::Exception if a space appearing in this cost is missing
+  ///                from `extents`.
   /// \return Numerical value of the cost.
   ///
   [[nodiscard]] double ops(ExtentMap const &extents) const;

--- a/SeQuant/core/asy_cost.hpp
+++ b/SeQuant/core/asy_cost.hpp
@@ -3,30 +3,36 @@
 
 #include <SeQuant/core/container.hpp>
 #include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/space.hpp>
 
 #include <cstddef>
 #include <string>
-#include <utility>
 
 namespace sequant {
 
 ///
-/// Represents a symbolic asymptotic cost in terms of active_occupied
-/// and the rest orbitals.
-/// eg.
-///     - AsyCost{2,4} implies scaling of $O^2V^4$. In other words, the cost
-///       scales by the second power in the number of active_occupied orbitals
-///       and the fourth power in the number of the rest orbitals.
-///     - AsyCost{sequant::rational{1,2}, 2, 4} implies the same scaling as
-///       above except the numeric value obtained by substituting $O$ and $V$
-///       numbers is then halved.
+/// Represents a symbolic asymptotic cost as a polynomial in the sizes of
+/// index spaces. A cost is a sum of terms, each of which is a rational
+/// multiplier times a product of space sizes raised to integer powers.
+/// Spaces are identified by `IndexSpace`; `AsyCost` orders and prints them
+/// using `IndexSpace`'s own ordering and `base_key()`, and never consults an
+/// `IndexSpaceRegistry`.
+///
+/// Examples (with `I`, `A` denoting two index spaces):
+///   - `AsyCost({{I, 2}, {A, 4}})` represents $I^2 A^4$.
+///   - `AsyCost({{I, 2}, {A, 4}}, rational{1, 2})` halves the numeric value
+///     above when extents are substituted.
 ///
 class AsyCost {
+ public:
+  using ExponentMap = container::map<IndexSpace, std::size_t>;
+  using ExtentMap = container::map<IndexSpace, std::size_t>;
+
  private:
   class AsyCostEntry {
-    size_t occ_;              // power of active_occupied
-    size_t virt_;             // power of the rest orbitals
-    mutable rational count_;  // count of this asymptotic symbol
+    ExponentMap exponents_;   // space -> power; zero exponents are not stored
+    mutable rational count_;  // multiplier
+    bool is_max_ = false;     // true for the AsyCost::max() sentinel
 
    public:
     static std::ostream &stream_out_rational(std::ostream &os,
@@ -36,7 +42,9 @@ class AsyCost {
 
     static AsyCostEntry const &zero();
 
-    AsyCostEntry(size_t nocc, size_t nvirt, rational count);
+    AsyCostEntry();
+
+    AsyCostEntry(ExponentMap exponents, rational count);
 
     AsyCostEntry(AsyCostEntry const &) = default;
 
@@ -46,13 +54,15 @@ class AsyCost {
 
     AsyCostEntry &operator=(AsyCostEntry &&) = default;
 
-    size_t occ() const;
+    [[nodiscard]] ExponentMap const &exponents() const;
 
-    size_t virt() const;
-
-    rational count() const;
+    [[nodiscard]] rational count() const;
 
     void set_count(rational n) const;
+
+    [[nodiscard]] bool is_zero() const;
+
+    [[nodiscard]] bool is_max() const;
 
     bool operator<(AsyCostEntry const &rhs) const;
 
@@ -60,9 +70,9 @@ class AsyCost {
 
     bool operator!=(AsyCostEntry const &rhs) const;
 
-    std::string text() const;
+    [[nodiscard]] std::string text() const;
 
-    std::string to_latex() const;
+    [[nodiscard]] std::string to_latex() const;
   };
 
  private:
@@ -84,28 +94,11 @@ class AsyCost {
   AsyCost();
 
   ///
-  /// \param count Rational number of times this cost repeats.
-  /// \param nocc Asymptotic scaling exponent in the active occupied orbitals.
-  /// \param nvirt Asymptotic scaling exponent in the active unoccupied
-  ///              orbitals.
+  /// \param exponents Map from index space to its exponent in this term.
+  ///                  Zero exponents may be supplied; they are dropped.
+  /// \param count     Rational multiplier; defaults to 1.
   ///
-  AsyCost(rational count, size_t nocc, size_t nvirt);
-
-  ///
-  /// \param nocc Asymptotic scaling exponent in the active occupied orbitals.
-  /// \param nvirt Asymptotic scaling exponent in the active unoccupied
-  ///              orbitals.
-  ///
-  AsyCost(size_t nocc, size_t nvirt);
-
-  ///
-  ///
-  /// \param ov A pair of size_ts.
-  ///           ov.first is the asymptotic scaling exponent in the active
-  ///           occupied orbitals.
-  ///           ov.second is that in the active unoccupied orbitals
-  ///
-  explicit AsyCost(std::pair<size_t, size_t> const &ov);
+  explicit AsyCost(ExponentMap exponents, rational count = 1);
 
   AsyCost(AsyCost const &) = default;
 
@@ -116,10 +109,13 @@ class AsyCost {
   AsyCost &operator=(AsyCost &&) = default;
 
   ///
-  /// \param nocc Substitute $O$ by nocc.
-  /// \param nvirt Substitute $V$ by nvirt.
-  /// \return Scaled asymptotic cost.
-  [[nodiscard]] double ops(size_t nocc, size_t nvirt) const;
+  /// Substitute each space in this cost by an extent and evaluate.
+  /// \param extents Map from index space to extent (size). Any space appearing
+  ///                in this cost but missing from `extents` is treated as
+  ///                extent 1 (i.e. contributes a factor of 1).
+  /// \return Numerical value of the cost.
+  ///
+  [[nodiscard]] double ops(ExtentMap const &extents) const;
 
   [[nodiscard]] std::wstring to_latex() const;
 

--- a/SeQuant/core/asy_cost.hpp
+++ b/SeQuant/core/asy_cost.hpp
@@ -29,49 +29,80 @@ class AsyCost {
   using ExtentMap = container::map<IndexSpace, std::size_t>;
 
  private:
+  /// A single term of an AsyCost: a rational prefactor times a
+  /// product of index-space sizes raised to per-space exponents, e.g.
+  /// `3/2 * O^2 V^4`.
   class AsyCostEntry {
-    ExponentMap exponents_;   // space -> power; zero exponents are not stored
-    mutable rational count_;  // multiplier
-    bool is_max_ = false;     // true for the AsyCost::max() sentinel
+    ExponentMap exponents_;       // space -> power; zero exponents not stored
+    mutable rational prefactor_;  // rational multiplier
+    bool is_max_ = false;         // true for the AsyCost::max() sentinel
 
    public:
+    /// Write a rational to a stream as `num`, or `num/den` when its
+    /// denominator is not 1.
+    /// \param os Stream to write to.
+    /// \param r Rational to format
+    /// \return `os`
     static std::ostream &stream_out_rational(std::ostream &os,
                                              rational const &r);
 
+    /// \return The sentinel entry representing an infinitely scaling cost; it
+    ///         compares greater than every non-max entry.
     static AsyCostEntry max();
 
+    /// \return The canonical zero entry (no exponents, zero prefactor).
     static AsyCostEntry const &zero();
 
+    /// Constructors
     AsyCostEntry();
-
-    AsyCostEntry(ExponentMap exponents, rational count);
 
     AsyCostEntry(AsyCostEntry const &) = default;
 
     AsyCostEntry(AsyCostEntry &&) = default;
 
+    /// \param exponents Map from index space to its exponent. Zero exponents
+    ///                  are dropped.
+    /// \param prefactor Rational multiplier. If it is zero, or no exponents
+    ///                  remain after dropping zeros, the entry collapses to
+    ///                  zero.
+    AsyCostEntry(ExponentMap exponents, rational prefactor);
+
     AsyCostEntry &operator=(AsyCostEntry const &) = default;
 
     AsyCostEntry &operator=(AsyCostEntry &&) = default;
 
+    /// \return The per-space exponents of this term.
     [[nodiscard]] ExponentMap const &exponents() const;
 
-    [[nodiscard]] rational count() const;
+    /// \return The rational multiplier (prefactor) of this term, e.g. `3/2`
+    ///         in `3/2 * O^2 V^4`.
+    [[nodiscard]] rational prefactor() const;
 
-    void set_count(rational n) const;
+    /// Set the rational multiplier. `const` because the prefactor is not part
+    /// of the term's identity (see \ref operator==).
+    void set_prefactor(rational n) const;
 
+    /// \return Whether this is the zero entry.
     [[nodiscard]] bool is_zero() const;
 
+    /// \return Whether this is the \ref max() sentinel.
     [[nodiscard]] bool is_max() const;
 
+    /// Order by the \ref max() sentinel (greatest), then by total polynomial
+    /// degree (sum of exponents), then space by space from highest- to
+    /// lowest-priority IndexSpace. Independent of the prefactor.
     bool operator<(AsyCostEntry const &rhs) const;
 
+    /// \return Whether two entries share the same monomial (same exponents and
+    ///         max-ness). The prefactor is not compared.
     bool operator==(AsyCostEntry const &rhs) const;
 
     bool operator!=(AsyCostEntry const &rhs) const;
 
+    /// \return A plain-text rendering of this term, e.g. `3/2*O^2V^4`.
     [[nodiscard]] std::string text() const;
 
+    /// \return A LaTeX rendering of this term.
     [[nodiscard]] std::string to_latex() const;
   };
 
@@ -96,9 +127,9 @@ class AsyCost {
   ///
   /// \param exponents Map from index space to its exponent in this term.
   ///                  Zero exponents may be supplied; they are dropped.
-  /// \param count     Rational multiplier; defaults to 1.
+  /// \param prefactor Rational multiplier; defaults to 1.
   ///
-  explicit AsyCost(ExponentMap exponents, rational count = 1);
+  explicit AsyCost(ExponentMap exponents, rational prefactor = 1);
 
   AsyCost(AsyCost const &) = default;
 
@@ -118,8 +149,12 @@ class AsyCost {
   ///
   [[nodiscard]] double ops(ExtentMap const &extents) const;
 
+  /// \return A LaTeX rendering of the whole cost: its terms joined by ` + `,
+  ///         most expensive first. The zero cost renders as `0`.
   [[nodiscard]] std::wstring to_latex() const;
 
+  /// \return A plain-text rendering of the whole cost: its terms joined by
+  ///         ` + `, most expensive first. The zero cost renders as `0`.
   [[nodiscard]] std::string text() const;
 
   AsyCost &operator+=(AsyCost const &);

--- a/SeQuant/core/asy_cost.hpp
+++ b/SeQuant/core/asy_cost.hpp
@@ -141,13 +141,13 @@ class AsyCost {
 
   ///
   /// Substitute each space in this cost by an extent and evaluate.
-  /// \param extents Map from index space to extent (size). Every space
-  ///                appearing in this cost must be present in `extents`.
-  /// \throw sequant::Exception if a space appearing in this cost is missing
-  ///                from `extents`.
+  /// \param extents Map from index space to extent (size). A space appearing
+  ///                in this cost but absent from `extents` falls back to its
+  ///                `IndexSpace::approximate_size()`. Defaults to empty, in
+  ///                which case every space uses its `approximate_size()`.
   /// \return Numerical value of the cost.
   ///
-  [[nodiscard]] double ops(ExtentMap const &extents) const;
+  [[nodiscard]] double ops(ExtentMap const &extents = {}) const;
 
   /// \return A LaTeX rendering of the whole cost: its terms joined by ` + `,
   ///         most expensive first. The zero cost renders as `0`.

--- a/SeQuant/core/eval/cache_manager.hpp
+++ b/SeQuant/core/eval/cache_manager.hpp
@@ -452,9 +452,8 @@ auto cache_manager(meta::eval_node_range auto const& nodes, auto&& is_volatile,
 /// \param expr A Sum whose terms will be evaluated by reusing intermediates.
 /// \param min_repeats Minimum number of repeats for a node to be cached. If not
 /// provided, will use the default of \c cache_manager().
-/// \return AsyCost object that represents the memory in terms of powers of
-///         active occupied and active unoccupied index extents of stored
-///         tensor.
+/// \return AsyCost object representing the peak memory as a polynomial in
+///         the index-space sizes of the stored tensors.
 ///
 AsyCost peak_cache(Sum const& expr,
                    std::optional<size_t> min_repeats = std::nullopt);

--- a/SeQuant/core/eval/eval_node.hpp
+++ b/SeQuant/core/eval/eval_node.hpp
@@ -44,12 +44,18 @@ namespace detail {
 
 enum NodePos { Left = 0, Right, This };
 
-/// Tally indices per IndexSpace appearing in the bra+ket of `t`. AsyCost is
-/// only used for analysis/reporting, so spaces are taken verbatim from the
-/// indices, with no registry lookup.
+/// Tally indices per IndexSpace appearing in the bra+ket+aux of `t`. The aux
+/// slots are included so that auxiliary spaces (e.g. density-fitting/THC) show
+/// up in the cost. AsyCost is only used for analysis/reporting, so spaces are
+/// taken verbatim from the indices, with no registry lookup.
+///
+/// Cost is expressed in terms of whatever IndexSpace each index carries. A
+/// union-space index (e.g. MR hole `I=i∪u`) contributes its union dimension
+/// `|I|=|i|+|u|` as a single symbol: it is not decomposed into base-space (`i`,
+/// `u`, ...) block terms.
 inline AsyCost::ExponentMap space_counts(Tensor const& t) {
   AsyCost::ExponentMap counts;
-  for (auto const& idx : t.const_braket_indices()) ++counts[idx.space()];
+  for (auto const& idx : t.const_braketaux_indices()) ++counts[idx.space()];
   return counts;
 }
 
@@ -65,14 +71,18 @@ class ContractedIndexCount {
     SEQUANT_ASSERT(n->is_tensor() && n.left()->is_tensor() &&
                    n.right()->is_tensor());
 
+    container::set<Index> distinct;
     for (auto p : {L, R, T}) {
       auto const& t = (p == L ? n.left() : p == R ? n.right() : n)->as_tensor();
       counts_[p] = space_counts(t);
       ranks_[p] = 0;
       for (auto const& [_, c] : counts_[p]) ranks_[p] += c;
+      for (auto const& idx : t.const_braketaux_indices()) distinct.insert(idx);
     }
 
     is_outerprod_ = ranks_[L] + ranks_[R] == ranks_[T];
+
+    for (auto const& idx : distinct) ++unique_[idx.space()];
   }
 
   [[nodiscard]] Counts const& counts(NodePos p) const noexcept {
@@ -83,29 +93,14 @@ class ContractedIndexCount {
 
   [[nodiscard]] bool is_outerprod() const noexcept { return is_outerprod_; }
 
-  /// Per-space count of unique indices participating in the contraction:
-  ///   unique[s] = (count_L[s] + count_R[s] + count_T[s]) / 2
-  /// (i.e. each contracted-pair index is counted once).
-  [[nodiscard]] Counts unique_counts() const {
-    Counts result;
-    auto get = [this](NodePos p, IndexSpace const& s) -> size_t {
-      auto it = counts_[p].find(s);
-      return it == counts_[p].end() ? 0 : it->second;
-    };
-    for (auto p : {NodePos::Left, NodePos::Right, NodePos::This}) {
-      for (auto const& [s, _] : counts_[p]) {
-        if (result.count(s)) continue;
-        auto const u = (get(NodePos::Left, s) + get(NodePos::Right, s) +
-                        get(NodePos::This, s)) /
-                       2;
-        if (u > 0) result.emplace(s, u);
-      }
-    }
-    return result;
-  }
+  /// Per-space count of distinct indices participating in the contraction.
+  /// Each external, contracted, or batched index is counted once. For ordinary
+  /// contractions (no batched index) this equals (L[s] + R[s] + T[s]) / 2.
+  [[nodiscard]] Counts const& unique_counts() const { return unique_; }
 
  private:
   std::array<Counts, 3> counts_;
+  Counts unique_;
   std::array<size_t, 3> ranks_{0, 0, 0};
   bool is_outerprod_ = false;
 };

--- a/SeQuant/core/eval/eval_node.hpp
+++ b/SeQuant/core/eval/eval_node.hpp
@@ -71,22 +71,25 @@ class ContractedIndexCount {
     SEQUANT_ASSERT(n->is_tensor() && n.left()->is_tensor() &&
                    n.right()->is_tensor());
 
+    // For the result and both operands, record the tensor's rank and collect
+    // every index into `distinct`. The set dedupes indices shared across
+    // tensors (a contracted index appears in both operands; a batched index in
+    // all three), so each is counted exactly once below.
     container::set<Index> distinct;
     for (auto p : {L, R, T}) {
       auto const& t = (p == L ? n.left() : p == R ? n.right() : n)->as_tensor();
-      counts_[p] = space_counts(t);
+      auto const counts = space_counts(t);
       ranks_[p] = 0;
-      for (auto const& [_, c] : counts_[p]) ranks_[p] += c;
+      for (auto const& [_, c] : counts) ranks_[p] += c;
       for (auto const& idx : t.const_braketaux_indices()) distinct.insert(idx);
     }
 
+    // An outer product contracts nothing, so the result keeps all operand
+    // indices and the ranks add up exactly.
     is_outerprod_ = ranks_[L] + ranks_[R] == ranks_[T];
 
+    // Cost exponent per space = number of distinct indices touching that space.
     for (auto const& idx : distinct) ++unique_[idx.space()];
-  }
-
-  [[nodiscard]] Counts const& counts(NodePos p) const noexcept {
-    return counts_[p];
   }
 
   [[nodiscard]] size_t rank(NodePos p) const noexcept { return ranks_[p]; }
@@ -99,7 +102,6 @@ class ContractedIndexCount {
   [[nodiscard]] Counts const& unique_counts() const { return unique_; }
 
  private:
-  std::array<Counts, 3> counts_;
   Counts unique_;
   std::array<size_t, 3> ranks_{0, 0, 0};
   bool is_outerprod_ = false;

--- a/SeQuant/core/eval/eval_node.hpp
+++ b/SeQuant/core/eval/eval_node.hpp
@@ -10,6 +10,7 @@
 #include <SeQuant/core/eval/eval_expr.hpp>
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/math.hpp>
+#include <SeQuant/core/space.hpp>
 #include <SeQuant/core/utility/macros.hpp>
 
 #include <range/v3/algorithm/count_if.hpp>
@@ -43,19 +44,19 @@ namespace detail {
 
 enum NodePos { Left = 0, Right, This };
 
-[[maybe_unused]] inline std::pair<size_t, size_t> occ_virt(Tensor const& t) {
-  auto bk_rank = t.bra_net_rank() + t.ket_net_rank();
-  auto nocc = ranges::count_if(t.const_braket_indices(), [](Index const& idx) {
-    return idx.space() ==
-           get_default_context().index_space_registry()->hole_space(
-               idx.space().qns());
-  });
-  auto nvirt = bk_rank - nocc;
-  return {nocc, nvirt};
+/// Tally indices per IndexSpace appearing in the bra+ket of `t`. AsyCost is
+/// only used for analysis/reporting, so spaces are taken verbatim from the
+/// indices, with no registry lookup.
+[[maybe_unused]] AsyCost::ExponentMap space_counts(Tensor const& t) {
+  AsyCost::ExponentMap counts;
+  for (auto const& idx : t.const_braket_indices()) ++counts[idx.space()];
+  return counts;
 }
 
 class ContractedIndexCount {
  public:
+  using Counts = AsyCost::ExponentMap;
+
   explicit ContractedIndexCount(meta::eval_node auto const& n) {
     auto const L = NodePos::Left;
     auto const R = NodePos::Right;
@@ -66,45 +67,46 @@ class ContractedIndexCount {
 
     for (auto p : {L, R, T}) {
       auto const& t = (p == L ? n.left() : p == R ? n.right() : n)->as_tensor();
-      std::tie(occs_[p], virts_[p]) = occ_virt(t);
-      ranks_[p] = occs_[p] + virts_[p];
+      counts_[p] = space_counts(t);
+      ranks_[p] = 0;
+      for (auto const& [_, c] : counts_[p]) ranks_[p] += c;
     }
-
-    // no. of contractions in occupied index space (always a whole number)
-    occ_ = (occs_[L] + occs_[R] - occs_[T]) / 2;
-
-    // no. of contractions in virtual index space (always a whole number)
-    virt_ = (virts_[L] + virts_[R] - virts_[T]) / 2;
 
     is_outerprod_ = ranks_[L] + ranks_[R] == ranks_[T];
   }
 
-  [[nodiscard]] size_t occ(NodePos p) const noexcept { return occs_[p]; }
-
-  [[nodiscard]] size_t virt(NodePos p) const noexcept { return virts_[p]; }
+  [[nodiscard]] Counts const& counts(NodePos p) const noexcept {
+    return counts_[p];
+  }
 
   [[nodiscard]] size_t rank(NodePos p) const noexcept { return ranks_[p]; }
 
-  [[nodiscard]] size_t occ() const noexcept { return occ_; }
+  [[nodiscard]] bool is_outerprod() const noexcept { return is_outerprod_; }
 
-  [[nodiscard]] size_t virt() const noexcept { return virt_; }
-
-  [[nodiscard]] bool is_outerpod() const noexcept { return is_outerprod_; }
-
-  [[nodiscard]] size_t unique_occs() const noexcept {
-    return occ(NodePos::Left) + occ(NodePos::Right) - occ();
-  }
-
-  [[nodiscard]] size_t unique_virts() const noexcept {
-    return virt(NodePos::Left) + virt(NodePos::Right) - virt();
+  /// Per-space count of unique indices participating in the contraction:
+  ///   unique[s] = (count_L[s] + count_R[s] + count_T[s]) / 2
+  /// (i.e. each contracted-pair index is counted once).
+  [[nodiscard]] Counts unique_counts() const {
+    Counts result;
+    auto get = [this](NodePos p, IndexSpace const& s) -> size_t {
+      auto it = counts_[p].find(s);
+      return it == counts_[p].end() ? 0 : it->second;
+    };
+    for (auto p : {NodePos::Left, NodePos::Right, NodePos::This}) {
+      for (auto const& [s, _] : counts_[p]) {
+        if (result.count(s)) continue;
+        auto const u = (get(NodePos::Left, s) + get(NodePos::Right, s) +
+                        get(NodePos::This, s)) /
+                       2;
+        if (u > 0) result.emplace(s, u);
+      }
+    }
+    return result;
   }
 
  private:
-  std::array<size_t, 3> occs_{0, 0, 0};
-  std::array<size_t, 3> virts_{0, 0, 0};
+  std::array<Counts, 3> counts_;
   std::array<size_t, 3> ranks_{0, 0, 0};
-  size_t occ_ = 0;
-  size_t virt_ = 0;
   bool is_outerprod_ = false;
 };
 }  // namespace detail
@@ -124,19 +126,19 @@ struct Flops {
         && n.left()->is_tensor()         //
         && n.right()->is_tensor()) {
       if (n->is_tensor()) {
-        auto const idx_count = detail::ContractedIndexCount{n};
-        auto c = AsyCost{idx_count.unique_occs(), idx_count.unique_virts()};
-        return idx_count.is_outerpod() ? c : 2 * c;
+        auto const idx_count = ContractedIndexCount{n};
+        auto c = AsyCost{idx_count.unique_counts()};
+        return idx_count.is_outerprod() ? c : 2 * c;
       } else {  // full contraction to scalar
         SEQUANT_ASSERT(n->is_scalar());
-        SEQUANT_ASSERT(detail::occ_virt(n.left()->as_tensor()) ==
-                       detail::occ_virt(n.right()->as_tensor()));
-        return 2 * AsyCost{detail::occ_virt(n.left()->as_tensor())};
+        SEQUANT_ASSERT(space_counts(n.left()->as_tensor()) ==
+                       space_counts(n.right()->as_tensor()));
+        return 2 * AsyCost{space_counts(n.left()->as_tensor())};
       }
     } else if (n->is_tensor()) {
       // scalar times a tensor
       // or a tensor plus a tensor
-      return AsyCost{detail::occ_virt(n->as_tensor())};
+      return AsyCost{space_counts(n->as_tensor())};
     } else /* scalar (+|*) scalar */
       return AsyCost::zero();
   }
@@ -155,7 +157,7 @@ struct Memory {
   [[nodiscard]] AsyCost operator()(meta::eval_node auto const& n) const {
     AsyCost result;
     auto add_cost = [&result](ExprPtr const& expr) {
-      result += expr.is<Tensor>() ? AsyCost{detail::occ_virt(expr.as<Tensor>())}
+      result += expr.is<Tensor>() ? AsyCost{space_counts(expr.as<Tensor>())}
                                   : AsyCost::zero();
     };
 
@@ -261,15 +263,15 @@ AsyCost min_storage(meta::eval_node auto const& node) {
   auto visitor = [&result](meta::eval_node auto const& n) {
     auto cost = AsyCost::zero();
     if (n.leaf() && n->is_tensor())
-      cost = AsyCost{detail::occ_virt(n->as_tensor())};
+      cost = AsyCost{space_counts(n->as_tensor())};
     else if (!n.leaf()) {
-      cost += (n.left()->is_tensor()
-                   ? AsyCost{detail::occ_virt(n.left()->as_tensor())}
-                   : AsyCost::zero());
+      cost +=
+          (n.left()->is_tensor() ? AsyCost{space_counts(n.left()->as_tensor())}
+                                 : AsyCost::zero());
       cost += (n.right()->is_tensor()
-                   ? AsyCost{detail::occ_virt(n.right()->as_tensor())}
+                   ? AsyCost{space_counts(n.right()->as_tensor())}
                    : AsyCost::zero());
-      cost += (n->is_tensor() ? AsyCost{detail::occ_virt(n->as_tensor())}
+      cost += (n->is_tensor() ? AsyCost{space_counts(n->as_tensor())}
                               : AsyCost::zero());
     } else {
       // do nothing

--- a/SeQuant/core/eval/eval_node.hpp
+++ b/SeQuant/core/eval/eval_node.hpp
@@ -92,8 +92,6 @@ class ContractedIndexCount {
     for (auto const& idx : distinct) ++unique_[idx.space()];
   }
 
-  [[nodiscard]] size_t rank(NodePos p) const noexcept { return ranks_[p]; }
-
   [[nodiscard]] bool is_outerprod() const noexcept { return is_outerprod_; }
 
   /// Per-space count of distinct indices participating in the contraction.

--- a/SeQuant/core/eval/eval_node.hpp
+++ b/SeQuant/core/eval/eval_node.hpp
@@ -47,7 +47,7 @@ enum NodePos { Left = 0, Right, This };
 /// Tally indices per IndexSpace appearing in the bra+ket of `t`. AsyCost is
 /// only used for analysis/reporting, so spaces are taken verbatim from the
 /// indices, with no registry lookup.
-[[maybe_unused]] AsyCost::ExponentMap space_counts(Tensor const& t) {
+inline AsyCost::ExponentMap space_counts(Tensor const& t) {
   AsyCost::ExponentMap counts;
   for (auto const& idx : t.const_braket_indices()) ++counts[idx.space()];
   return counts;
@@ -121,12 +121,13 @@ class ContractedIndexCount {
 ///
 struct Flops {
   [[nodiscard]] AsyCost operator()(meta::eval_node auto const& n) const {
+    using detail::space_counts;
     if (n.leaf()) return AsyCost::zero();
     if (n->op_type() == EvalOp::Product  //
         && n.left()->is_tensor()         //
         && n.right()->is_tensor()) {
       if (n->is_tensor()) {
-        auto const idx_count = ContractedIndexCount{n};
+        auto const idx_count = detail::ContractedIndexCount{n};
         auto c = AsyCost{idx_count.unique_counts()};
         return idx_count.is_outerprod() ? c : 2 * c;
       } else {  // full contraction to scalar
@@ -157,8 +158,9 @@ struct Memory {
   [[nodiscard]] AsyCost operator()(meta::eval_node auto const& n) const {
     AsyCost result;
     auto add_cost = [&result](ExprPtr const& expr) {
-      result += expr.is<Tensor>() ? AsyCost{space_counts(expr.as<Tensor>())}
-                                  : AsyCost::zero();
+      result += expr.is<Tensor>()
+                    ? AsyCost{detail::space_counts(expr.as<Tensor>())}
+                    : AsyCost::zero();
     };
 
     // Adjoint is unary — the right child is the Constant(1) sentinel (zero
@@ -259,6 +261,7 @@ AsyCost asy_cost(Node const& node, F const& cost_fn = {}) {
 /// \return The minimum storage required for evaluating the given node.
 ///
 AsyCost min_storage(meta::eval_node auto const& node) {
+  using detail::space_counts;
   auto result = AsyCost::zero();
   auto visitor = [&result](meta::eval_node auto const& n) {
     auto cost = AsyCost::zero();

--- a/tests/unit/test_asy_cost.cpp
+++ b/tests/unit/test_asy_cost.cpp
@@ -3,7 +3,6 @@
 #include <SeQuant/core/asy_cost.hpp>
 #include <SeQuant/core/rational.hpp>
 #include <SeQuant/core/space.hpp>
-#include <SeQuant/core/utility/exception.hpp>
 
 #include "catch2_sequant.hpp"
 
@@ -219,9 +218,23 @@ TEST_CASE("asy_cost", "[AsyCost]") {
                           std::pow(7.0, 1);
     REQUIRE(c.ops(ext) == expected);
 
-    // Missing extent for a space the cost depends on is an error.
+    // A space absent from the extent map falls back to its approximate_size().
+    // Here K (exponent 2) is omitted, so its approximate_size() is used.
     AsyCost::ExtentMap const ext2{{O, 10}, {V, 100}, {U, 5}, {Q, 7}};
-    REQUIRE_THROWS_AS(c.ops(ext2), sequant::Exception);
+    auto const expected2 =
+        std::pow(10.0, 2) * std::pow(5.0, 1) * std::pow(100.0, 3) *
+        std::pow(static_cast<double>(K.approximate_size()), 2) *
+        std::pow(7.0, 1);
+    REQUIRE(c.ops(ext2) == expected2);
+
+    // With no extents supplied, every space uses its approximate_size().
+    auto const expected_default =
+        std::pow(static_cast<double>(O.approximate_size()), 2) *
+        std::pow(static_cast<double>(U.approximate_size()), 1) *
+        std::pow(static_cast<double>(V.approximate_size()), 3) *
+        std::pow(static_cast<double>(K.approximate_size()), 2) *
+        std::pow(static_cast<double>(Q.approximate_size()), 1);
+    REQUIRE(c.ops() == expected_default);
 
     // Ordering is by total degree (sum of exponents) first: the overall
     // polynomial / worst-case scaling dominates regardless of which spaces

--- a/tests/unit/test_asy_cost.cpp
+++ b/tests/unit/test_asy_cost.cpp
@@ -2,6 +2,7 @@
 
 #include <SeQuant/core/asy_cost.hpp>
 #include <SeQuant/core/rational.hpp>
+#include <SeQuant/core/space.hpp>
 
 #include "catch2_sequant.hpp"
 
@@ -9,6 +10,9 @@
 #include <cstddef>
 #include <string>
 
+namespace {
+
+// Numerical reference for ops() given two-space costs.
 struct MatFlops {
   double occ_range_size;
   double virt_range_size;
@@ -20,70 +24,87 @@ struct MatFlops {
   }
 };
 
+// Two distinct index spaces used to build occupied/virtual costs. The type
+// bits make `virt_space` order above `occ_space`, so the virtual exponent
+// dominates cost comparison (and base_key drives how each space prints).
+sequant::IndexSpace const occ_space{L"O", 0b01};
+sequant::IndexSpace const virt_space{L"V", 0b10};
+
+sequant::AsyCost::ExponentMap ov(std::size_t nocc, std::size_t nvirt) {
+  sequant::AsyCost::ExponentMap m;
+  if (nocc > 0) m.emplace(occ_space, nocc);
+  if (nvirt > 0) m.emplace(virt_space, nvirt);
+  return m;
+}
+
+}  // namespace
+
 TEST_CASE("asy_cost", "[AsyCost]") {
   using sequant::AsyCost;
   using sequant::rational;
 
   SECTION("to_text") {
-    REQUIRE(AsyCost{0, 0}.text() == "0");
+    REQUIRE(AsyCost{ov(0, 0)}.text() == "0");
 
     REQUIRE(AsyCost{}.text() == "0");
 
-    REQUIRE(AsyCost{1, 0}.text() == "O");
+    REQUIRE(AsyCost{ov(1, 0)}.text() == "O");
 
-    REQUIRE(AsyCost{0, 1}.text() == "V");
+    REQUIRE(AsyCost{ov(0, 1)}.text() == "V");
 
-    REQUIRE(AsyCost{1, 1}.text() == "OV");
+    REQUIRE(AsyCost{ov(1, 1)}.text() == "OV");
 
-    REQUIRE(AsyCost{2, 1}.text() == "O^2V");
+    REQUIRE(AsyCost{ov(2, 1)}.text() == "O^2V");
 
-    REQUIRE(AsyCost{1, 2}.text() == "OV^2");
+    REQUIRE(AsyCost{ov(1, 2)}.text() == "OV^2");
 
-    REQUIRE(AsyCost{2, 2}.text() == "O^2V^2");
+    REQUIRE(AsyCost{ov(2, 2)}.text() == "O^2V^2");
 
-    auto c = AsyCost{2, 2} + AsyCost{3, 2} + AsyCost{2, 3} + AsyCost{3, 3};
+    auto c = AsyCost{ov(2, 2)} + AsyCost{ov(3, 2)} + AsyCost{ov(2, 3)} +
+             AsyCost{ov(3, 3)};
     REQUIRE(c.text() == "O^3V^3 + O^2V^3 + O^3V^2 + O^2V^2");
 
-    c = AsyCost{1, 1} - AsyCost{2, 3} + AsyCost{2, 2};
+    c = AsyCost{ov(1, 1)} - AsyCost{ov(2, 3)} + AsyCost{ov(2, 2)};
     REQUIRE(c.text() == "- O^2V^3 + O^2V^2 + OV");
 
-    REQUIRE(AsyCost{20, 1, 1}.text() == "20*OV");
+    REQUIRE(AsyCost{ov(1, 1), 20}.text() == "20*OV");
 
-    REQUIRE(AsyCost{0, 0} == AsyCost::zero());
+    REQUIRE(AsyCost{ov(0, 0)} == AsyCost::zero());
 
-    REQUIRE(AsyCost{0, 1, 1} == AsyCost::zero());
+    REQUIRE(AsyCost{ov(1, 1), 0} == AsyCost::zero());
   }
 
   SECTION("Comparisons") {
-    auto const c1 = AsyCost{0, 0};
-    auto const c2 = AsyCost{0, 1};
-    auto const c3 = AsyCost{0, 2};
-    auto const c4 = AsyCost{0, 2};
+    auto const c1 = AsyCost{ov(0, 0)};
+    auto const c2 = AsyCost{ov(0, 1)};
+    auto const c3 = AsyCost{ov(0, 2)};
+    auto const c4 = AsyCost{ov(0, 2)};
 
     REQUIRE(c1 == AsyCost::zero());
 
     REQUIRE(c1 < c2);
-    REQUIRE(c1 <= c2);
-
-    REQUIRE(c2 > c1);
-    REQUIRE(c2 >= c1);
+    REQUIRE_FALSE(c1 == c2);
 
     REQUIRE(c2 < c3);
-    REQUIRE(c3 > c2);
+    REQUIRE_FALSE(c2 == c3);
+
+    REQUIRE(c1 < c3);
+    REQUIRE_FALSE(c1 == c3);
 
     REQUIRE(c3 == c4);
 
-    auto const cc1 = AsyCost{4, 1} + AsyCost{3, 2} + AsyCost{4, 2};
-    auto const cc2 = AsyCost{2, 2} + (AsyCost{2, 4} + AsyCost{2, 4});
+    auto const cc1 = AsyCost{ov(4, 1)} + AsyCost{ov(3, 2)} + AsyCost{ov(4, 2)};
+    auto const cc2 =
+        AsyCost{ov(2, 2)} + (AsyCost{ov(2, 4)} + AsyCost{ov(2, 4)});
     REQUIRE(cc1 < cc2);
     REQUIRE_FALSE(cc2 < cc1);
     REQUIRE(cc2 > cc1);
   }
 
   SECTION("Addition and subtraction") {
-    auto const c1 = AsyCost{0, 0};
-    auto const c2 = AsyCost{0, 1};
-    auto const c3 = AsyCost{1, 2};
+    auto const c1 = AsyCost{ov(0, 0)};
+    auto const c2 = AsyCost{ov(0, 1)};
+    auto const c3 = AsyCost{ov(1, 2)};
     REQUIRE(c1 + c2 == c2);
     REQUIRE(c1 - c2 == -1 * c2);
     REQUIRE((c2 + c3).text() == "OV^2 + V");
@@ -92,9 +113,9 @@ TEST_CASE("asy_cost", "[AsyCost]") {
   }
 
   SECTION("Assignments") {
-    auto c1 = AsyCost{0, 0};
-    auto c2 = AsyCost{0, 1};
-    auto c3 = AsyCost{1, 2};
+    auto c1 = AsyCost{ov(0, 0)};
+    auto c2 = AsyCost{ov(0, 1)};
+    auto c3 = AsyCost{ov(1, 2)};
     c2 += c1;
     REQUIRE(c2.text() == "V");
     c2 -= c1;
@@ -103,47 +124,105 @@ TEST_CASE("asy_cost", "[AsyCost]") {
     REQUIRE(c2.text() == "OV^2 + V");
     c2 -= c3;
     REQUIRE(c2.text() == "V");
-    c2 += c2;
-    REQUIRE(c2.text() == "2*V");
+    c2 -= c3;
+    REQUIRE(c2.text() == "- OV^2 + V");
   }
 
   SECTION("Ops count") {
-    const size_t nocc = 2;
-    const size_t nvirt = 20;
+    const std::size_t nocc = 2;
+    const std::size_t nvirt = 20;
 
-    auto flops = MatFlops{nocc, nvirt};
-    REQUIRE(AsyCost::zero().ops(nocc, nvirt) == 0);
+    AsyCost::ExtentMap const ext{{occ_space, nocc}, {virt_space, nvirt}};
+    auto flops =
+        MatFlops{static_cast<double>(nocc), static_cast<double>(nvirt)};
+    REQUIRE(AsyCost::zero().ops(ext) == 0);
 
-    REQUIRE(AsyCost{2, 3}.ops(nocc, nvirt) == flops(2, 3));
+    REQUIRE(AsyCost{ov(2, 3)}.ops(ext) == flops(2, 3));
 
-    auto const cost = AsyCost{3, 1} + AsyCost{2, 1};
-    REQUIRE(cost.ops(nocc, nvirt) == flops(3, 1) + flops(2, 1));
+    auto const cost = AsyCost{ov(3, 1)} + AsyCost{ov(2, 1)};
+    REQUIRE(cost.ops(ext) == flops(3, 1) + flops(2, 1));
   }
 
   SECTION("Fractional costs") {
-    auto c0 = AsyCost{{1, 2}, 2, 4};
+    auto c0 = AsyCost{ov(2, 4), rational{1, 2}};
     REQUIRE(c0.text() == "1/2*O^2V^4");
 
-    auto const c1 = AsyCost{1, 2} * rational{2, 3};
+    auto const c1 = AsyCost{ov(1, 2)} * rational{2, 3};
     REQUIRE(c1.text() == "2/3*OV^2");
 
-    auto const c2 = AsyCost{1, 2} / rational{2, 3};
+    auto const c2 = AsyCost{ov(1, 2)} / rational{2, 3};
     REQUIRE(c2.text() == "3/2*OV^2");
 
-    auto const c3 = (AsyCost{1, 2} + AsyCost{2, 4}) * 2;
+    auto const c3 = (AsyCost{ov(1, 2)} + AsyCost{ov(2, 4)}) * 2;
     REQUIRE(c3.text() == "2*O^2V^4 + 2*OV^2");
   }
 
   SECTION("LaTeX") {
-    auto cost = AsyCost{{1, 4}, 2, 3};
+    auto cost = AsyCost{ov(2, 3), rational{1, 4}};
     REQUIRE(cost.to_latex() == L"\\frac{1}{4}O^{2}V^{3}");
-    cost = AsyCost{2, 3};
+    cost = AsyCost{ov(2, 3)};
     REQUIRE(cost.to_latex() == L"O^{2}V^{3}");
-    cost = AsyCost{{1, 1}, 2, 3};
+    cost = AsyCost{ov(2, 3), rational{1, 1}};
     REQUIRE(cost.to_latex() == L"O^{2}V^{3}");
-    cost = AsyCost{{-1, 1}, 2, 3};
+    cost = AsyCost{ov(2, 3), rational{-1, 1}};
     REQUIRE(cost.to_latex() == L"- O^{2}V^{3}");
-    cost = AsyCost{{-1, 4}, 2, 3};
+    cost = AsyCost{ov(2, 3), rational{-1, 4}};
     REQUIRE(cost.to_latex() == L"- \\frac{1}{4}O^{2}V^{3}");
+  }
+
+  SECTION("generalized spaces") {
+    using sequant::IndexSpace;
+    // Exercise > 2 spaces, including one whose base_key is multi-character.
+    // Type bits set the ordering O < U < V < K < Q.
+    IndexSpace const O{L"O", 0b00001};
+    IndexSpace const U{L"U", 0b00010};
+    IndexSpace const V{L"V", 0b00100};
+    IndexSpace const K{L"K", 0b01000};
+    IndexSpace const Q{L"(qq)", 0b10000};
+
+    AsyCost::ExponentMap m;
+    m.emplace(O, 2);
+    m.emplace(U, 1);
+    m.emplace(V, 3);
+    m.emplace(K, 2);
+    m.emplace(Q, 1);
+    auto const c = AsyCost{m};
+
+    auto const tex = c.to_latex();
+    REQUIRE(tex.find(L"O^{2}") != std::wstring::npos);
+    REQUIRE(tex.find(L"V^{3}") != std::wstring::npos);
+    REQUIRE(tex.find(L"K^{2}") != std::wstring::npos);
+    REQUIRE(tex.find(L"(qq)") != std::wstring::npos);
+    REQUIRE(tex.find(L"U^{") == std::wstring::npos);     // exp 1: no caret
+    REQUIRE(tex.find(L"(qq)^{") == std::wstring::npos);  // exp 1: no caret
+
+    // Equal costs constructed in two different orders compare equal.
+    AsyCost::ExponentMap m2;
+    m2.emplace(K, 2);
+    m2.emplace(Q, 1);
+    m2.emplace(V, 3);
+    m2.emplace(O, 2);
+    m2.emplace(U, 1);
+    REQUIRE(AsyCost{m2} == c);
+
+    // Numerical evaluation with explicit extents.
+    AsyCost::ExtentMap const ext{{O, 10}, {V, 100}, {U, 5}, {K, 500}, {Q, 7}};
+    auto const expected = std::pow(10.0, 2) * std::pow(5.0, 1) *
+                          std::pow(100.0, 3) * std::pow(500.0, 2) *
+                          std::pow(7.0, 1);
+    REQUIRE(c.ops(ext) == expected);
+
+    // Missing extent for K falls back to 1.
+    AsyCost::ExtentMap const ext2{{O, 10}, {V, 100}, {U, 5}, {Q, 7}};
+    auto const expected2 = std::pow(10.0, 2) * std::pow(5.0, 1) *
+                           std::pow(100.0, 3) * 1.0 * std::pow(7.0, 1);
+    REQUIRE(c.ops(ext2) == expected2);
+
+    // Ordering follows IndexSpace priority (highest space dominates): with
+    // K > V > U > O, a larger K-exponent makes a cost larger regardless of
+    // the lower spaces.
+    AsyCost const heavy_k{AsyCost::ExponentMap{{O, 4}, {K, 3}}};
+    AsyCost const light_k{AsyCost::ExponentMap{{O, 9}, {K, 2}}};
+    REQUIRE(light_k < heavy_k);
   }
 }

--- a/tests/unit/test_asy_cost.cpp
+++ b/tests/unit/test_asy_cost.cpp
@@ -218,11 +218,17 @@ TEST_CASE("asy_cost", "[AsyCost]") {
                            std::pow(100.0, 3) * 1.0 * std::pow(7.0, 1);
     REQUIRE(c.ops(ext2) == expected2);
 
-    // Ordering follows IndexSpace priority (highest space dominates): with
-    // K > V > U > O, a larger K-exponent makes a cost larger regardless of
-    // the lower spaces.
-    AsyCost const heavy_k{AsyCost::ExponentMap{{O, 4}, {K, 3}}};
-    AsyCost const light_k{AsyCost::ExponentMap{{O, 9}, {K, 2}}};
-    REQUIRE(light_k < heavy_k);
+    // Ordering is by total degree (sum of exponents) first: the overall
+    // polynomial / worst-case scaling dominates regardless of which spaces
+    // carry the exponents.
+    AsyCost const deg7{AsyCost::ExponentMap{{O, 4}, {K, 3}}};   // sum 7
+    AsyCost const deg11{AsyCost::ExponentMap{{O, 9}, {K, 2}}};  // sum 11
+    REQUIRE(deg7 < deg11);
+
+    // Among equal total degrees, IndexSpace priority breaks the tie: with
+    // K > O, a larger K-exponent makes the cost larger.
+    AsyCost const big_k{AsyCost::ExponentMap{{O, 1}, {K, 3}}};    // sum 4
+    AsyCost const small_k{AsyCost::ExponentMap{{O, 3}, {K, 1}}};  // sum 4
+    REQUIRE(small_k < big_k);
   }
 }

--- a/tests/unit/test_asy_cost.cpp
+++ b/tests/unit/test_asy_cost.cpp
@@ -3,6 +3,7 @@
 #include <SeQuant/core/asy_cost.hpp>
 #include <SeQuant/core/rational.hpp>
 #include <SeQuant/core/space.hpp>
+#include <SeQuant/core/utility/exception.hpp>
 
 #include "catch2_sequant.hpp"
 
@@ -212,11 +213,9 @@ TEST_CASE("asy_cost", "[AsyCost]") {
                           std::pow(7.0, 1);
     REQUIRE(c.ops(ext) == expected);
 
-    // Missing extent for K falls back to 1.
+    // Missing extent for a space the cost depends on is an error.
     AsyCost::ExtentMap const ext2{{O, 10}, {V, 100}, {U, 5}, {Q, 7}};
-    auto const expected2 = std::pow(10.0, 2) * std::pow(5.0, 1) *
-                           std::pow(100.0, 3) * 1.0 * std::pow(7.0, 1);
-    REQUIRE(c.ops(ext2) == expected2);
+    REQUIRE_THROWS_AS(c.ops(ext2), sequant::Exception);
 
     // Ordering is by total degree (sum of exponents) first: the overall
     // polynomial / worst-case scaling dominates regardless of which spaces

--- a/tests/unit/test_asy_cost.cpp
+++ b/tests/unit/test_asy_cost.cpp
@@ -31,11 +31,16 @@ struct MatFlops {
 sequant::IndexSpace const occ_space{L"O", 0b01};
 sequant::IndexSpace const virt_space{L"V", 0b10};
 
-sequant::AsyCost::ExponentMap ov(std::size_t nocc, std::size_t nvirt) {
+sequant::AsyCost occ_virt_cost(sequant::rational prefactor, std::size_t nocc,
+                               std::size_t nvirt) {
   sequant::AsyCost::ExponentMap m;
   if (nocc > 0) m.emplace(occ_space, nocc);
   if (nvirt > 0) m.emplace(virt_space, nvirt);
-  return m;
+  return sequant::AsyCost{m, prefactor};
+}
+
+sequant::AsyCost occ_virt_cost(std::size_t nocc, std::size_t nvirt) {
+  return occ_virt_cost(1, nocc, nvirt);
 }
 
 }  // namespace
@@ -45,41 +50,41 @@ TEST_CASE("asy_cost", "[AsyCost]") {
   using sequant::rational;
 
   SECTION("to_text") {
-    REQUIRE(AsyCost{ov(0, 0)}.text() == "0");
+    REQUIRE(occ_virt_cost(0, 0).text() == "0");
 
     REQUIRE(AsyCost{}.text() == "0");
 
-    REQUIRE(AsyCost{ov(1, 0)}.text() == "O");
+    REQUIRE(occ_virt_cost(1, 0).text() == "O");
 
-    REQUIRE(AsyCost{ov(0, 1)}.text() == "V");
+    REQUIRE(occ_virt_cost(0, 1).text() == "V");
 
-    REQUIRE(AsyCost{ov(1, 1)}.text() == "OV");
+    REQUIRE(occ_virt_cost(1, 1).text() == "OV");
 
-    REQUIRE(AsyCost{ov(2, 1)}.text() == "O^2V");
+    REQUIRE(occ_virt_cost(2, 1).text() == "O^2V");
 
-    REQUIRE(AsyCost{ov(1, 2)}.text() == "OV^2");
+    REQUIRE(occ_virt_cost(1, 2).text() == "OV^2");
 
-    REQUIRE(AsyCost{ov(2, 2)}.text() == "O^2V^2");
+    REQUIRE(occ_virt_cost(2, 2).text() == "O^2V^2");
 
-    auto c = AsyCost{ov(2, 2)} + AsyCost{ov(3, 2)} + AsyCost{ov(2, 3)} +
-             AsyCost{ov(3, 3)};
+    auto c = occ_virt_cost(2, 2) + occ_virt_cost(3, 2) + occ_virt_cost(2, 3) +
+             occ_virt_cost(3, 3);
     REQUIRE(c.text() == "O^3V^3 + O^2V^3 + O^3V^2 + O^2V^2");
 
-    c = AsyCost{ov(1, 1)} - AsyCost{ov(2, 3)} + AsyCost{ov(2, 2)};
+    c = occ_virt_cost(1, 1) - occ_virt_cost(2, 3) + occ_virt_cost(2, 2);
     REQUIRE(c.text() == "- O^2V^3 + O^2V^2 + OV");
 
-    REQUIRE(AsyCost{ov(1, 1), 20}.text() == "20*OV");
+    REQUIRE(occ_virt_cost(20, 1, 1).text() == "20*OV");
 
-    REQUIRE(AsyCost{ov(0, 0)} == AsyCost::zero());
+    REQUIRE(occ_virt_cost(0, 0) == AsyCost::zero());
 
-    REQUIRE(AsyCost{ov(1, 1), 0} == AsyCost::zero());
+    REQUIRE(occ_virt_cost(0, 1, 1) == AsyCost::zero());
   }
 
   SECTION("Comparisons") {
-    auto const c1 = AsyCost{ov(0, 0)};
-    auto const c2 = AsyCost{ov(0, 1)};
-    auto const c3 = AsyCost{ov(0, 2)};
-    auto const c4 = AsyCost{ov(0, 2)};
+    auto const c1 = occ_virt_cost(0, 0);
+    auto const c2 = occ_virt_cost(0, 1);
+    auto const c3 = occ_virt_cost(0, 2);
+    auto const c4 = occ_virt_cost(0, 2);
 
     REQUIRE(c1 == AsyCost::zero());
 
@@ -94,18 +99,19 @@ TEST_CASE("asy_cost", "[AsyCost]") {
 
     REQUIRE(c3 == c4);
 
-    auto const cc1 = AsyCost{ov(4, 1)} + AsyCost{ov(3, 2)} + AsyCost{ov(4, 2)};
+    auto const cc1 =
+        occ_virt_cost(4, 1) + occ_virt_cost(3, 2) + occ_virt_cost(4, 2);
     auto const cc2 =
-        AsyCost{ov(2, 2)} + (AsyCost{ov(2, 4)} + AsyCost{ov(2, 4)});
+        occ_virt_cost(2, 2) + (occ_virt_cost(2, 4) + occ_virt_cost(2, 4));
     REQUIRE(cc1 < cc2);
     REQUIRE_FALSE(cc2 < cc1);
     REQUIRE(cc2 > cc1);
   }
 
   SECTION("Addition and subtraction") {
-    auto const c1 = AsyCost{ov(0, 0)};
-    auto const c2 = AsyCost{ov(0, 1)};
-    auto const c3 = AsyCost{ov(1, 2)};
+    auto const c1 = occ_virt_cost(0, 0);
+    auto const c2 = occ_virt_cost(0, 1);
+    auto const c3 = occ_virt_cost(1, 2);
     REQUIRE(c1 + c2 == c2);
     REQUIRE(c1 - c2 == -1 * c2);
     REQUIRE((c2 + c3).text() == "OV^2 + V");
@@ -114,9 +120,9 @@ TEST_CASE("asy_cost", "[AsyCost]") {
   }
 
   SECTION("Assignments") {
-    auto c1 = AsyCost{ov(0, 0)};
-    auto c2 = AsyCost{ov(0, 1)};
-    auto c3 = AsyCost{ov(1, 2)};
+    auto c1 = occ_virt_cost(0, 0);
+    auto c2 = occ_virt_cost(0, 1);
+    auto c3 = occ_virt_cost(1, 2);
     c2 += c1;
     REQUIRE(c2.text() == "V");
     c2 -= c1;
@@ -138,36 +144,36 @@ TEST_CASE("asy_cost", "[AsyCost]") {
         MatFlops{static_cast<double>(nocc), static_cast<double>(nvirt)};
     REQUIRE(AsyCost::zero().ops(ext) == 0);
 
-    REQUIRE(AsyCost{ov(2, 3)}.ops(ext) == flops(2, 3));
+    REQUIRE(occ_virt_cost(2, 3).ops(ext) == flops(2, 3));
 
-    auto const cost = AsyCost{ov(3, 1)} + AsyCost{ov(2, 1)};
+    auto const cost = occ_virt_cost(3, 1) + occ_virt_cost(2, 1);
     REQUIRE(cost.ops(ext) == flops(3, 1) + flops(2, 1));
   }
 
   SECTION("Fractional costs") {
-    auto c0 = AsyCost{ov(2, 4), rational{1, 2}};
+    auto c0 = occ_virt_cost(rational{1, 2}, 2, 4);
     REQUIRE(c0.text() == "1/2*O^2V^4");
 
-    auto const c1 = AsyCost{ov(1, 2)} * rational{2, 3};
+    auto const c1 = occ_virt_cost(1, 2) * rational{2, 3};
     REQUIRE(c1.text() == "2/3*OV^2");
 
-    auto const c2 = AsyCost{ov(1, 2)} / rational{2, 3};
+    auto const c2 = occ_virt_cost(1, 2) / rational{2, 3};
     REQUIRE(c2.text() == "3/2*OV^2");
 
-    auto const c3 = (AsyCost{ov(1, 2)} + AsyCost{ov(2, 4)}) * 2;
+    auto const c3 = (occ_virt_cost(1, 2) + occ_virt_cost(2, 4)) * 2;
     REQUIRE(c3.text() == "2*O^2V^4 + 2*OV^2");
   }
 
   SECTION("LaTeX") {
-    auto cost = AsyCost{ov(2, 3), rational{1, 4}};
+    auto cost = occ_virt_cost(rational{1, 4}, 2, 3);
     REQUIRE(cost.to_latex() == L"\\frac{1}{4}O^{2}V^{3}");
-    cost = AsyCost{ov(2, 3)};
+    cost = occ_virt_cost(2, 3);
     REQUIRE(cost.to_latex() == L"O^{2}V^{3}");
-    cost = AsyCost{ov(2, 3), rational{1, 1}};
+    cost = occ_virt_cost(rational{1, 1}, 2, 3);
     REQUIRE(cost.to_latex() == L"O^{2}V^{3}");
-    cost = AsyCost{ov(2, 3), rational{-1, 1}};
+    cost = occ_virt_cost(rational{-1, 1}, 2, 3);
     REQUIRE(cost.to_latex() == L"- O^{2}V^{3}");
-    cost = AsyCost{ov(2, 3), rational{-1, 4}};
+    cost = occ_virt_cost(rational{-1, 4}, 2, 3);
     REQUIRE(cost.to_latex() == L"- \\frac{1}{4}O^{2}V^{3}");
   }
 

--- a/tests/unit/test_asy_cost.cpp
+++ b/tests/unit/test_asy_cost.cpp
@@ -202,6 +202,12 @@ TEST_CASE("asy_cost", "[AsyCost]") {
     REQUIRE(tex.find(L"U^{") == std::wstring::npos);     // exp 1: no caret
     REQUIRE(tex.find(L"(qq)^{") == std::wstring::npos);  // exp 1: no caret
 
+    // Pin down the full rendered string, not just substring presence: within a
+    // term the spaces print in IndexSpace order (O < U < V < K < Q), so the
+    // sequence is fixed regardless of construction order.
+    REQUIRE(c.text() == "O^2UV^3K^2(qq)");
+    REQUIRE(c.to_latex() == L"O^{2}UV^{3}K^{2}(qq)");
+
     // Equal costs constructed in two different orders compare equal.
     AsyCost::ExponentMap m2;
     m2.emplace(K, 2);
@@ -248,5 +254,34 @@ TEST_CASE("asy_cost", "[AsyCost]") {
     AsyCost const big_k{AsyCost::ExponentMap{{O, 1}, {K, 3}}};    // sum 4
     AsyCost const small_k{AsyCost::ExponentMap{{O, 3}, {K, 1}}};  // sum 4
     REQUIRE(small_k < big_k);
+
+    // A multi-term cost renders most-expensive-first, which under the new
+    // semantics means highest total degree first. Pinning the full string locks
+    // down the term sequence: deg 4 (O^2K^2) > deg 3 (V^3) > deg 2 (OV).
+    AsyCost const multi =
+        AsyCost{AsyCost::ExponentMap{{O, 1}, {V, 1}}} +  // deg 2
+        AsyCost{AsyCost::ExponentMap{{O, 2}, {K, 2}}} +  // deg 4
+        AsyCost{AsyCost::ExponentMap{{V, 3}}};           // deg 3
+    REQUIRE(multi.text() == "O^2K^2 + V^3 + OV");
+  }
+
+  SECTION("max() sentinel") {
+    using sequant::IndexSpace;
+    IndexSpace const O{L"O", 0b01};
+    IndexSpace const V{L"V", 0b10};
+
+    // max() flows through ops() as infinity, regardless of supplied extents.
+    REQUIRE(std::isinf(AsyCost::max().ops()));
+    AsyCost::ExtentMap const ext{{O, 10}, {V, 100}};
+    REQUIRE(std::isinf(AsyCost::max().ops(ext)));
+
+    // max() is the greatest cost: it compares above any finite cost via the
+    // is_max branch of operator<, and equals itself.
+    auto const finite = AsyCost{AsyCost::ExponentMap{{O, 9}, {V, 9}}};
+    REQUIRE(finite < AsyCost::max());
+    REQUIRE(AsyCost::max() > finite);
+    REQUIRE_FALSE(AsyCost::max() < finite);
+    REQUIRE(AsyCost::max() == AsyCost::max());
+    REQUIRE(AsyCost::max() > AsyCost::zero());
   }
 }

--- a/tests/unit/test_eval_node.cpp
+++ b/tests/unit/test_eval_node.cpp
@@ -14,6 +14,7 @@
 #include <SeQuant/core/io/shorthands.hpp>
 #include <SeQuant/core/rational.hpp>
 #include <SeQuant/core/utility/macros.hpp>
+#include <SeQuant/domain/mbpt/convention.hpp>
 
 #include <initializer_list>
 #include <memory>
@@ -69,6 +70,16 @@ sequant::AsyCost ov(std::size_t nocc, std::size_t nvirt) {
 
 sequant::AsyCost ov(sequant::rational c, std::size_t nocc, std::size_t nvirt) {
   return sequant::AsyCost{ov_map(nocc, nvirt), c};
+}
+
+// Like ov_map, but also accounts for the density-fitting auxiliary space
+// ("Κ", added to the registry by mbpt::add_df_spaces).
+sequant::AsyCost ovx(sequant::rational c, std::size_t nocc, std::size_t nvirt,
+                     std::size_t naux) {
+  auto const& isr = *sequant::get_default_context().index_space_registry();
+  auto m = ov_map(nocc, nvirt);
+  if (naux > 0) m.emplace(isr.retrieve(L"Κ"), naux);
+  return sequant::AsyCost{m, c};
 }
 
 }  // namespace
@@ -345,6 +356,75 @@ TEST_CASE("eval_node", "[EvalNode]") {
     auto const np8 = eval_node(p8);
     REQUIRE(asy_cost(np8) == AsyCost{2, 2, 4});  // 2 * O^2V^4
 #endif
+
+    SECTION("PPL and density-fitting") {
+      // AsyCost on parsed coupled-cluster expressions, using the plain Flops
+      // metric
+      auto isr = mbpt::make_min_sr_spaces();
+      mbpt::add_df_spaces(isr);
+      auto _ =
+          set_scoped_default_context({.index_space_registry_shared_ptr = isr,
+                                      .vacuum = Vacuum::SingleProduct,
+                                      .spbasis = SPBasis::Spinor});
+
+      // The particle-particle ladder term
+      auto const ppl = deserialize(L"g{a3,a4;a1,a2} t{a1,a2;i1,i2}");
+      REQUIRE(sequant::asy_cost(eval_node(ppl)) == ovx(2, 2, 4, 0));
+      REQUIRE(sequant::asy_cost(eval_node(ppl)) == ov(2, 2, 4));
+
+      // Density-fitting splits the rank-4 integral into two rank-3 factors
+      // sharing an auxiliary index, g{a3,a4;a1,a2} -> B{a3;a1;Κ} B{a4;a2;Κ}.
+      // (B{a4;a2;Κ} t{a1,a2;i1,i2}) B{a3;a1;Κ}.
+      auto const pp_ladder_df =
+          deserialize(L"(B{a4;a2;Κ_1} t{a1,a2;i1,i2}) B{a3;a1;Κ_1}");
+      REQUIRE(sequant::asy_cost(eval_node(pp_ladder_df)) == ovx(4, 2, 3, 1));
+    }
+
+    SECTION("batched index") {
+      auto isr = mbpt::make_min_sr_spaces();
+      mbpt::add_batching_spaces(isr);
+      auto _ =
+          set_scoped_default_context({.index_space_registry_shared_ptr = isr,
+                                      .vacuum = Vacuum::SingleProduct,
+                                      .spbasis = SPBasis::Spinor});
+      auto const& reg = *get_default_context().index_space_registry();
+      auto const a = reg.retrieve(L"a");
+      auto const z = reg.retrieve(L"z");
+
+      // A batched index appears in left, right, AND result: it is neither
+      // summed over (like a contracted index) nor unique to one operand (like
+      // an external index). `R{a1;a2;z1} = A{a1;a3;z1} B{a3;a2;z1}` is, for
+      // each fixed z1, the matmul A(a1,a3)·B(a3,a2) -> R(a1,a2) at cost a^3 (a3
+      // is the contracted index); repeating it for every value of z1 multiplies
+      // the cost by |z|. Total: a^3 · z^1. The leading 2 is the per-element
+      // flop count (one multiply + one add).
+      auto const e1 = binarize(
+          deserialize<ResultExpr>(L"R{a1;a2;z1} = A{a1;a3;z1} B{a3;a2;z1}"));
+      REQUIRE(sequant::asy_cost(e1) ==
+              AsyCost{AsyCost::ExponentMap{{a, 3}, {z, 1}}, 2});
+
+      // Two batched indices z1,z2 (both in space z): the a^3 matmul is repeated
+      // for every (z1,z2) pair, so the cost scales as a^3 · z^2.
+      auto const e2 = binarize(deserialize<ResultExpr>(
+          L"R{a1;a2;z1,z2} = A{a1;a3;z1,z2} B{a3;a2;z1,z2}"));
+      REQUIRE(sequant::asy_cost(e2) ==
+              AsyCost{AsyCost::ExponentMap{{a, 3}, {z, 2}}, 2});
+    }
+
+    SECTION("MRCC like example") {
+      auto isr = mbpt::make_min_mr_spaces();
+      auto _ =
+          set_scoped_default_context({.index_space_registry_shared_ptr = isr,
+                                      .vacuum = Vacuum::SingleProduct,
+                                      .spbasis = SPBasis::Spinor});
+      auto const& reg = *get_default_context().index_space_registry();
+      auto const u = reg.retrieve(L"u");  // active
+      auto const a = reg.retrieve(L"a");  // virtual
+
+      auto const n = eval_node(deserialize(L"g{u1,u2;a1,a2} t{a1,a2;u3,u4}"));
+      REQUIRE(sequant::asy_cost(n) ==
+              AsyCost{AsyCost::ExponentMap{{u, 4}, {a, 2}}, 2});  // 2 * u^4 a^2
+    }
   }
 
   SECTION("minimum storage") {

--- a/tests/unit/test_eval_node.cpp
+++ b/tests/unit/test_eval_node.cpp
@@ -54,7 +54,7 @@ sequant::EvalExpr node(sequant::EvalNode<sequant::EvalExpr> const& n,
 
 // Build an IndexSpace-keyed ExponentMap over the SR test registry's hole
 // ("i") and particle ("a") spaces, matching the spaces that
-// `eval_node::space_counts` reads off the corresponding indices.
+// `detail::space_counts` reads off the corresponding indices.
 sequant::AsyCost::ExponentMap ov_map(std::size_t nocc, std::size_t nvirt) {
   auto const& isr = *sequant::get_default_context().index_space_registry();
   sequant::AsyCost::ExponentMap m;

--- a/tests/unit/test_eval_node.cpp
+++ b/tests/unit/test_eval_node.cpp
@@ -56,7 +56,8 @@ sequant::EvalExpr node(sequant::EvalNode<sequant::EvalExpr> const& n,
 // Build an IndexSpace-keyed ExponentMap over the SR test registry's hole
 // ("i") and particle ("a") spaces, matching the spaces that
 // `detail::space_counts` reads off the corresponding indices.
-sequant::AsyCost::ExponentMap ov_map(std::size_t nocc, std::size_t nvirt) {
+sequant::AsyCost::ExponentMap occ_virt_map(std::size_t nocc,
+                                           std::size_t nvirt) {
   auto const& isr = *sequant::get_default_context().index_space_registry();
   sequant::AsyCost::ExponentMap m;
   if (nocc > 0) m.emplace(isr.retrieve(L"i"), nocc);
@@ -64,20 +65,21 @@ sequant::AsyCost::ExponentMap ov_map(std::size_t nocc, std::size_t nvirt) {
   return m;
 }
 
-sequant::AsyCost ov(std::size_t nocc, std::size_t nvirt) {
-  return sequant::AsyCost{ov_map(nocc, nvirt)};
+sequant::AsyCost occ_virt_cost(std::size_t nocc, std::size_t nvirt) {
+  return sequant::AsyCost{occ_virt_map(nocc, nvirt)};
 }
 
-sequant::AsyCost ov(sequant::rational c, std::size_t nocc, std::size_t nvirt) {
-  return sequant::AsyCost{ov_map(nocc, nvirt), c};
+sequant::AsyCost occ_virt_cost(sequant::rational c, std::size_t nocc,
+                               std::size_t nvirt) {
+  return sequant::AsyCost{occ_virt_map(nocc, nvirt), c};
 }
 
-// Like ov_map, but also accounts for the density-fitting auxiliary space
+// Like occ_virt_map, but also accounts for the density-fitting auxiliary space
 // ("Κ", added to the registry by mbpt::add_df_spaces).
-sequant::AsyCost ovx(sequant::rational c, std::size_t nocc, std::size_t nvirt,
-                     std::size_t naux) {
+sequant::AsyCost occ_virt_aux_cost(sequant::rational c, std::size_t nocc,
+                                   std::size_t nvirt, std::size_t naux) {
   auto const& isr = *sequant::get_default_context().index_space_registry();
-  auto m = ov_map(nocc, nvirt);
+  auto m = occ_virt_map(nocc, nvirt);
   if (naux > 0) m.emplace(isr.retrieve(L"Κ"), naux);
   return sequant::AsyCost{m, c};
 }
@@ -274,20 +276,20 @@ TEST_CASE("eval_node", "[EvalNode]") {
     auto asy_cost_single_node = FlopsWithSymm{};
     auto const p1 =
         parse_expr_antisymm(L"g_{i2, a1}^{a2, a3} * t_{a2, a3}^{i1, i2}");
-    REQUIRE(asy_cost_single_node(eval_node(p1)) == ov(2, 2, 3));
+    REQUIRE(asy_cost_single_node(eval_node(p1)) == occ_virt_cost(2, 2, 3));
 
     auto const p2 = parse_expr_antisymm(
         L"g_{i2,i3}^{a2,a3} * t_{a2}^{i1} * t_{a1,a3}^{i2,i3}");
     auto const n2 = eval_node(p2);
 
-    REQUIRE(asy_cost_single_node(n2) == ov(2, 3, 2));
-    REQUIRE(asy_cost_single_node(n2.left()) == ov(2, 3, 2));
+    REQUIRE(asy_cost_single_node(n2) == occ_virt_cost(2, 3, 2));
+    REQUIRE(asy_cost_single_node(n2.left()) == occ_virt_cost(2, 3, 2));
 
     auto const p3 =
         parse_expr_antisymm(L"g_{i2,i3}^{i1,a2} * t_{a2}^{i2} * t_{a1}^{i3}");
     auto const n3 = eval_node(p3);
-    REQUIRE(asy_cost_single_node(n3) == ov(2, 2, 1));
-    REQUIRE(asy_cost_single_node(n3.left()) == ov(2, 3, 1));
+    REQUIRE(asy_cost_single_node(n3) == occ_virt_cost(2, 2, 1));
+    REQUIRE(asy_cost_single_node(n3.left()) == occ_virt_cost(2, 3, 1));
   }
 
   SECTION("asy_cost") {
@@ -296,25 +298,25 @@ TEST_CASE("eval_node", "[EvalNode]") {
     };
     auto const p1 =
         parse_expr_antisymm(L"g_{i2, a1}^{a2, a3} * t_{a2, a3}^{i1, i2}");
-    REQUIRE(asy_cost(eval_node(p1)) == ov(2, 2, 3));
+    REQUIRE(asy_cost(eval_node(p1)) == occ_virt_cost(2, 2, 3));
 
     auto const p2 = parse_expr_antisymm(
         L"g_{i2,i3}^{a2,a3} * t_{a2}^{i1} * t_{a1,a3}^{i2,i3}");
 
     auto const np2 = eval_node(p2);
-    REQUIRE(asy_cost(np2) == ov(2, 3, 2) + ov(2, 3, 2));
+    REQUIRE(asy_cost(np2) == occ_virt_cost(2, 3, 2) + occ_virt_cost(2, 3, 2));
 
     auto const p3 =
         parse_expr_antisymm(L"g_{i2,i3}^{i1,a2} * t_{a2}^{i2} * t_{a1}^{i3}");
     auto const np3 = eval_node(p3);
-    REQUIRE(asy_cost(np3) == ov(2, 2, 1) + ov(2, 3, 1));
+    REQUIRE(asy_cost(np3) == occ_virt_cost(2, 2, 1) + occ_virt_cost(2, 3, 1));
 
     // full contraction to scalar: cc energy-like expression
     auto const p_e = parse_expr_antisymm(
         L"f_{i1}^{a1} * t_{a1}^{i1} + g_{i1,i2}^{a1,a2} * t_{a1,a2}^{i1,i2}");
     auto const n_e = eval_node(p_e);
     REQUIRE(n_e->is_scalar());
-    REQUIRE(asy_cost(n_e) == 2 * ov(2, 2) + 2 * ov(1, 1));
+    REQUIRE(asy_cost(n_e) == 2 * occ_virt_cost(2, 2) + 2 * occ_virt_cost(1, 1));
 
 #if 0
     auto const s1 =
@@ -369,15 +371,17 @@ TEST_CASE("eval_node", "[EvalNode]") {
 
       // The particle-particle ladder term
       auto const ppl = deserialize(L"g{a3,a4;a1,a2} t{a1,a2;i1,i2}");
-      REQUIRE(sequant::asy_cost(eval_node(ppl)) == ovx(2, 2, 4, 0));
-      REQUIRE(sequant::asy_cost(eval_node(ppl)) == ov(2, 2, 4));
+      REQUIRE(sequant::asy_cost(eval_node(ppl)) ==
+              occ_virt_aux_cost(2, 2, 4, 0));
+      REQUIRE(sequant::asy_cost(eval_node(ppl)) == occ_virt_cost(2, 2, 4));
 
       // Density-fitting splits the rank-4 integral into two rank-3 factors
       // sharing an auxiliary index, g{a3,a4;a1,a2} -> B{a3;a1;Κ} B{a4;a2;Κ}.
       // (B{a4;a2;Κ} t{a1,a2;i1,i2}) B{a3;a1;Κ}.
       auto const pp_ladder_df =
           deserialize(L"(B{a4;a2;Κ_1} t{a1,a2;i1,i2}) B{a3;a1;Κ_1}");
-      REQUIRE(sequant::asy_cost(eval_node(pp_ladder_df)) == ovx(4, 2, 3, 1));
+      REQUIRE(sequant::asy_cost(eval_node(pp_ladder_df)) ==
+              occ_virt_aux_cost(4, 2, 3, 1));
     }
 
     SECTION("batched index") {
@@ -438,10 +442,12 @@ TEST_CASE("eval_node", "[EvalNode]") {
     // - scaling of I requires OV + OV = 2 * OV.
     // The maximum of the two steps is OV^3 + O^2V^2 + OV, which is the minimum
     // storage requirement.
-    REQUIRE(min_storage(n1) == ov(1, 3) + ov(2, 2) + ov(1, 1));
+    REQUIRE(min_storage(n1) ==
+            occ_virt_cost(1, 3) + occ_virt_cost(2, 2) + occ_virt_cost(1, 1));
 
     auto p2 = deserialize(L"1/2 * (g{a1,a2; a3,a4} t{a3;i1}) t{a4;i2}");
     auto const n2 = eval_node(p2);
-    REQUIRE(min_storage(n2) == ov(0, 4) + ov(1, 3) + ov(1, 1));
+    REQUIRE(min_storage(n2) ==
+            occ_virt_cost(0, 4) + occ_virt_cost(1, 3) + occ_virt_cost(1, 1));
   }
 }

--- a/tests/unit/test_eval_node.cpp
+++ b/tests/unit/test_eval_node.cpp
@@ -6,9 +6,11 @@
 #include <SeQuant/core/attr.hpp>
 #include <SeQuant/core/binary_node.hpp>
 #include <SeQuant/core/container.hpp>
+#include <SeQuant/core/context.hpp>
 #include <SeQuant/core/eval/eval_expr.hpp>
 #include <SeQuant/core/eval/eval_node.hpp>
 #include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/index_space_registry.hpp>
 #include <SeQuant/core/io/shorthands.hpp>
 #include <SeQuant/core/rational.hpp>
 #include <SeQuant/core/utility/macros.hpp>
@@ -48,6 +50,25 @@ sequant::EvalExpr node(sequant::EvalNode<sequant::EvalExpr> const& n,
 [[maybe_unused]] std::wstring tikz(
     sequant::EvalNode<sequant::EvalExpr> const& n) noexcept {
   return n.tikz([](auto&& n) { return L"$" + n->expr()->to_latex() + L"$"; });
+}
+
+// Build an IndexSpace-keyed ExponentMap over the SR test registry's hole
+// ("i") and particle ("a") spaces, matching the spaces that
+// `eval_node::space_counts` reads off the corresponding indices.
+sequant::AsyCost::ExponentMap ov_map(std::size_t nocc, std::size_t nvirt) {
+  auto const& isr = *sequant::get_default_context().index_space_registry();
+  sequant::AsyCost::ExponentMap m;
+  if (nocc > 0) m.emplace(isr.retrieve(L"i"), nocc);
+  if (nvirt > 0) m.emplace(isr.retrieve(L"a"), nvirt);
+  return m;
+}
+
+sequant::AsyCost ov(std::size_t nocc, std::size_t nvirt) {
+  return sequant::AsyCost{ov_map(nocc, nvirt)};
+}
+
+sequant::AsyCost ov(sequant::rational c, std::size_t nocc, std::size_t nvirt) {
+  return sequant::AsyCost{ov_map(nocc, nvirt), c};
 }
 
 }  // namespace
@@ -242,20 +263,20 @@ TEST_CASE("eval_node", "[EvalNode]") {
     auto asy_cost_single_node = FlopsWithSymm{};
     auto const p1 =
         parse_expr_antisymm(L"g_{i2, a1}^{a2, a3} * t_{a2, a3}^{i1, i2}");
-    REQUIRE(asy_cost_single_node(eval_node(p1)) == AsyCost{2, 2, 3});
+    REQUIRE(asy_cost_single_node(eval_node(p1)) == ov(2, 2, 3));
 
     auto const p2 = parse_expr_antisymm(
         L"g_{i2,i3}^{a2,a3} * t_{a2}^{i1} * t_{a1,a3}^{i2,i3}");
     auto const n2 = eval_node(p2);
 
-    REQUIRE(asy_cost_single_node(n2) == AsyCost{2, 3, 2});
-    REQUIRE(asy_cost_single_node(n2.left()) == AsyCost{2, 3, 2});
+    REQUIRE(asy_cost_single_node(n2) == ov(2, 3, 2));
+    REQUIRE(asy_cost_single_node(n2.left()) == ov(2, 3, 2));
 
     auto const p3 =
         parse_expr_antisymm(L"g_{i2,i3}^{i1,a2} * t_{a2}^{i2} * t_{a1}^{i3}");
     auto const n3 = eval_node(p3);
-    REQUIRE(asy_cost_single_node(n3) == AsyCost{2, 2, 1});
-    REQUIRE(asy_cost_single_node(n3.left()) == AsyCost{2, 3, 1});
+    REQUIRE(asy_cost_single_node(n3) == ov(2, 2, 1));
+    REQUIRE(asy_cost_single_node(n3.left()) == ov(2, 3, 1));
   }
 
   SECTION("asy_cost") {
@@ -264,25 +285,25 @@ TEST_CASE("eval_node", "[EvalNode]") {
     };
     auto const p1 =
         parse_expr_antisymm(L"g_{i2, a1}^{a2, a3} * t_{a2, a3}^{i1, i2}");
-    REQUIRE(asy_cost(eval_node(p1)) == AsyCost{2, 2, 3});
+    REQUIRE(asy_cost(eval_node(p1)) == ov(2, 2, 3));
 
     auto const p2 = parse_expr_antisymm(
         L"g_{i2,i3}^{a2,a3} * t_{a2}^{i1} * t_{a1,a3}^{i2,i3}");
 
     auto const np2 = eval_node(p2);
-    REQUIRE(asy_cost(np2) == AsyCost{2, 3, 2} + AsyCost{2, 3, 2});
+    REQUIRE(asy_cost(np2) == ov(2, 3, 2) + ov(2, 3, 2));
 
     auto const p3 =
         parse_expr_antisymm(L"g_{i2,i3}^{i1,a2} * t_{a2}^{i2} * t_{a1}^{i3}");
     auto const np3 = eval_node(p3);
-    REQUIRE(asy_cost(np3) == AsyCost{2, 2, 1} + AsyCost{2, 3, 1});
+    REQUIRE(asy_cost(np3) == ov(2, 2, 1) + ov(2, 3, 1));
 
     // full contraction to scalar: cc energy-like expression
     auto const p_e = parse_expr_antisymm(
         L"f_{i1}^{a1} * t_{a1}^{i1} + g_{i1,i2}^{a1,a2} * t_{a1,a2}^{i1,i2}");
     auto const n_e = eval_node(p_e);
     REQUIRE(n_e->is_scalar());
-    REQUIRE(asy_cost(n_e) == 2 * AsyCost{2, 2} + 2 * AsyCost{1, 1});
+    REQUIRE(asy_cost(n_e) == 2 * ov(2, 2) + 2 * ov(1, 1));
 
 #if 0
     auto const s1 =
@@ -337,10 +358,10 @@ TEST_CASE("eval_node", "[EvalNode]") {
     // - scaling of I requires OV + OV = 2 * OV.
     // The maximum of the two steps is OV^3 + O^2V^2 + OV, which is the minimum
     // storage requirement.
-    REQUIRE(min_storage(n1) == AsyCost{1, 3} + AsyCost{2, 2} + AsyCost{1, 1});
+    REQUIRE(min_storage(n1) == ov(1, 3) + ov(2, 2) + ov(1, 1));
 
     auto p2 = deserialize(L"1/2 * (g{a1,a2; a3,a4} t{a3;i1}) t{a4;i2}");
     auto const n2 = eval_node(p2);
-    REQUIRE(min_storage(n2) == AsyCost{0, 4} + AsyCost{1, 3} + AsyCost{1, 1});
+    REQUIRE(min_storage(n2) == ov(0, 4) + ov(1, 3) + ov(1, 1));
   }
 }


### PR DESCRIPTION
## Generalize `AsyCost` from O/V to arbitrary `IndexSpace`

`AsyCost` previously hard-coded asymptotic cost as a polynomial in exactly two orbital spaces: occupied (O) and virtual (V), with each entry storing a fixed (occ, virt) exponent pair. 

This PR replaces the fixed O/V representation with a general map from `IndexSpace` to integer exponent, so a cost term is now a rational multiplier times a product of arbitrary space sizes raised to integer powers

### Changes
- A cost entry now stores a map from `IndexSpace` to exponent instead of fixed occupied/virtual powers, so any number of spaces is supported.
- Constructors take an exponent map; `ops()` takes a map of space extents instead of two numbers.
- Printing uses base labels of each `IndexSpace`. 
- Cost ordering now compares total scaling first, then breaks ties space by space. 
- `test_asy_cost.cpp` and `test_eval_node.cpp` updated to construct costs via the exponent-map API, and new tests are added with general `IndexSpace`s. 