### PR TITLE
Improvements related to CCk Refactor

### DIFF
--- a/SeQuant/core/binary_node.hpp
+++ b/SeQuant/core/binary_node.hpp
@@ -84,7 +84,10 @@ constexpr TreeTraversal operator&(TreeTraversal lhs, TreeTraversal rhs) {
       break;                                                         \
   }
 
-namespace {
+// implementation details of the full-binary-node tree visitor; prefer
+// sequant::detail over an unnamed namespace in a header (see CppCoreGuidelines
+// SF.21)
+namespace detail {
 
 /// Visit leaf nodes only.
 struct VisitLeaf {};
@@ -213,7 +216,7 @@ void visit(Node&& node, Visitor&& f, NodeType) {
   }
 }
 
-}  // namespace
+}  // namespace detail
 
 ///
 /// @brief Represents a node with data of @c T type in a full-binary tree.
@@ -480,14 +483,16 @@ class FullBinaryNode {
   ///
   template <typename F>
   void visit(F&& visitor, TreeTraversal order = TreeTraversal::PreOrder) const {
-    TRAVERSAL_TO_TEMPLATE_ARG(order, sequant::visit,
-                              (*this, std::forward<F>(visitor), VisitAll{}));
+    TRAVERSAL_TO_TEMPLATE_ARG(
+        order, sequant::detail::visit,
+        (*this, std::forward<F>(visitor), detail::VisitAll{}));
   }
 
   template <typename F>
   void visit(F&& visitor, TreeTraversal order = TreeTraversal::PreOrder) {
-    TRAVERSAL_TO_TEMPLATE_ARG(order, sequant::visit,
-                              (*this, std::forward<F>(visitor), VisitAll{}));
+    TRAVERSAL_TO_TEMPLATE_ARG(
+        order, sequant::detail::visit,
+        (*this, std::forward<F>(visitor), detail::VisitAll{}));
   }
 
   ///
@@ -504,16 +509,16 @@ class FullBinaryNode {
   void visit_internal(F&& visitor,
                       TreeTraversal order = TreeTraversal::PreOrder) const {
     TRAVERSAL_TO_TEMPLATE_ARG(
-        order, sequant::visit,
-        (*this, std::forward<F>(visitor), VisitInternal{}));
+        order, sequant::detail::visit,
+        (*this, std::forward<F>(visitor), detail::VisitInternal{}));
   }
 
   template <typename F>
   void visit_internal(F&& visitor,
                       TreeTraversal order = TreeTraversal::PreOrder) {
     TRAVERSAL_TO_TEMPLATE_ARG(
-        order, sequant::visit,
-        (*this, std::forward<F>(visitor), VisitInternal{}));
+        order, sequant::detail::visit,
+        (*this, std::forward<F>(visitor), detail::VisitInternal{}));
   }
 
   ///
