### PR TITLE
core/tensor_network: braket-symmetric tensor shade invariant under bra↔ket exchange

### DIFF
--- a/SeQuant/core/tensor_network/vertex_painter.cpp
+++ b/SeQuant/core/tensor_network/vertex_painter.cpp
@@ -26,8 +26,10 @@ std::size_t VertexPainterImpl::to_hash_value(
   // asymmetry, in the core-vertex shade.)
   auto bra_rank = tensor._bra_rank();
   auto ket_rank = tensor._ket_rank();
-  if (tensor._braket_symmetry() == BraKetSymmetry::Symm && bra_rank > ket_rank)
+  if (tensor._braket_symmetry() == BraKetSymmetry::Symm &&
+      bra_rank > ket_rank) {
     std::swap(bra_rank, ket_rank);
+  }
   auto hashes = {hash::value(tensor._label()),
                  hash::value(bra_rank),
                  hash::value(ket_rank),

--- a/SeQuant/core/tensor_network/vertex_painter.cpp
+++ b/SeQuant/core/tensor_network/vertex_painter.cpp
@@ -3,6 +3,8 @@
 #include <SeQuant/core/tensor_network/vertex_painter.hpp>
 #include <SeQuant/core/utility/macros.hpp>
 
+#include <utility>
+
 namespace sequant {
 
 VertexPainterImpl::VertexPainterImpl(
@@ -14,9 +16,21 @@ VertexPainterImpl::VertexPainterImpl(
 
 std::size_t VertexPainterImpl::to_hash_value(
     const AbstractTensor &tensor) const {
+  // For a braket-symmetric tensor, bra<->ket exchange is a symmetry, so the
+  // tensor's "shade" (which salts the colors of all of its slot and index
+  // vertices) must be invariant under swapping the bra and ket ranks. Hash them
+  // as an unordered pair in that case, so e.g. a half-tensor X{a;;x} and its
+  // bra/ket-swapped form X{;a;x} receive the same color and canonicalize to the
+  // same form. (TNV3 already colors bra/ket slot and bundle vertices
+  // symmetrically for such tensors; this removes the last ordered-by-bra/ket
+  // asymmetry, in the core-vertex shade.)
+  auto bra_rank = tensor._bra_rank();
+  auto ket_rank = tensor._ket_rank();
+  if (tensor._braket_symmetry() == BraKetSymmetry::Symm && bra_rank > ket_rank)
+    std::swap(bra_rank, ket_rank);
   auto hashes = {hash::value(tensor._label()),
-                 hash::value(tensor._bra_rank()),
-                 hash::value(tensor._ket_rank()),
+                 hash::value(bra_rank),
+                 hash::value(ket_rank),
                  hash::value(tensor._aux_rank()),
                  hash::value(tensor._symmetry()),
                  hash::value(tensor._column_symmetry()),

--- a/tests/unit/test_canonicalize.cpp
+++ b/tests/unit/test_canonicalize.cpp
@@ -604,11 +604,6 @@ TEST_CASE("canonicalization", "[algorithms]") {
 
 TEST_CASE("braket_symmetric_half_tensor_canonicalization", "[algorithms]") {
   using namespace sequant;
-  TensorCanonicalizer::register_instance(
-      std::make_shared<DefaultTensorCanonicalizer>());
-  auto ctx = get_default_context();
-  ctx.set(sequant::mbpt::make_sr_spaces());
-  auto ctx_resetter = set_scoped_default_context(ctx);
 
   auto canon_hash = [](std::wstring spec) {
     auto e = deserialize(spec);

--- a/tests/unit/test_canonicalize.cpp
+++ b/tests/unit/test_canonicalize.cpp
@@ -13,6 +13,7 @@
 #include <SeQuant/domain/mbpt/convention.hpp>
 
 #include <SeQuant/core/bliss.hpp>
+#include <SeQuant/core/tensor_network.hpp>
 #include <SeQuant/core/tensor_network/v3.hpp>
 #include <SeQuant/external/bliss/graph.hh>
 
@@ -599,4 +600,31 @@ TEST_CASE("canonicalization", "[algorithms]") {
           EquivalentTo("t{a2;i4} t{a1,a3;i3,i2} B{i3;i1;p5} B{i4;a3;p5}"));
     }
   }
+}
+
+TEST_CASE("braket_symmetric_half_tensor_canonicalization", "[algorithms]") {
+  using namespace sequant;
+  TensorCanonicalizer::register_instance(
+      std::make_shared<DefaultTensorCanonicalizer>());
+  auto isr = sequant::mbpt::make_legacy_spaces();
+  mbpt::add_pao_spaces(isr);
+  auto ctx = get_default_context();
+  ctx.set(isr);
+  auto ctx_resetter = set_scoped_default_context(ctx);
+
+  auto canon_hash = [](std::wstring spec) {
+    auto e = deserialize(spec);
+    ExprPtrList tl{e};
+    TensorNetwork tn(tl);
+    return tn.canonicalize_slots(TensorCanonicalizer::cardinal_tensor_labels())
+        .hash_value();
+  };
+
+  // A braket-symmetric tensor is invariant under bra<->ket exchange, so a
+  // half-tensor with the orbital in bra must canonicalize identically to the
+  // form with the orbital in ket (regression: the vertex painter's tensor
+  // "shade" hashed bra_rank/ket_rank in fixed order, distinguishing them).
+  CHECK(canon_hash(L"X{a1;;i1}:N-S-N") == canon_hash(L"X{;a1;i1}:N-S-N"));
+  // Without braket symmetry the two forms must remain distinct.
+  CHECK(canon_hash(L"X{a1;;i1}:N-N-N") != canon_hash(L"X{;a1;i1}:N-N-N"));
 }

--- a/tests/unit/test_canonicalize.cpp
+++ b/tests/unit/test_canonicalize.cpp
@@ -606,10 +606,8 @@ TEST_CASE("braket_symmetric_half_tensor_canonicalization", "[algorithms]") {
   using namespace sequant;
   TensorCanonicalizer::register_instance(
       std::make_shared<DefaultTensorCanonicalizer>());
-  auto isr = sequant::mbpt::make_legacy_spaces();
-  mbpt::add_pao_spaces(isr);
   auto ctx = get_default_context();
-  ctx.set(isr);
+  ctx.set(sequant::mbpt::make_sr_spaces());
   auto ctx_resetter = set_scoped_default_context(ctx);
 
   auto canon_hash = [](std::wstring spec) {


### PR DESCRIPTION
## Summary

`VertexPainterImpl::to_hash_value()` computes a tensor's **shade** — the color that salts every one of its slot/index vertices in the canonicalization graph — from a hash that included `bra_rank` and `ket_rank` **in fixed order**, with no regard for `braket_symmetry()`.

For a braket-symmetric tensor, bra↔ket exchange is a symmetry, so a *half-tensor* `X{a;;x}` (bra-orbital) and its swapped form `X{;a;x}` (ket-orbital) **should** canonicalize identically. They didn't: the ordered `(bra_rank, ket_rank)` gave them different shades → different canonical graphs → different canonical hashes. TNV3 already colors bra/ket slot and bundle vertices symmetrically for such tensors (`is_braket_symm`); the core-vertex shade was the last ordered-by-bra/ket asymmetry.

## Change

- `vertex_painter.cpp`: when `braket_symmetry == Symm`, hash the two ranks as an **unordered** pair (sort them) so the shade is bra↔ket-invariant.
- Regression test (`test_canonicalize.cpp`): a braket-symmetric half-tensor's bra-orbital and ket-orbital forms now share a canonical hash; the non-symmetric forms stay distinct.

## Impact

No effect on tensors with equal bra/ket ranks or non-symmetric braket (the common cases) — the existing canonicalization snapshots are **unchanged** (full unit suite passes, no rebaselines).

## Scope note

This makes the **canonicalizer** recognize braket-symmetric half-tensors as equivalent. It is a prerequisite for, but does not by itself deliver, auto-folding of such half-tensors in the **eval/export** path (e.g. noncovariant-THC export), which additionally requires routing regular (non-ToT) eval leaves through tensor-network canonicalization — a separate, broader follow-up.