@@ -529,14 +534,16 @@ class FullBinaryNode {
   template <typename F>
   void visit_leaf(F&& visitor,
                   TreeTraversal order = TreeTraversal::PreOrder) const {
-    TRAVERSAL_TO_TEMPLATE_ARG(order, sequant::visit,
-                              (*this, std::forward<F>(visitor), VisitLeaf{}));
+    TRAVERSAL_TO_TEMPLATE_ARG(
+        order, sequant::detail::visit,
+        (*this, std::forward<F>(visitor), detail::VisitLeaf{}));
   }
 
   template <typename F>
   void visit_leaf(F&& visitor, TreeTraversal order = TreeTraversal::PreOrder) {
-    TRAVERSAL_TO_TEMPLATE_ARG(order, sequant::visit,
-                              (*this, std::forward<F>(visitor), VisitLeaf{}));
+    TRAVERSAL_TO_TEMPLATE_ARG(
+        order, sequant::detail::visit,
+        (*this, std::forward<F>(visitor), detail::VisitLeaf{}));
   }
 
  private:

--- a/SeQuant/core/eval/backends/btas/result.hpp
+++ b/SeQuant/core/eval/backends/btas/result.hpp
@@ -234,8 +234,8 @@ class ResultTensorBTAS final : public Result {
     auto const pre_annot = std::any_cast<annot_t>(ann[0]);
     auto const post_annot = std::any_cast<annot_t>(ann[1]);
 
-    log_btas(ords_to_labels(post_annot), " = adjoint(",
-             ords_to_labels(pre_annot), ")\n");
+    detail::log_btas(detail::ords_to_labels(post_annot), " = adjoint(",
+                     detail::ords_to_labels(pre_annot), ")\n");
 
     T result;
     btas::permute(get<T>(), pre_annot, result, post_annot);

--- a/SeQuant/core/eval/backends/btas/result.hpp
+++ b/SeQuant/core/eval/backends/btas/result.hpp
@@ -17,7 +17,10 @@
 
 namespace sequant {
 
-namespace {
+// implementation details of the BTAS result backend; prefer sequant::detail
+// over an unnamed namespace in a header (see CppCoreGuidelines SF.21 / "Use
+// unnamed namespaces in headers ... no" guidance)
+namespace detail {
 
 ///
 /// \brief This function implements the symmetrization of btas::Tensor.
@@ -125,7 +128,7 @@ inline void log_btas(Args const&... args) noexcept {
   log_result("[BTAS] ", args...);
 }
 
-}  // namespace
+}  // namespace detail
 
 ///
 /// \brief Result for a tensor value of btas::Tensor type.
@@ -154,8 +157,9 @@ class ResultTensorBTAS final : public Result {
     SEQUANT_ASSERT(other.is<ResultTensorBTAS<T>>());
     auto const a = annot_wrap{annot};
 
-    log_btas(ords_to_labels(a.lannot), " + ", ords_to_labels(a.rannot), " = ",
-             ords_to_labels(a.this_annot), "\n");
+    detail::log_btas(detail::ords_to_labels(a.lannot), " + ",
+                     detail::ords_to_labels(a.rannot), " = ",
+                     detail::ords_to_labels(a.this_annot), "\n");
 
     T lres, rres;
     btas::permute(get<T>(), a.lannot, lres, a.this_annot);
@@ -170,8 +174,8 @@ class ResultTensorBTAS final : public Result {
 
     if (other.is<ResultScalar<numeric_type>>()) {
       auto const scalar = other.as<ResultScalar<numeric_type>>().value();
-      log_btas(ords_to_labels(a.lannot), " * ", scalar, " = ",
-               ords_to_labels(a.this_annot), "\n");
+      detail::log_btas(detail::ords_to_labels(a.lannot), " * ", scalar, " = ",
+                       detail::ords_to_labels(a.this_annot), "\n");
 
       T result;
       btas::permute(get<T>(), a.lannot, result, a.this_annot);
@@ -185,13 +189,14 @@ class ResultTensorBTAS final : public Result {
       T rres;
       btas::permute(other.get<T>(), a.rannot, rres, a.lannot);
       numeric_type const d = btas::dot(get<T>(), rres);
-      log_btas(ords_to_labels(a.lannot), " * ", ords_to_labels(a.rannot), " = ",
-               d, "\n");
+      detail::log_btas(detail::ords_to_labels(a.lannot), " * ",
+                       detail::ords_to_labels(a.rannot), " = ", d, "\n");
       return eval_result<ResultScalar<numeric_type>>(d);
     }
 
-    log_btas(ords_to_labels(a.lannot), " * ", ords_to_labels(a.rannot), " = ",
-             ords_to_labels(a.this_annot), "\n");
+    detail::log_btas(detail::ords_to_labels(a.lannot), " * ",
+                     detail::ords_to_labels(a.rannot), " = ",
+                     detail::ords_to_labels(a.this_annot), "\n");
 
     T result;
     btas::contract(numeric_type{1},           //
@@ -213,8 +218,8 @@ class ResultTensorBTAS final : public Result {
     auto const pre_annot = std::any_cast<annot_t>(ann[0]);
     auto const post_annot = std::any_cast<annot_t>(ann[1]);
 
-    log_btas(ords_to_labels(pre_annot), " = ", ords_to_labels(post_annot),
-             "\n");
+    detail::log_btas(detail::ords_to_labels(pre_annot), " = ",
+                     detail::ords_to_labels(post_annot), "\n");
 
     T result;
     btas::permute(get<T>(), pre_annot, result, post_annot);
@@ -245,20 +250,21 @@ class ResultTensorBTAS final : public Result {
     auto const& o = other.get<T>();
     SEQUANT_ASSERT(t.range() == o.range());
 
-    auto const ann = ords_to_annot(
+    auto const ann = detail::ords_to_annot(
         ranges::views::iota(size_t{0}, static_cast<size_t>(t.rank())));
-    log_btas(ann, " += ", ann, "\n");
+    detail::log_btas(ann, " += ", ann, "\n");
 
     t += o;
   }
 
   [[nodiscard]] ResultPtr symmetrize() const override {
-    return eval_result<ResultTensorBTAS<T>>(column_symmetrize_btas(get<T>()));
+    return eval_result<ResultTensorBTAS<T>>(
+        detail::column_symmetrize_btas(get<T>()));
   }
 
   [[nodiscard]] ResultPtr antisymmetrize(size_t bra_rank) const override {
     return eval_result<ResultTensorBTAS<T>>(
-        particle_antisymmetrize_btas(get<T>(), bra_rank));
+        detail::particle_antisymmetrize_btas(get<T>(), bra_rank));
   }
 
  private:

--- a/SeQuant/core/eval/backends/tapp/result.hpp
+++ b/SeQuant/core/eval/backends/tapp/result.hpp
@@ -18,7 +18,10 @@
 
 namespace sequant {
 
-namespace {
+// implementation details of the TAPP result backend; prefer sequant::detail
+// over an unnamed namespace in a header (see CppCoreGuidelines SF.21 / "Use
+// unnamed namespaces in headers ... no" guidance)
+namespace detail {
 
 ///
 /// \brief Symmetrize a TAPPTensor by summing over all symmetric particle
@@ -146,7 +149,7 @@ inline void log_tapp(Args const&... args) noexcept {
   log_result("[TAPP] ", args...);
 }
 
-}  // namespace
+}  // namespace detail
 
 ///
 /// \brief Result for a tensor value of TAPPTensor type.
@@ -174,8 +177,9 @@ class ResultTensorTAPP final : public Result {
     SEQUANT_ASSERT(other.is<ResultTensorTAPP<T>>());
     auto const a = annot_wrap{annot};
 
-    log_tapp(ords_to_labels(a.lannot), " + ", ords_to_labels(a.rannot), " = ",
-             ords_to_labels(a.this_annot), "\n");
+    detail::log_tapp(detail::ords_to_labels(a.lannot), " + ",
+                     detail::ords_to_labels(a.rannot), " = ",
+                     detail::ords_to_labels(a.this_annot), "\n");
 
     T lres, rres;
     tapp_ops::permute(get<T>(), a.lannot, lres, a.this_annot);
@@ -191,8 +195,8 @@ class ResultTensorTAPP final : public Result {
 
     if (other.is<ResultScalar<numeric_type>>()) {
       auto const scalar = other.as<ResultScalar<numeric_type>>().value();
-      log_tapp(ords_to_labels(a.lannot), " * ", scalar, " = ",
-               ords_to_labels(a.this_annot), "\n");
+      detail::log_tapp(detail::ords_to_labels(a.lannot), " * ", scalar, " = ",
+                       detail::ords_to_labels(a.this_annot), "\n");
 
       T result;
       tapp_ops::permute(get<T>(), a.lannot, result, a.this_annot);
@@ -207,13 +211,14 @@ class ResultTensorTAPP final : public Result {
       T rres;
       tapp_ops::permute(other.get<T>(), a.rannot, rres, a.lannot);
       numeric_type const d = tapp_ops::dot(get<T>(), rres);
-      log_tapp(ords_to_labels(a.lannot), " * ", ords_to_labels(a.rannot), " = ",
-               d, "\n");
+      detail::log_tapp(detail::ords_to_labels(a.lannot), " * ",
+                       detail::ords_to_labels(a.rannot), " = ", d, "\n");
       return eval_result<ResultScalar<numeric_type>>(d);
     }
 
-    log_tapp(ords_to_labels(a.lannot), " * ", ords_to_labels(a.rannot), " = ",
-             ords_to_labels(a.this_annot), "\n");
+    detail::log_tapp(detail::ords_to_labels(a.lannot), " * ",
+                     detail::ords_to_labels(a.rannot), " = ",
+                     detail::ords_to_labels(a.this_annot), "\n");
 
     T result;
     tapp_ops::contract(numeric_type{1},           //
@@ -235,8 +240,8 @@ class ResultTensorTAPP final : public Result {
     auto const pre_annot = std::any_cast<annot_t>(ann[0]);
     auto const post_annot = std::any_cast<annot_t>(ann[1]);
 
-    log_tapp(ords_to_labels(pre_annot), " = ", ords_to_labels(post_annot),
-             "\n");
+    detail::log_tapp(detail::ords_to_labels(pre_annot), " = ",
+                     detail::ords_to_labels(post_annot), "\n");
 
     T result;
     tapp_ops::permute(get<T>(), pre_annot, result, post_annot);
@@ -269,20 +274,21 @@ class ResultTensorTAPP final : public Result {
     auto const& o = other.get<T>();
     SEQUANT_ASSERT(t.extents() == o.extents());
 
-    auto const ann = ords_to_annot(
+    auto const ann = detail::ords_to_annot(
         ranges::views::iota(size_t{0}, static_cast<size_t>(t.rank())));
-    log_tapp(ann, " += ", ann, "\n");
+    detail::log_tapp(ann, " += ", ann, "\n");
 
     t += o;
   }
 
   [[nodiscard]] ResultPtr symmetrize() const override {
-    return eval_result<ResultTensorTAPP<T>>(column_symmetrize_tapp(get<T>()));
+    return eval_result<ResultTensorTAPP<T>>(
+        detail::column_symmetrize_tapp(get<T>()));
   }
 
   [[nodiscard]] ResultPtr antisymmetrize(size_t bra_rank) const override {
     return eval_result<ResultTensorTAPP<T>>(
-        particle_antisymmetrize_tapp(get<T>(), bra_rank));
+        detail::particle_antisymmetrize_tapp(get<T>(), bra_rank));
   }
 
  private:

--- a/SeQuant/core/eval/backends/tapp/result.hpp
+++ b/SeQuant/core/eval/backends/tapp/result.hpp
@@ -258,8 +258,8 @@ class ResultTensorTAPP final : public Result {
     auto const pre_annot = std::any_cast<annot_t>(ann[0]);
     auto const post_annot = std::any_cast<annot_t>(ann[1]);
 
-    log_tapp(ords_to_labels(post_annot), " = adjoint(",
-             ords_to_labels(pre_annot), ")\n");
+    detail::log_tapp(detail::ords_to_labels(post_annot), " = adjoint(",
+                     detail::ords_to_labels(pre_annot), ")\n");
 
     T result;
     tapp_ops::permute(get<T>(), pre_annot, result, post_annot);

--- a/SeQuant/core/eval/backends/tiledarray/result.hpp
+++ b/SeQuant/core/eval/backends/tiledarray/result.hpp
@@ -14,33 +14,93 @@
 
 namespace sequant {
 
+/// Inner-tensor mode count of a tensor-of-tensor DistArray (0 for a regular,
+/// non-nested array). The outer trange carries no inner information, so the
+/// inner rank is read from the first local non-empty inner tile and reduced
+/// (max) across the world -- this makes it well-defined on ranks holding no
+/// local data (or only empty inner tiles), as long as some rank holds a
+/// non-empty inner tile. Needed to build a ToT-valid annotation ("outer;inner")
+/// in the annotation-free array operations (add_inplace,
+/// slice_array_over_mode), since a flat annotation trips DistArray's
+/// is_tot_index() check.
+template <typename ArrayT>
+[[nodiscard]] std::size_t tot_inner_rank(ArrayT const& arr) {
+  std::size_t r = 0;
+  if constexpr (TA::detail::is_tensor_of_tensor_v<
+                    typename ArrayT::value_type>) {
+    // Inner tensors carry the rank; an outer tile may hold null/empty inner
+    // views (e.g. a screened pair), so skip those -- calling range() on an
+    // empty view asserts (ArenaTensor) or is UB (TA::Tensor).
+    for (auto it = arr.begin(); it != arr.end() && r == 0; ++it) {
+      auto const& outer_tile = it->get();
+      for (auto const& inner : outer_tile) {
+        if (inner.empty()) continue;
+        if (inner.range().rank() > 0) {
+          r = inner.range().rank();
+          break;
+        }
+      }
+    }
+    arr.world().gop.max(r);
+  }
+  return r;
+}
+
 namespace {
 
 ///
-/// \brief This function implements the symmetrization of TA::DistArray.
+/// \brief Particle-symmetrize a TA::DistArray (tensor-of-scalar or
+///        tensor-of-tensor).
 ///
-/// \param arr The array to be symmetrized
+/// \param arr The array to be symmetrized.
 ///
-/// \pre The rank of the array must be even
+/// \pre ToS: rank is even. ToT: outer rank == inner rank.
 ///
 /// \return The symmetrized TA::DistArray.
 ///
 template <typename... Args>
 auto column_symmetrize_ta(TA::DistArray<Args...> const& arr) {
   using ranges::views::iota;
+  constexpr bool is_tot = TA::detail::is_tensor_of_tensor_v<
+      typename TA::DistArray<Args...>::value_type>;
 
-  size_t const rank = arr.trange().rank();
-  if (rank % 2 != 0)
+  size_t const outer_rank = arr.trange().rank();
+
+  size_t const total_rank = [&] {
+    if constexpr (is_tot) {
+      size_t const inner_rank = tot_inner_rank(arr);
+      if (outer_rank != inner_rank)
+        throw Exception(
+            "ToT symmetrization requires equal outer and inner rank");
+      return outer_rank + inner_rank;
+    } else {
+      return outer_rank;
+    }
+  }();
+
+  if (total_rank % 2 != 0)
     throw Exception("This function only supports even-ranked tensors");
 
+  size_t const nparticles = total_rank / 2;
+
+  perm_t perm = iota(size_t{0}, total_rank) | ranges::to<perm_t>;
+
+  auto make_annot = [nparticles](perm_t const& p) {
+    if constexpr (is_tot) {
+      perm_t const outer(p.begin(), p.begin() + nparticles);
+      perm_t const inner(p.begin() + nparticles, p.end());
+      return ords_to_annot(outer) + ";" + ords_to_annot(inner);
+    } else {
+      return ords_to_annot(p);
+    }
+  };
+
+  auto const lannot = make_annot(perm);
+
   TA::DistArray<Args...> result;
-
-  perm_t perm = iota(size_t{0}, rank) | ranges::to<perm_t>;
-
-  auto const lannot = ords_to_annot(perm);
-
-  auto call_back = [&result, &lannot, &arr, &perm = std::as_const(perm)]() {
-    auto const rannot = ords_to_annot(perm);
+  auto call_back = [&result, &lannot, &arr, &perm = std::as_const(perm),
+                    &make_annot]() {
+    auto const rannot = make_annot(perm);
     if (result.is_initialized()) {
       result(lannot) += arr(rannot);
     } else {
@@ -48,7 +108,6 @@ auto column_symmetrize_ta(TA::DistArray<Args...> const& arr) {
     }
   };
 
-  auto const nparticles = rank / 2;
   symmetric_permutation(SymmetricParticleRange{perm.begin(),               //
                                                perm.begin() + nparticles,  //
                                                nparticles},
@@ -165,38 +224,6 @@ template <typename... Args>
 [[nodiscard]] TA::DistArray<Args...> slice_array_over_mode(
     TA::DistArray<Args...> const& arr, std::size_t mode, std::size_t tile_lo,
     std::size_t tile_hi);
-
-/// Inner-tensor mode count of a tensor-of-tensor DistArray (0 for a regular,
-/// non-nested array). The outer trange carries no inner information, so the
-/// inner rank is read from the first local non-empty inner tile and reduced
-/// (max) across the world -- this makes it well-defined on ranks holding no
-/// local data (or only empty inner tiles), as long as some rank holds a
-/// non-empty inner tile. Needed to build a ToT-valid annotation ("outer;inner")
-/// in the annotation-free array operations (add_inplace,
-/// slice_array_over_mode), since a flat annotation trips DistArray's
-/// is_tot_index() check.
-template <typename ArrayT>
-[[nodiscard]] std::size_t tot_inner_rank(ArrayT const& arr) {
-  std::size_t r = 0;
-  if constexpr (TA::detail::is_tensor_of_tensor_v<
-                    typename ArrayT::value_type>) {
-    // Inner tensors carry the rank; an outer tile may hold null/empty inner
-    // views (e.g. a screened pair), so skip those -- calling range() on an
-    // empty view asserts (ArenaTensor) or is UB (TA::Tensor).
-    for (auto it = arr.begin(); it != arr.end() && r == 0; ++it) {
-      auto const& outer_tile = it->get();
-      for (auto const& inner : outer_tile) {
-        if (inner.empty()) continue;
-        if (inner.range().rank() > 0) {
-          r = inner.range().rank();
-          break;
-        }
-      }
-    }
-    arr.world().gop.max(r);
-  }
-  return r;
-}
 
 /// Partition a TiledRange1 into contiguous, tile-aligned element-range batches,
 /// each covering at least \p target_batch_size elements where possible. Tiles
@@ -624,8 +651,7 @@ class ResultTensorOfTensorTA final : public Result {
   }
 
   [[nodiscard]] ResultPtr symmetrize() const override {
-    // not implemented yet
-    return nullptr;
+    return eval_result<this_type>(column_symmetrize_ta(get<ArrayT>()));
   }
 
   [[nodiscard]] ResultPtr antisymmetrize(size_t /*bra_rank*/) const override {

--- a/SeQuant/core/eval/backends/tiledarray/result.hpp
+++ b/SeQuant/core/eval/backends/tiledarray/result.hpp
@@ -71,7 +71,9 @@ auto column_symmetrize_ta(TA::DistArray<Args...> const& arr) {
       size_t const inner_rank = tot_inner_rank(arr);
       if (outer_rank != inner_rank)
         throw Exception(
-            "ToT symmetrization requires equal outer and inner rank");
+            "ToT symmetrization requires equal outer and inner rank (outer=" +
+            std::to_string(outer_rank) +
+            ", inner=" + std::to_string(inner_rank) + ")");
       return outer_rank + inner_rank;
     } else {
       return outer_rank;

--- a/SeQuant/core/eval/backends/tiledarray/result.hpp
+++ b/SeQuant/core/eval/backends/tiledarray/result.hpp
@@ -14,6 +14,8 @@
 
 namespace sequant {
 
+namespace {
+
 /// Inner-tensor mode count of a tensor-of-tensor DistArray (0 for a regular,
 /// non-nested array). The outer trange carries no inner information, so the
 /// inner rank is read from the first local non-empty inner tile and reduced
@@ -45,8 +47,6 @@ template <typename ArrayT>
   }
   return r;
 }
-
-namespace {
 
 ///
 /// \brief Particle-symmetrize a TA::DistArray (tensor-of-scalar or

--- a/SeQuant/core/eval/backends/tiledarray/result.hpp
+++ b/SeQuant/core/eval/backends/tiledarray/result.hpp
@@ -14,7 +14,10 @@
 
 namespace sequant {
 
-namespace {
+// implementation details of the TiledArray result backend; prefer
+// sequant::detail over an unnamed namespace in a header (see CppCoreGuidelines
+// SF.21 / "Use unnamed namespaces in headers ... no" guidance)
+namespace detail {
 
 /// Inner-tensor mode count of a tensor-of-tensor DistArray (0 for a regular,
 /// non-nested array). The outer trange carries no inner information, so the
@@ -203,7 +206,7 @@ inline constexpr TA::DeNest to_ta_denest(DeNest d) noexcept {
   return d == DeNest::True ? TA::DeNest::True : TA::DeNest::False;
 }
 
-}  // namespace
+}  // namespace detail
 
 /// TA::Tensor memory use logger
 /// If TiledArray was configured with TA_TENSOR_MEM_PROFILE set this
@@ -286,7 +289,7 @@ class ResultTensorTA final : public Result {
     SEQUANT_ASSERT(other.is<this_type>());
     auto const a = annot_wrap{annot};
 
-    log_ta(a.lannot, " + ", a.rannot, " = ", a.this_annot, "\n");
+    detail::log_ta(a.lannot, " + ", a.rannot, " = ", a.this_annot, "\n");
 
     ArrayT result;
     result(a.this_annot) =
@@ -333,7 +336,7 @@ class ResultTensorTA final : public Result {
       auto result = get<ArrayT>();
       auto scalar = other.get<numeric_type>();
 
-      log_ta(a.lannot, " * ", scalar, " = ", a.this_annot, "\n");
+      detail::log_ta(a.lannot, " * ", scalar, " = ", a.this_annot, "\n");
 
       result(a.this_annot) = scalar * result(a.lannot);
 
@@ -350,7 +353,7 @@ class ResultTensorTA final : public Result {
       ArrayT::wait_for_lazy_cleanup(get<ArrayT>().world());
       ArrayT::wait_for_lazy_cleanup(other.get<ArrayT>().world());
 
-      log_ta(a.lannot, " * ", a.rannot, " = ", d, "\n");
+      detail::log_ta(a.lannot, " * ", a.rannot, " = ", d, "\n");
 
       log_ta_tensor_host_memory_use();
       return eval_result<ResultScalar<numeric_type>>(d);
@@ -365,7 +368,7 @@ class ResultTensorTA final : public Result {
 
     // confirmed: other.is<this_type>() is true
 
-    log_ta(a.lannot, " * ", a.rannot, " = ", a.this_annot, "\n");
+    detail::log_ta(a.lannot, " * ", a.rannot, " = ", a.this_annot, "\n");
 
     ArrayT result;
 
@@ -387,7 +390,7 @@ class ResultTensorTA final : public Result {
     auto const pre_annot = std::any_cast<std::string>(ann[0]);
     auto const post_annot = std::any_cast<std::string>(ann[1]);
 
-    log_ta(pre_annot, " = ", post_annot, "\n");
+    detail::log_ta(pre_annot, " = ", post_annot, "\n");
 
     ArrayT result;
     result(post_annot) = get<ArrayT>()(pre_annot);
@@ -406,7 +409,7 @@ class ResultTensorTA final : public Result {
     auto const pre_annot = std::any_cast<std::string>(ann[0]);
     auto const post_annot = std::any_cast<std::string>(ann[1]);
 
-    log_ta(post_annot, " = adjoint(", pre_annot, ")\n");
+    detail::log_ta(post_annot, " = adjoint(", pre_annot, ")\n");
 
     ArrayT result;
     if constexpr (TA::detail::is_complex_v<numeric_type>) {
@@ -428,7 +431,7 @@ class ResultTensorTA final : public Result {
     SEQUANT_ASSERT(t.trange() == o.trange());
     auto ann = TA::detail::dummy_annotation(t.trange().rank());
 
-    log_ta(ann, " += ", ann, "\n");
+    detail::log_ta(ann, " += ", ann, "\n");
 
     t(ann) += o(ann);
     ArrayT::wait_for_lazy_cleanup(t.world());
@@ -436,12 +439,12 @@ class ResultTensorTA final : public Result {
   }
 
   [[nodiscard]] ResultPtr symmetrize() const override {
-    return eval_result<this_type>(column_symmetrize_ta(get<ArrayT>()));
+    return eval_result<this_type>(detail::column_symmetrize_ta(get<ArrayT>()));
   }
 
   [[nodiscard]] ResultPtr antisymmetrize(size_t bra_rank) const override {
     return eval_result<this_type>(
-        particle_antisymmetrize_ta(get<ArrayT>(), bra_rank));
+        detail::particle_antisymmetrize_ta(get<ArrayT>(), bra_rank));
   }
 
  private:
@@ -491,7 +494,7 @@ class ResultTensorOfTensorTA final : public Result {
     SEQUANT_ASSERT(other.is<this_type>());
     auto const a = annot_wrap{annot};
 
-    log_ta(a.lannot, " + ", a.rannot, " = ", a.this_annot, "\n");
+    detail::log_ta(a.lannot, " + ", a.rannot, " = ", a.this_annot, "\n");
 
     ArrayT result;
     result(a.this_annot) =
@@ -538,7 +541,7 @@ class ResultTensorOfTensorTA final : public Result {
       auto result = get<ArrayT>();
       auto scalar = other.get<numeric_type>();
 
-      log_ta(a.lannot, " * ", scalar, " = ", a.this_annot, "\n");
+      detail::log_ta(a.lannot, " * ", scalar, " = ", a.this_annot, "\n");
 
       result(a.this_annot) = scalar * result(a.lannot);
 
@@ -553,13 +556,13 @@ class ResultTensorOfTensorTA final : public Result {
       ArrayT::wait_for_lazy_cleanup(get<ArrayT>().world());
       ArrayT::wait_for_lazy_cleanup(other.get<ArrayT>().world());
 
-      log_ta(a.lannot, " * ", a.rannot, " = ", d, "\n");
+      detail::log_ta(a.lannot, " * ", a.rannot, " = ", d, "\n");
 
       log_ta_tensor_host_memory_use();
       return eval_result<ResultScalar<numeric_type>>(d);
     }
 
-    log_ta(a.lannot, " * ", a.rannot, " = ", a.this_annot, "\n");
+    detail::log_ta(a.lannot, " * ", a.rannot, " = ", a.this_annot, "\n");
 
     if (other.is<that_type>()) {
       // ToT * T -> ToT
@@ -584,7 +587,7 @@ class ResultTensorOfTensorTA final : public Result {
       log_ta_tensor_host_memory_use();
       return eval_result<this_type>(std::move(result));
     } else {
-      throw invalid_operand();
+      throw detail::invalid_operand();
     }
   }
 
@@ -600,7 +603,7 @@ class ResultTensorOfTensorTA final : public Result {
     auto const pre_annot = std::any_cast<std::string>(ann[0]);
     auto const post_annot = std::any_cast<std::string>(ann[1]);
 
-    log_ta(pre_annot, " = ", post_annot, "\n");
+    detail::log_ta(pre_annot, " = ", post_annot, "\n");
 
     ArrayT result;
     result(post_annot) = get<ArrayT>()(pre_annot);
@@ -618,7 +621,7 @@ class ResultTensorOfTensorTA final : public Result {
     auto const pre_annot = std::any_cast<std::string>(ann[0]);
     auto const post_annot = std::any_cast<std::string>(ann[1]);
 
-    log_ta(post_annot, " = adjoint(", pre_annot, ")\n");
+    detail::log_ta(post_annot, " = adjoint(", pre_annot, ")\n");
 
     ArrayT result;
     if constexpr (TA::detail::is_complex_v<numeric_type>) {
@@ -642,10 +645,10 @@ class ResultTensorOfTensorTA final : public Result {
     // DistArray::operator() rejects it (is_tot_index). dummy_annotation's
     // second argument is the inner-mode count, read from the array's inner
     // tiles.
-    auto ann =
-        TA::detail::dummy_annotation(t.trange().rank(), tot_inner_rank(t));
+    auto ann = TA::detail::dummy_annotation(t.trange().rank(),
+                                            detail::tot_inner_rank(t));
 
-    log_ta(ann, " += ", ann, "\n");
+    detail::log_ta(ann, " += ", ann, "\n");
 
     t(ann) += o(ann);
     ArrayT::wait_for_lazy_cleanup(t.world());
@@ -653,7 +656,7 @@ class ResultTensorOfTensorTA final : public Result {
   }
 
   [[nodiscard]] ResultPtr symmetrize() const override {
-    return eval_result<this_type>(column_symmetrize_ta(get<ArrayT>()));
+    return eval_result<this_type>(detail::column_symmetrize_ta(get<ArrayT>()));
   }
 
   [[nodiscard]] ResultPtr antisymmetrize(size_t /*bra_rank*/) const override {
@@ -702,9 +705,9 @@ template <typename... Args>
   if constexpr (TA::detail::is_tensor_of_tensor_v<value_type>) {
     annot = TA::detail::dummy_annotation(
         static_cast<unsigned int>(rank),
-        static_cast<unsigned int>(tot_inner_rank(arr)));
+        static_cast<unsigned int>(detail::tot_inner_rank(arr)));
   } else {
-    annot = ords_to_annot(iota(std::size_t{0}, rank));
+    annot = detail::ords_to_annot(iota(std::size_t{0}, rank));
   }
   TA::DistArray<Args...> out;
   out(annot) = arr(annot).block(lo, hi);

--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -341,7 +341,9 @@ inline auto term(TermMode mode, std::string_view term) {
 
 }  // namespace log
 
-namespace {
+// implementation details of the eval engine; prefer sequant::detail over an
+// unnamed namespace in a header (see CppCoreGuidelines SF.21)
+namespace detail {
 
 ///
 /// Invokes @c fun that returns void on the arguments @c args and returns the
@@ -379,7 +381,7 @@ auto&& node0(std::ranges::range auto&& rng) {
 
 enum struct CacheCheck { Checked, Unchecked };
 
-}  // namespace
+}  // namespace detail
 
 enum struct Trace {
   On,
@@ -393,9 +395,11 @@ enum struct Trace {
 };
 static_assert(Trace::Default == Trace::On || Trace::Default == Trace::Off);
 
-namespace {
+// implementation details of the eval engine; prefer sequant::detail over an
+// unnamed namespace in a header (see CppCoreGuidelines SF.21)
+namespace detail {
 [[nodiscard]] consteval bool trace(Trace t) noexcept { return t == Trace::On; }
-}  // namespace
+}  // namespace detail
 
 /// \brief The indices contracted at a binary evaluation node.
 ///
@@ -493,23 +497,24 @@ template <typename Node>
 /// \return Evaluated result as ResultPtr.
 ///
 template <Trace EvalTrace = Trace::Default,
-          CacheCheck Cache = CacheCheck::Checked, meta::can_evaluate Node,
-          typename F, typename N, bool FHC>
+          detail::CacheCheck Cache = detail::CacheCheck::Checked,
+          meta::can_evaluate Node, typename F, typename N, bool FHC>
   requires meta::leaf_node_evaluator<Node, F>
 ResultPtr evaluate(Node const& node,  //
                    F const& le,       //
                    CacheManager<N, FHC>& cache) {
-  if constexpr (Cache == CacheCheck::Checked) {  // return from cache if found
+  if constexpr (Cache == detail::CacheCheck::Checked) {  // return from cache if
+                                                         // found
 
     auto mult_by_phase = [&node, &cache](ResultPtr res) {
       auto phase = node->canon_phase();
       if (phase == 1) return res;
 
       ResultPtr post;
-      auto time =
-          timed_eval_inplace([&]() { post = res->mult_by_phase(phase); });
+      auto time = detail::timed_eval_inplace(
+          [&]() { post = res->mult_by_phase(phase); });
 
-      if constexpr (trace(EvalTrace)) {
+      if constexpr (detail::trace(EvalTrace)) {
         size_t hwmark = log::bytes(cache, post).value;
         if (!cache.alive(node)) hwmark += log::bytes(res).value;
         auto stat =
@@ -524,14 +529,17 @@ ResultPtr evaluate(Node const& node,  //
     };
 
     if (auto ptr = cache.access(node); ptr) {
-      if constexpr (trace(EvalTrace)) log::cache(node, cache, log::label(node));
+      if constexpr (detail::trace(EvalTrace))
+        log::cache(node, cache, log::label(node));
 
       return mult_by_phase(ptr);
     } else if (cache.exists(node)) {
       auto ptr = cache.store(
-          node, mult_by_phase(evaluate<EvalTrace, CacheCheck::Unchecked>(
-                    node, le, cache)));
-      if constexpr (trace(EvalTrace)) log::cache(node, cache, log::label(node));
+          node,
+          mult_by_phase(evaluate<EvalTrace, detail::CacheCheck::Unchecked>(
+              node, le, cache)));
+      if constexpr (detail::trace(EvalTrace))
+        log::cache(node, cache, log::label(node));
 
       return mult_by_phase(ptr);
     } else {
@@ -553,10 +561,10 @@ ResultPtr evaluate(Node const& node,  //
   if (!node.leaf()) {
     if (auto const& custom_eval = cache.custom_evaluator(); custom_eval) {
       ResultPtr intercepted;
-      time =
-          timed_eval_inplace([&]() { intercepted = custom_eval(node, cache); });
+      time = detail::timed_eval_inplace(
+          [&]() { intercepted = custom_eval(node, cache); });
       if (intercepted) {
-        if constexpr (trace(EvalTrace)) {
+        if constexpr (detail::trace(EvalTrace)) {
           log::eval(log::EvalStat{.mode = log::eval_mode(node),
                                   .time = time,
                                   .mem_result = log::bytes(intercepted),
@@ -571,7 +579,7 @@ ResultPtr evaluate(Node const& node,  //
   }
 
   if (node.leaf()) {
-    time = timed_eval_inplace([&]() { result = le(node); });
+    time = detail::timed_eval_inplace([&]() { result = le(node); });
   } else if (node->op_type() == EvalOp::Adjoint) {
     // Unary IR op: dispatch on left operand only; right is the Constant(1)
     // sentinel kept around to preserve FullBinaryNode's invariant. We
@@ -581,7 +589,8 @@ ResultPtr evaluate(Node const& node,  //
     left = evaluate<EvalTrace>(node.left(), le, cache);
     SEQUANT_ASSERT(left);
     std::array<std::any, 2> const adj_ann{node.left()->annot(), node->annot()};
-    time = timed_eval_inplace([&]() { result = left->adjoint(adj_ann); });
+    time =
+        detail::timed_eval_inplace([&]() { result = left->adjoint(adj_ann); });
   } else {
     left = evaluate<EvalTrace>(node.left(), le, cache);
     right = evaluate<EvalTrace>(node.right(), le, cache);
@@ -591,12 +600,13 @@ ResultPtr evaluate(Node const& node,  //
     std::array<std::any, 3> const ann{node.left()->annot(),
                                       node.right()->annot(), node->annot()};
     if (node->op_type() == EvalOp::Sum) {
-      time = timed_eval_inplace([&]() { result = left->sum(*right, ann); });
+      time = detail::timed_eval_inplace(
+          [&]() { result = left->sum(*right, ann); });
     } else {
       SEQUANT_ASSERT(node->op_type() == EvalOp::Product);
       auto const de_nest =
           node.left()->tot() && node.right()->tot() && !node->tot();
-      time = timed_eval_inplace([&]() {
+      time = detail::timed_eval_inplace([&]() {
         result =
             left->prod(*right, ann, de_nest ? DeNest::True : DeNest::False);
       });
@@ -606,7 +616,7 @@ ResultPtr evaluate(Node const& node,  //
   SEQUANT_ASSERT(result);
 
   // logging
-  if constexpr (trace(EvalTrace)) {
+  if constexpr (detail::trace(EvalTrace)) {
     if (node.leaf()) {
       log::eval(log::EvalStat{.mode = log::eval_mode(node),
                               .time = time,
@@ -667,7 +677,7 @@ ResultPtr evaluate(Node const& node,           //
   bool const perm = layout != decltype(layout){};
 
   std::string xpr;
-  if constexpr (trace(EvalTrace)) {
+  if constexpr (detail::trace(EvalTrace)) {
     xpr = toUtf8(io::serialization::to_string(to_expr(node)));
     log::term(log::TermMode::Begin, xpr);
   }
@@ -678,7 +688,7 @@ ResultPtr evaluate(Node const& node,           //
 
   result.pre = evaluate<EvalTrace>(node, le, cache);
 
-  auto time = timed_eval_inplace([&]() {
+  auto time = detail::timed_eval_inplace([&]() {
     result.post = perm ? result.pre->permute(
                              std::array<std::any, 2>{node->annot(), layout})
                        : result.pre;
@@ -687,7 +697,7 @@ ResultPtr evaluate(Node const& node,           //
   SEQUANT_ASSERT(result.post);
 
   // logging
-  if constexpr (trace(EvalTrace)) {
+  if constexpr (detail::trace(EvalTrace)) {
     if (perm) {
       // result.pre aliases the cache only when the inner evaluate returned
       // the cached buffer unchanged — i.e. the node is cached AND no
@@ -745,10 +755,11 @@ ResultPtr evaluate(Nodes const& nodes,  //
     }
 
     ResultPtr pre = evaluate<EvalTrace>(n, layout, le, cache);
-    auto time = timed_eval_inplace([&]() { result->add_inplace(*pre); });
+    auto time =
+        detail::timed_eval_inplace([&]() { result->add_inplace(*pre); });
 
     // logging
-    if constexpr (trace(EvalTrace)) {
+    if constexpr (detail::trace(EvalTrace)) {
       // SumInplace allocates nothing: it writes into the accumulator.
       // hwmark counts the cache plus both operands live at this moment;
       // skip pre's bytes only when pre is the cached buffer itself.
@@ -806,10 +817,10 @@ ResultPtr evaluate(Nodes const& nodes,  //
 /// \return Evaluated result as ResultPtr.
 ///
 template <Trace EvalTrace = Trace::Default, typename... Args>
-  requires(!last_type_is_cache_manager<Args...>)
+  requires(!detail::last_type_is_cache_manager<Args...>)
 ResultPtr evaluate(Args&&... args) {
-  using Node =
-      std::remove_cvref_t<decltype(node0(arg0(std::forward<Args>(args)...)))>;
+  using Node = std::remove_cvref_t<decltype(detail::node0(
+      detail::arg0(std::forward<Args>(args)...)))>;
   auto cache = CacheManager<Node>::empty();
   return evaluate<EvalTrace>(std::forward<Args>(args)..., cache);
 }
@@ -830,10 +841,10 @@ ResultPtr evaluate_symm(Args&&... args) {
   ResultPtr pre = evaluate<EvalTrace>(std::forward<Args>(args)...);
   SEQUANT_ASSERT(pre);
   ResultPtr result;
-  auto time = timed_eval_inplace([&]() { result = pre->symmetrize(); });
+  auto time = detail::timed_eval_inplace([&]() { result = pre->symmetrize(); });
 
   // logging
-  if constexpr (trace(EvalTrace)) {
+  if constexpr (detail::trace(EvalTrace)) {
     // cache is owned by the inner evaluate call and out of scope here;
     // hwmark reflects only the local working set (pre + freshly allocated
     // result both live during the symmetrize op).
@@ -842,7 +853,9 @@ ResultPtr evaluate_symm(Args&&... args) {
                               .mem_result = log::bytes(result),
                               .mem_alloc = log::bytes(result),
                               .mem_hwmark = log::bytes(pre, result)};
-    log::eval(stat, node0(arg0(std::forward<Args>(args)...))->label());
+    log::eval(
+        stat,
+        detail::node0(detail::arg0(std::forward<Args>(args)...))->label());
   }
 
   return result;
@@ -863,14 +876,14 @@ ResultPtr evaluate_antisymm(Args&&... args) {
   ResultPtr pre = evaluate<EvalTrace>(std::forward<Args>(args)...);
   SEQUANT_ASSERT(pre);
 
-  auto const& n0 = node0(arg0(std::forward<Args>(args)...));
+  auto const& n0 = detail::node0(detail::arg0(std::forward<Args>(args)...));
 
   ResultPtr result;
-  auto time = timed_eval_inplace(
+  auto time = detail::timed_eval_inplace(
       [&]() { result = pre->antisymmetrize(n0->as_tensor().bra_rank()); });
 
   // logging
-  if constexpr (trace(EvalTrace)) {
+  if constexpr (detail::trace(EvalTrace)) {
     // See Symmetrize for the rationale on hwmark.
     auto stat = log::EvalStat{.mode = log::EvalMode::Antisymmetrize,
                               .time = time,

--- a/SeQuant/core/eval/eval_node.hpp
+++ b/SeQuant/core/eval/eval_node.hpp
@@ -37,11 +37,13 @@ ExprPtr linearize_eval_node(Node const& node) {
       Product{1, ExprPtrList{lres, rres}, Product::Flatten::Yes});
 }
 
-namespace {
+// implementation details of eval-node cost analysis; prefer sequant::detail
+// over an unnamed namespace in a header (see CppCoreGuidelines SF.21)
+namespace detail {
 
 enum NodePos { Left = 0, Right, This };
 
-[[maybe_unused]] std::pair<size_t, size_t> occ_virt(Tensor const& t) {
+[[maybe_unused]] inline std::pair<size_t, size_t> occ_virt(Tensor const& t) {
   auto bk_rank = t.bra_net_rank() + t.ket_net_rank();
   auto nocc = ranges::count_if(t.const_braket_indices(), [](Index const& idx) {
     return idx.space() ==
@@ -105,7 +107,7 @@ class ContractedIndexCount {
   size_t virt_ = 0;
   bool is_outerprod_ = false;
 };
-}  // namespace
+}  // namespace detail
 
 ///
 /// \brief This function object takes an evaluation node and returns the
@@ -122,19 +124,19 @@ struct Flops {
         && n.left()->is_tensor()         //
         && n.right()->is_tensor()) {
       if (n->is_tensor()) {
-        auto const idx_count = ContractedIndexCount{n};
+        auto const idx_count = detail::ContractedIndexCount{n};
         auto c = AsyCost{idx_count.unique_occs(), idx_count.unique_virts()};
         return idx_count.is_outerpod() ? c : 2 * c;
       } else {  // full contraction to scalar
         SEQUANT_ASSERT(n->is_scalar());
-        SEQUANT_ASSERT(occ_virt(n.left()->as_tensor()) ==
-                       occ_virt(n.right()->as_tensor()));
-        return 2 * AsyCost{occ_virt(n.left()->as_tensor())};
+        SEQUANT_ASSERT(detail::occ_virt(n.left()->as_tensor()) ==
+                       detail::occ_virt(n.right()->as_tensor()));
+        return 2 * AsyCost{detail::occ_virt(n.left()->as_tensor())};
       }
     } else if (n->is_tensor()) {
       // scalar times a tensor
       // or a tensor plus a tensor
-      return AsyCost{occ_virt(n->as_tensor())};
+      return AsyCost{detail::occ_virt(n->as_tensor())};
     } else /* scalar (+|*) scalar */
       return AsyCost::zero();
   }
@@ -153,7 +155,7 @@ struct Memory {
   [[nodiscard]] AsyCost operator()(meta::eval_node auto const& n) const {
     AsyCost result;
     auto add_cost = [&result](ExprPtr const& expr) {
-      result += expr.is<Tensor>() ? AsyCost{occ_virt(expr.as<Tensor>())}
+      result += expr.is<Tensor>() ? AsyCost{detail::occ_virt(expr.as<Tensor>())}
                                   : AsyCost::zero();
     };
 
@@ -259,14 +261,15 @@ AsyCost min_storage(meta::eval_node auto const& node) {
   auto visitor = [&result](meta::eval_node auto const& n) {
     auto cost = AsyCost::zero();
     if (n.leaf() && n->is_tensor())
-      cost = AsyCost{occ_virt(n->as_tensor())};
+      cost = AsyCost{detail::occ_virt(n->as_tensor())};
     else if (!n.leaf()) {
-      cost += (n.left()->is_tensor() ? AsyCost{occ_virt(n.left()->as_tensor())}
-                                     : AsyCost::zero());
-      cost +=
-          (n.right()->is_tensor() ? AsyCost{occ_virt(n.right()->as_tensor())}
-                                  : AsyCost::zero());
-      cost += (n->is_tensor() ? AsyCost{occ_virt(n->as_tensor())}
+      cost += (n.left()->is_tensor()
+                   ? AsyCost{detail::occ_virt(n.left()->as_tensor())}
+                   : AsyCost::zero());
+      cost += (n.right()->is_tensor()
+                   ? AsyCost{detail::occ_virt(n.right()->as_tensor())}
+                   : AsyCost::zero());
+      cost += (n->is_tensor() ? AsyCost{detail::occ_virt(n->as_tensor())}
                               : AsyCost::zero());
     } else {
       // do nothing

--- a/SeQuant/core/eval/result.hpp
+++ b/SeQuant/core/eval/result.hpp
@@ -24,14 +24,17 @@
 
 namespace sequant {
 
-namespace {
+// implementation details of the eval Result layer; prefer sequant::detail over
+// an unnamed namespace in a header (see CppCoreGuidelines SF.21 / "Use unnamed
+// namespaces in headers ... no" guidance)
+namespace detail {
 
-[[maybe_unused]] std::logic_error invalid_operand(
+[[maybe_unused]] inline std::logic_error invalid_operand(
     std::string_view msg = "Invalid operand for binary op") noexcept {
   return std::logic_error{msg.data()};
 }
 
-[[maybe_unused]] std::logic_error unimplemented_method(
+[[maybe_unused]] inline std::logic_error unimplemented_method(
     std::string_view msg) noexcept {
   using namespace std::string_literals;
   return std::logic_error{"Not implemented in this derived class: "s +
@@ -176,7 +179,7 @@ inline void log_constant(Args const&... args) noexcept {
   log_result("[CONST] ", args...);
 }
 
-}  // namespace
+}  // namespace detail
 
 /******************************************************************************/
 
@@ -289,7 +292,7 @@ class Result {
   ///
   [[nodiscard]] virtual ResultPtr adjoint(
       std::array<std::any, 2> const& /*ann*/) const {
-    throw unimplemented_method("adjoint");
+    throw detail::unimplemented_method("adjoint");
   }
 
   ///
@@ -307,7 +310,7 @@ class Result {
   [[nodiscard]] virtual ResultPtr slice_mode(std::size_t /*mode*/,
                                              std::size_t /*elem_lo*/,
                                              std::size_t /*elem_hi*/) const {
-    throw unimplemented_method("slice_mode");
+    throw detail::unimplemented_method("slice_mode");
   }
 
   ///
@@ -326,7 +329,7 @@ class Result {
   ///
   [[nodiscard]] virtual container::svector<std::pair<std::size_t, std::size_t>>
   mode_batches(std::size_t /*mode*/, std::size_t /*target_batch_size*/) const {
-    throw unimplemented_method("mode_batches");
+    throw detail::unimplemented_method("mode_batches");
   }
 
   ///
@@ -410,11 +413,11 @@ class ResultScalar final : public Result {
       auto const& o = other.as<ResultScalar<T>>();
       auto s = value() + o.value();
 
-      log_constant(value(), " + ", o.value(), " = ", s, "\n");
+      detail::log_constant(value(), " + ", o.value(), " = ", s, "\n");
 
       return eval_result<ResultScalar<T>>(s);
     } else {
-      throw invalid_operand();
+      throw detail::invalid_operand();
     }
   }
 
@@ -425,7 +428,7 @@ class ResultScalar final : public Result {
       auto const& o = other.as<ResultScalar<T>>();
       auto p = value() * o.value();
 
-      log_constant(value(), " * ", o.value(), " = ", p, "\n");
+      detail::log_constant(value(), " * ", o.value(), " = ", p, "\n");
 
       return eval_result<ResultScalar<T>>(value() * o.value());
     } else {
@@ -437,22 +440,22 @@ class ResultScalar final : public Result {
 
   [[nodiscard]] ResultPtr permute(
       std::array<std::any, 2> const&) const override {
-    throw unimplemented_method("permute");
+    throw detail::unimplemented_method("permute");
   }
 
   void add_inplace(Result const& other) override {
     SEQUANT_ASSERT(other.is<ResultScalar<T>>());
-    log_constant(value(), " += ", other.get<T>(), "\n");
+    detail::log_constant(value(), " += ", other.get<T>(), "\n");
     auto& val = get<T>();
     val += other.get<T>();
   }
 
   [[nodiscard]] ResultPtr symmetrize() const override {
-    throw unimplemented_method("symmetrize");
+    throw detail::unimplemented_method("symmetrize");
   }
 
   [[nodiscard]] ResultPtr antisymmetrize(size_t /*bra_rank*/) const override {
-    throw unimplemented_method("antisymmetrize");
+    throw detail::unimplemented_method("antisymmetrize");
   }
 
   [[nodiscard]] ResultPtr mult_by_phase(std::int8_t factor) const override {

--- a/SeQuant/core/expressions/constant.hpp
+++ b/SeQuant/core/expressions/constant.hpp
@@ -14,7 +14,9 @@
 
 namespace sequant {
 
-namespace {
+// implementation details of Constant; prefer sequant::detail over an unnamed
+// namespace in a header (see CppCoreGuidelines SF.21)
+namespace detail {
 template <typename X>
 X numeric_cast(const sequant::rational &r) {
   if constexpr (std::is_integral_v<X>) {
@@ -25,7 +27,7 @@ X numeric_cast(const sequant::rational &r) {
            boost::numeric_cast<X>(denominator(r));
   }
 };
-}  // namespace
+}  // namespace detail
 
 /// @brief a constant number
 
@@ -57,10 +59,10 @@ class Constant : public Expr {
   auto value() const {
     if constexpr (std::is_arithmetic_v<T>) {
       SEQUANT_ASSERT(value_.imag() == 0);
-      return numeric_cast<T>(value_.real());
+      return detail::numeric_cast<T>(value_.real());
     } else if constexpr (meta::is_complex_v<T>) {
-      return T(numeric_cast<typename T::value_type>(value_.real()),
-               numeric_cast<typename T::value_type>(value_.imag()));
+      return T(detail::numeric_cast<typename T::value_type>(value_.real()),
+               detail::numeric_cast<typename T::value_type>(value_.imag()));
     } else
       throw Exception("Constant::value<T>: cannot convert value to type T");
   }

--- a/SeQuant/core/utility/conversion.hpp
+++ b/SeQuant/core/utility/conversion.hpp
@@ -16,7 +16,9 @@ class ConversionException : public Exception {
   using Exception::Exception;
 };
 
-namespace {
+// implementation details of string conversion; prefer sequant::detail over an
+// unnamed namespace in a header (see CppCoreGuidelines SF.21)
+namespace detail {
 template <typename T, typename Arg>
   requires(std::integral<T> || std::floating_point<T>)
 T string_to_impl(std::string_view str, Arg &&arg) {
@@ -52,7 +54,7 @@ T string_to_impl(std::string_view str, Arg &&arg) {
   return val;
 }
 
-}  // namespace
+}  // namespace detail
 
 template <typename T>
 concept string_to_supports =
@@ -77,7 +79,7 @@ T string_to(std::string_view str, int base = 10) {
   static_assert(string_to_supports<T>,
                 "Your C++ standard library is missing a std::from_chars "
                 "implementation for this integral type");
-  return string_to_impl<T>(str, base);
+  return detail::string_to_impl<T>(str, base);
 }
 
 /// Converts the provided string to the desired floating-point type.
@@ -101,7 +103,7 @@ T string_to(std::string_view str,
                 "Your C++ standard library is missing a std::from_chars "
                 "implementation for this floating point type");
 
-  return string_to_impl<T>(str, fmt);
+  return detail::string_to_impl<T>(str, fmt);
 }
 
 }  // namespace sequant

--- a/SeQuant/domain/mbpt/biorthogonalization.hpp
+++ b/SeQuant/domain/mbpt/biorthogonalization.hpp
@@ -284,23 +284,27 @@ auto biorthogonal_nns_project_ta(TA::DistArray<Args...> const& arr,
 
   TA::DistArray<Args...> result;
 
-  perm_t perm = iota(size_t{0}, rank) | ranges::to<perm_t>;
-  perm_t bra_perm = iota(size_t{0}, bra_rank) | ranges::to<perm_t>;
-  perm_t ket_perm = iota(bra_rank, rank) | ranges::to<perm_t>;
+  sequant::detail::perm_t perm =
+      iota(size_t{0}, rank) | ranges::to<sequant::detail::perm_t>;
+  sequant::detail::perm_t bra_perm =
+      iota(size_t{0}, bra_rank) | ranges::to<sequant::detail::perm_t>;
+  sequant::detail::perm_t ket_perm =
+      iota(bra_rank, rank) | ranges::to<sequant::detail::perm_t>;
 
-  const auto lannot = ords_to_annot(perm);
+  const auto lannot = sequant::detail::ords_to_annot(perm);
 
   if (ket_rank > 2 && !nns_p_coeffs.empty()) {
-    const auto bra_annot = bra_rank == 0 ? "" : ords_to_annot(bra_perm);
+    const auto bra_annot =
+        bra_rank == 0 ? "" : sequant::detail::ords_to_annot(bra_perm);
 
     size_t num_perms = nns_p_coeffs.size();
     for (size_t perm_rank = 0; perm_rank < num_perms; ++perm_rank) {
-      perm_t permuted_ket =
+      sequant::detail::perm_t permuted_ket =
           detail::compute_permuted_indices(ket_perm, perm_rank, ket_rank);
 
       numeric_type coeff = nns_p_coeffs[perm_rank];
 
-      const auto ket_annot = ords_to_annot(permuted_ket);
+      const auto ket_annot = sequant::detail::ords_to_annot(permuted_ket);
       const auto annot =
           bra_annot.empty() ? ket_annot : bra_annot + "," + ket_annot;
 
@@ -354,21 +358,24 @@ auto biorthogonal_nns_project_btas(btas::Tensor<Args...> const& arr,
 
   btas::Tensor<Args...> result;
 
-  perm_t perm = iota(size_t{0}, rank) | ranges::to<perm_t>;
-  perm_t bra_perm = iota(size_t{0}, bra_rank) | ranges::to<perm_t>;
-  perm_t ket_perm = iota(bra_rank, rank) | ranges::to<perm_t>;
+  sequant::detail::perm_t perm =
+      iota(size_t{0}, rank) | ranges::to<sequant::detail::perm_t>;
+  sequant::detail::perm_t bra_perm =
+      iota(size_t{0}, bra_rank) | ranges::to<sequant::detail::perm_t>;
+  sequant::detail::perm_t ket_perm =
+      iota(bra_rank, rank) | ranges::to<sequant::detail::perm_t>;
 
   if (ket_rank > 2 && !nns_p_coeffs.empty()) {
     bool result_initialized = false;
 
     size_t num_perms = nns_p_coeffs.size();
     for (size_t perm_rank = 0; perm_rank < num_perms; ++perm_rank) {
-      perm_t permuted_ket =
+      sequant::detail::perm_t permuted_ket =
           detail::compute_permuted_indices(ket_perm, perm_rank, ket_rank);
 
       numeric_type coeff = nns_p_coeffs[perm_rank];
 
-      perm_t annot = bra_perm;
+      sequant::detail::perm_t annot = bra_perm;
       annot.insert(annot.end(), permuted_ket.begin(), permuted_ket.end());
 
       btas::Tensor<Args...> temp;

--- a/SeQuant/domain/mbpt/models/cc.cpp
+++ b/SeQuant/domain/mbpt/models/cc.cpp
@@ -140,8 +140,9 @@ std::vector<ExprPtr> CC::λ() {
                                                             {L"g", symm}});
 
   // 2. project onto each manifold, screen, lower to tensor form and wick it
+  // p == 0 yields the Lagrangian
   std::vector<ExprPtr> result(N + 1);
-  for (auto p = N; p >= 1; --p) {
+  for (std::int64_t p = N; p >= 0; --p) {
     // 2.a. screen out terms that cannot give nonzero after projection onto
     // <P|
     std::shared_ptr<Sum>
@@ -173,7 +174,8 @@ std::vector<ExprPtr> CC::λ() {
 
     // 2.b multiply by adjoint of P(p) (i.e., P(-p)) on the right side and
     // compute VEV
-    result.at(p) = this->ref_av(lhbar_for_vev * P(nₚ(-p)), op_connect);
+    result.at(p) = this->ref_av(
+        p != 0 ? lhbar_for_vev * P(nₚ(-p)) : lhbar_for_vev, op_connect);
   }
   return result;
 }

--- a/SeQuant/domain/mbpt/models/cc.cpp
+++ b/SeQuant/domain/mbpt/models/cc.cpp
@@ -146,7 +146,7 @@ std::vector<ExprPtr> CC::λ() {
     const auto hbar_λ =
         mbpt::lst(H(), adjoint(Λ(N, skip_singles())), commutator_rank);
     result.at(0) = this->ref_av(
-        hbar_λ, {{L"h", L"λ"}, {L"f", L"λ"}, {L"f̃", L"λ"}, {L"g", L"λ"}});
+        hbar_λ, {{L"h", L"λ⁺"}, {L"f", L"λ⁺"}, {L"f̃", L"λ⁺"}, {L"g", L"λ⁺"}});
   }
 
   // 2. project onto each manifold, screen, lower to tensor form and wick it

--- a/SeQuant/domain/mbpt/models/cc.cpp
+++ b/SeQuant/domain/mbpt/models/cc.cpp
@@ -139,10 +139,18 @@ std::vector<ExprPtr> CC::λ() {
                                                             {L"f", symm},
                                                             {L"g", symm}});
 
-  // 2. project onto each manifold, screen, lower to tensor form and wick it
-  // p == 0 yields the Lagrangian
   std::vector<ExprPtr> result(N + 1);
-  for (std::int64_t p = N; p >= 0; --p) {
+
+  // element 0: λ pseudoenergy, computed as the CC energy with T → Λ⁺.
+  {
+    const auto hbar_λ =
+        mbpt::lst(H(), adjoint(Λ(N, skip_singles())), commutator_rank);
+    result.at(0) = this->ref_av(
+        hbar_λ, {{L"h", L"λ"}, {L"f", L"λ"}, {L"f̃", L"λ"}, {L"g", L"λ"}});
+  }
+
+  // 2. project onto each manifold, screen, lower to tensor form and wick it
+  for (std::int64_t p = N; p >= 1; --p) {
     // 2.a. screen out terms that cannot give nonzero after projection onto
     // <P|
     std::shared_ptr<Sum>
@@ -174,8 +182,7 @@ std::vector<ExprPtr> CC::λ() {
 
     // 2.b multiply by adjoint of P(p) (i.e., P(-p)) on the right side and
     // compute VEV
-    result.at(p) = this->ref_av(
-        p != 0 ? lhbar_for_vev * P(nₚ(-p)) : lhbar_for_vev, op_connect);
+    result.at(p) = this->ref_av(lhbar_for_vev * P(nₚ(-p)), op_connect);
   }
   return result;
 }

--- a/SeQuant/domain/mbpt/models/cc.cpp
+++ b/SeQuant/domain/mbpt/models/cc.cpp
@@ -150,7 +150,7 @@ std::vector<ExprPtr> CC::λ() {
   }
 
   // 2. project onto each manifold, screen, lower to tensor form and wick it
-  for (std::int64_t p = N; p >= 1; --p) {
+  for (auto p = N; p >= 1; --p) {
     // 2.a. screen out terms that cannot give nonzero after projection onto
     // <P|
     std::shared_ptr<Sum>

--- a/SeQuant/domain/mbpt/models/cc.hpp
+++ b/SeQuant/domain/mbpt/models/cc.hpp
@@ -110,8 +110,8 @@ class CC {
   /// equation
   ///   \f$ \langle 0| (1 + \hat{\Lambda}) \frac{d \bar{H}}{d \hat{T}_k} |0
   ///   \rangle = 0 \f$ for `k` in
-  /// the [1,N] range; element 0 contains the Lagrangian
-  ///   \f$ \langle 0| (1 + \hat{\Lambda}) \bar{H} |0 \rangle \f$
+  /// the [1,N] range; element 0 contains the λ pseudoenergy, computed as the
+  /// CC energy with \f$ \hat{T} \f$ replaced by \f$ \hat{\Lambda}^{\dagger} \f$
   [[nodiscard]] std::vector<ExprPtr> λ();
 
   // clang-format off

--- a/SeQuant/domain/mbpt/models/cc.hpp
+++ b/SeQuant/domain/mbpt/models/cc.hpp
@@ -110,7 +110,8 @@ class CC {
   /// equation
   ///   \f$ \langle 0| (1 + \hat{\Lambda}) \frac{d \bar{H}}{d \hat{T}_k} |0
   ///   \rangle = 0 \f$ for `k` in
-  /// the [1,N] range; element 0 is always null
+  /// the [1,N] range; element 0 contains the Lagrangian
+  ///   \f$ \langle 0| (1 + \hat{\Lambda}) \bar{H} |0 \rangle \f$
   [[nodiscard]] std::vector<ExprPtr> λ();
 
   // clang-format off

--- a/SeQuant/domain/mbpt/op.ipp
+++ b/SeQuant/domain/mbpt/op.ipp
@@ -160,16 +160,19 @@ void Operator<QuantumNumbers, S>::adjoint() {
   const auto saved_order = this->order_;
   const auto saved_batch_ordinals = this->batch_ordinals_;
 
-  const auto tnsr = this->tensor_form();
-  *this =
-      Operator{[=]() -> std::wstring_view { return lbl; },  // label_generator
-               [=]() -> ExprPtr {
-                 return sequant::adjoint(tnsr);  // tensor_form_generator
-               },
-               [=](qnc_t& qn) {
-                 qn += sequant::adjoint(dN);
-                 return qn;  // qn_action
-               }};
+  // capture the current tensor-form generator so that each call regenerates
+  // fresh dummy indices; otherwise using this adjoint operator more than once
+  // would yield tensors that have same indices
+  auto base_tensor_form = this->tensor_form_generator_;
+  *this = Operator{
+      [=]() -> std::wstring_view { return lbl; },  // label_generator
+      [=]() -> ExprPtr {
+        return sequant::adjoint(base_tensor_form());  // tensor_form_generator
+      },
+      [=](qnc_t& qn) {
+        qn += sequant::adjoint(dN);
+        return qn;  // qn_action
+      }};
   this->is_adjoint_ = !this->is_adjoint_;  // toggle adjoint flag
 
   // restore original order and batch_ordinals

--- a/SeQuant/domain/mbpt/op.ipp
+++ b/SeQuant/domain/mbpt/op.ipp
@@ -162,7 +162,7 @@ void Operator<QuantumNumbers, S>::adjoint() {
 
   // capture the current tensor-form generator so that each call regenerates
   // fresh dummy indices; otherwise using this adjoint operator more than once
-  // would yield tensors that have same indices
+  // would yield tensors that have the same indices.
   auto base_tensor_form = this->tensor_form_generator_;
   *this = Operator{
       [=]() -> std::wstring_view { return lbl; },  // label_generator

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -1295,6 +1295,71 @@ TEST_CASE("eval_with_tiledarray", "[eval]") {
       }
       REQUIRE(result == Catch::Approx(ref));
     }
+
+    SECTION("symmetrize") {
+      // A double-valued yield is used because the 1/n! prefactor is fractional.
+      rand_tensor_yield<double> dyield{world, nocc, nvirt};
+      using DArrayToT = typename decltype(dyield)::array_tot_type;
+
+      // n=2 (logical rank 4): outer = occupied (i1,i2), inner = virtual
+      // (a1,a2). symmetrize() must produce S(i,j;a,b) = 1/2! * (R(i,j;a,b) +
+      // R(j,i;b,a))
+      // -- outer and inner modes permute in lockstep.
+      {
+        auto const Rnode = eval_node(
+            deserialize<sequant::ExprPtr>(L"R{a1<i1,i2>,a2<i1,i2>;i1,i2}"));
+        auto const Rres = dyield(Rnode);
+        auto const& R = Rres->get<DArrayToT>();
+
+        auto const symm = Rres->symmetrize()->get<DArrayToT>();
+
+        std::string const annot{"i_1,i_2;a_1i_1i_2,a_2i_1i_2"};
+        DArrayToT ref;
+        ref(annot) = R(annot) + R("i_2,i_1;a_2i_1i_2,a_1i_1i_2");
+        ref(annot) = 0.5 * ref(annot);
+
+        DArrayToT diff;
+        diff(annot) = symm(annot) - ref(annot);
+        // Norm-squared of the difference; an absolute margin is needed because
+        // Approx(0.0) is a pure relative test. The reference sums the same
+        // permutations in a different order than the production helper, so a
+        // tiny rounding residual (~1e-30) is expected; a real mismatch is O(1).
+        REQUIRE(diff(annot).dot(diff(annot)) ==
+                Catch::Approx(0.0).margin(1e-12));
+      }
+
+      // n=3 (logical rank 6): exercises the 6-permutation / 1/3! path. The 6
+      // particle permutations permute outer (i1,i2,i3) and inner (a1,a2,a3) in
+      // lockstep; each inner index keeps its proto-suffix "i_1i_2i_3".
+      {
+        auto const Rnode = eval_node(deserialize<sequant::ExprPtr>(
+            L"R{a1<i1,i2,i3>,a2<i1,i2,i3>,a3<i1,i2,i3>;i1,i2,i3}"));
+        auto const Rres = dyield(Rnode);
+        auto const& R = Rres->get<DArrayToT>();
+
+        auto const symm = Rres->symmetrize()->get<DArrayToT>();
+
+        std::string const annot{
+            "i_1,i_2,i_3;a_1i_1i_2i_3,a_2i_1i_2i_3,a_3i_1i_2i_3"};
+        DArrayToT ref;
+        ref(annot) = R("i_1,i_2,i_3;a_1i_1i_2i_3,a_2i_1i_2i_3,a_3i_1i_2i_3") +
+                     R("i_1,i_3,i_2;a_1i_1i_2i_3,a_3i_1i_2i_3,a_2i_1i_2i_3") +
+                     R("i_3,i_1,i_2;a_3i_1i_2i_3,a_1i_1i_2i_3,a_2i_1i_2i_3") +
+                     R("i_3,i_2,i_1;a_3i_1i_2i_3,a_2i_1i_2i_3,a_1i_1i_2i_3") +
+                     R("i_2,i_3,i_1;a_2i_1i_2i_3,a_3i_1i_2i_3,a_1i_1i_2i_3") +
+                     R("i_2,i_1,i_3;a_2i_1i_2i_3,a_1i_1i_2i_3,a_3i_1i_2i_3");
+        ref(annot) = (1.0 / 6.0) * ref(annot);
+
+        DArrayToT diff;
+        diff(annot) = symm(annot) - ref(annot);
+        // Norm-squared of the difference; an absolute margin is needed because
+        // Approx(0.0) is a pure relative test. The reference sums the same
+        // permutations in a different order than the production helper, so a
+        // tiny rounding residual (~1e-30) is expected; a real mismatch is O(1).
+        REQUIRE(diff(annot).dot(diff(annot)) ==
+                Catch::Approx(0.0).margin(1e-12));
+      }
+    }
   }
 }
 

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -534,6 +534,16 @@ TEST_CASE("mbpt", "[mbpt][valgrind_skip]") {
       auto λ1_order3_adj = adjoint(λ1_order3);
       REQUIRE(λ1_order3_adj.as<op_t>().order() == 3);
 
+      // each call to tensor_form() must generate fresh dummy indices, otherwise
+      // using an operator more than once (e.g. squaring it in a similarity
+      // transform) yields tensors that share indices. Non-adjoint
+      // operators satisfy this:
+      op_t t2op = t(2)->as<op_t>();
+      REQUIRE(to_latex(t2op.tensor_form()) != to_latex(t2op.tensor_form()));
+      // adjoint operators must satisfy it too:
+      op_t λ2adj = adjoint(λ(2))->as<op_t>();
+      REQUIRE(to_latex(λ2adj.tensor_form()) != to_latex(λ2adj.tensor_form()));
+
     }  // SECTION("adjoint")
 
     SECTION("screen") {

--- a/tests/unit/test_mbpt_cc.cpp
+++ b/tests/unit/test_mbpt_cc.cpp
@@ -31,6 +31,23 @@ TEST_CASE("mbpt_cc", "[mbpt/cc][valgrind_skip]") {
       }
 
     }  // SECTION("t")
+
+    SECTION("λ") {
+      SECTION("CCSD λ") {
+        const auto N = 2;
+        auto cc = CC{N};
+        auto λ_eqs = cc.λ();
+        REQUIRE(λ_eqs.size() == N + 1);
+        // element 0 is the λ pseudoenergy: the CC energy with T → Λ⁺, i.e. the
+        // CC energy expression with the cluster amplitudes replaced by Λ⁺
+        REQUIRE_THAT(λ_eqs[0],
+                     EquivalentTo(L"f{i_1;a_1}:A-C-S λ⁺{a_1;i_1}:A-N-S "
+                                  L"+ 1/4 g{i_1,i_2;a_1,a_2}:A-C-S "
+                                  L"λ⁺{a_1,a_2;i_1,i_2}:A-N-S "
+                                  L"+ 1/2 g{i_1,i_2;a_1,a_2}:A-C-S "
+                                  L"λ⁺{a_1;i_1}:A-N-S λ⁺{a_2;i_2}:A-N-S"));
+      }
+    }  // SECTION("λ")
   }
 
   SECTION("eom_cc"){SECTION("EOM-CCSD"){const auto N = 2;


### PR DESCRIPTION
This PR is a collection of changes needed for the CCk refactor in MPQC4.

### Changes
- `CC::λ()` computes the λ pseudoenergy (CC energy with `T` → `Λ⁺`) as the zeroth element (e6821b3ca & 704d7f0)
- Fix `mbpt::Operator::adjoint()` to regenerate fresh dummy indices on each `tensor_form()` call (3be936f50)
- Support `evaluate_symm` for ToT (681c6dd393f3ace4f6c0cfa68460882e9c28e401)