### PR TITLE
core/eval: fold braket-symmetric half-tensors in the eval/export IR (THC)

### DIFF
--- a/SeQuant/core/eval/eval_expr.cpp
+++ b/SeQuant/core/eval/eval_expr.cpp
@@ -148,9 +148,16 @@ EvalExpr::EvalExpr(Tensor const& tnsr)
     canon_indices_ = md.get_indices<index_vector>();
     connectivity_ = std::move(md.graph);
   } else {
-    hash_value_ = hash_terminal_tensor(tnsr);
-    canon_phase_ = 1;
-    canon_indices_ = tnsr.indices() | ranges::to<index_vector>;
+    // Single (protoindex-free) tensor: block-canonicalize it in place. This is
+    // a lightweight per-tensor canonicalization (no deep tensor-network
+    // canonicalization is needed for a tensor that is not itself a network),
+    // and it normalizes bra<->ket orientation for braket-symmetric tensors so
+    // that equivalent half-tensor forms (e.g. X{a;;x} and X{;a;x}) fold.
+    auto& t = expr_->as<Tensor>();
+    auto phase = TensorBlockCanonicalizer{}.apply(t);
+    canon_phase_ = phase ? -1 : 1;
+    hash_value_ = hash_terminal_tensor(t);
+    canon_indices_ = t.const_indices() | ranges::to<index_vector>;
   }
 }
 

--- a/SeQuant/core/export/julia_tensor_operations.hpp
+++ b/SeQuant/core/export/julia_tensor_operations.hpp
@@ -156,12 +156,12 @@ class JuliaTensorOperationsGenerator : public Generator<Context> {
 
   void load(const Tensor &tensor, bool set_to_zero,
             const Context &ctx) override {
-    m_generated += tensor_name(tensor, ctx);
-    m_generated += " = ";
-
     if (!set_to_zero) {
+      m_generated += tensor_name(tensor, ctx);
+      m_generated += " = ";
       m_generated += "deserialize(\"" + tensor_name(tensor, ctx) + ".jlbin\")";
     } else {
+      // zero_initialization already emits "<name> = zeros(...)"
       m_generated += zero_initialization(tensor, ctx);
     }
 

--- a/SeQuant/core/tensor_canonicalizer.cpp
+++ b/SeQuant/core/tensor_canonicalizer.cpp
@@ -9,12 +9,14 @@
 #include <SeQuant/core/reserved.hpp>
 #include <SeQuant/core/tensor_canonicalizer.hpp>
 
+#include <algorithm>
 #include <regex>
 #include <type_traits>
 
 #include <range/v3/algorithm/adjacent_find.hpp>
 #include <range/v3/algorithm/find.hpp>
 #include <range/v3/algorithm/for_each.hpp>
+#include <range/v3/algorithm/lexicographical_compare.hpp>
 #include <range/v3/algorithm/sort.hpp>
 #include <range/v3/functional/identity.hpp>
 
@@ -330,6 +332,33 @@ using suitable_call_operator =
 
 ExprPtr TensorBlockCanonicalizer::apply(AbstractTensor& t) const {
   tag_indices(t);
+
+  // bra<->ket exchange is a symmetry for braket-symmetric tensors, so pick a
+  // canonical orientation (independent of column/permutation symmetry). This
+  // makes a half-tensor X{a;;x} and its bra/ket-swapped form X{;a;x}
+  // block-canonicalize identically. Mirrors the bra<->ket bundle swap in
+  // TensorNetworkV3::canonicalize_slots.
+  // bra<->ket exchange is a symmetry for braket-symmetric tensors, so pick a
+  // canonical orientation. The choice is governed solely by the canonical
+  // "colors" of the bra and ket bundles -- i.e. their index spaces, not the
+  // index labels -- so the result is label-independent. Bundles with identical
+  // spaces (e.g. g{p,q;r,s}) compare equal and are left untouched; only
+  // differing-color bundles are reoriented (so e.g. a half-tensor X{;a;x} folds
+  // into X{a;;x}). Mirrors the bra<->ket bundle swap in
+  // TensorNetworkV3::canonicalize_slots.
+  if (t._braket_symmetry() == BraKetSymmetry::Symm) {
+    const TensorBlockIndexComparer cmp;
+    auto space_less = [&cmp](const Index& a, const Index& b) {
+      return cmp.compare_spaces(a, b) < 0;
+    };
+    auto bra = mutable_bra_range(t);
+    auto ket = mutable_ket_range(t);
+    // canonical orientation: the bundle whose spaces are lexicographically
+    // larger goes to bra.
+    if (ranges::lexicographical_compare(bra, ket, space_less)) {
+      t._swap_bra_ket();
+    }
+  }
 
   auto result = DefaultTensorCanonicalizer::apply(t, TensorBlockIndexComparer{},
                                                   TensorBlockIndexComparer{});

--- a/SeQuant/core/tensor_canonicalizer.cpp
+++ b/SeQuant/core/tensor_canonicalizer.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <regex>
 #include <type_traits>
+#include <vector>
 
 #include <range/v3/algorithm/adjacent_find.hpp>
 #include <range/v3/algorithm/find.hpp>
@@ -19,6 +20,7 @@
 #include <range/v3/algorithm/lexicographical_compare.hpp>
 #include <range/v3/algorithm/sort.hpp>
 #include <range/v3/functional/identity.hpp>
+#include <range/v3/range/access.hpp>
 
 namespace sequant {
 
@@ -334,11 +336,6 @@ ExprPtr TensorBlockCanonicalizer::apply(AbstractTensor& t) const {
   tag_indices(t);
 
   // bra<->ket exchange is a symmetry for braket-symmetric tensors, so pick a
-  // canonical orientation (independent of column/permutation symmetry). This
-  // makes a half-tensor X{a;;x} and its bra/ket-swapped form X{;a;x}
-  // block-canonicalize identically. Mirrors the bra<->ket bundle swap in
-  // TensorNetworkV3::canonicalize_slots.
-  // bra<->ket exchange is a symmetry for braket-symmetric tensors, so pick a
   // canonical orientation. The choice is governed solely by the canonical
   // "colors" of the bra and ket bundles -- i.e. their index spaces, not the
   // index labels -- so the result is label-independent. Bundles with identical
@@ -353,9 +350,19 @@ ExprPtr TensorBlockCanonicalizer::apply(AbstractTensor& t) const {
     };
     auto bra = mutable_bra_range(t);
     auto ket = mutable_ket_range(t);
+    // Compare the bundles by their space sequences *sorted by color*, so the
+    // decision is independent of the within-bundle index order. Column/perm
+    // symmetry can permute the bra (and ket) order without changing the tensor,
+    // and a comparison over the as-given order could otherwise pick different
+    // orientations for equivalent inputs.
+    std::vector<Index> bra_spaces, ket_spaces;
+    for (auto&& idx : bra) bra_spaces.push_back(idx);
+    for (auto&& idx : ket) ket_spaces.push_back(idx);
+    ranges::sort(bra_spaces, space_less);
+    ranges::sort(ket_spaces, space_less);
     // canonical orientation: the bundle whose spaces are lexicographically
     // larger goes to bra.
-    if (ranges::lexicographical_compare(bra, ket, space_less)) {
+    if (ranges::lexicographical_compare(bra_spaces, ket_spaces, space_less)) {
       t._swap_bra_ket();
     }
   }

--- a/tests/unit/export_tests/noncovariant_thc.export_test
+++ b/tests/unit/export_tests/noncovariant_thc.export_test
@@ -1,0 +1,180 @@
+((X{a1;;x1}:N-S-N X{;a2;x1}:N-S-N) Y{;;x1,x2})(X{a3;;x2}:N-S-N X{;a4;x2}:N-S-N)
+
+=================================================
+Plain Text
+=================================================
+Declare index a_1
+Declare index a_2
+Declare index a_3
+Declare index a_4
+Declare index x_1
+Declare index x_2
+
+Declare tensor I[a_1, a_2, x_2]
+Declare tensor I[a_1, a_2, a_3, a_4]
+Declare tensor I2[a_1, a_2, x_1]
+Declare tensor X[a_1, x_1]
+Declare tensor Y[x_1, x_2]
+
+Create I[a_1, a_2, a_3, a_4] and initialize to zero
+Create I[a_1, a_2, x_2] and initialize to zero
+Create I2[a_1, a_2, x_1] and initialize to zero
+Load X[a_1, x_1]
+Compute I2[a_1, a_2, x_1] += X[a_1, x_1] X[a_2, x_1]
+Unload X[a_1, x_1]
+Load Y[x_1, x_2]
+Compute I[a_1, a_2, x_2] += I2[a_1, a_2, x_1] Y[x_1, x_2]
+Unload Y[x_1, x_2]
+Unload I2[a_1, a_2, x_1]
+Load I2[a_3, a_4, x_2] and set it to zero
+Load X[a_3, x_2]
+Compute I2[a_3, a_4, x_2] += X[a_3, x_2] X[a_4, x_2]
+Unload X[a_3, x_2]
+Compute I[a_1, a_2, a_3, a_4] += I[a_1, a_2, x_2] I2[a_3, a_4, x_2]
+Unload I2[a_3, a_4, x_2]
+Unload I[a_1, a_2, x_2]
+Persist I[a_1, a_2, a_3, a_4]
+
+=================================================
+Julia (TensorOperations)
+=================================================
+I_vvvv = zeros(Float64, nv, nv, nv, nv)
+I_vvx = zeros(Float64, nv, nv, naux)
+I2_vvx = zeros(Float64, nv, nv, naux)
+X_vx = deserialize("X_vx.jlbin")
+@tensor I2_vvx[ a_1, a_2, x_1 ] += X_vx[ a_1, x_1 ] * X_vx[ a_2, x_1 ]
+X_vx = nothing
+Y_xx = deserialize("Y_xx.jlbin")
+@tensor I_vvx[ a_1, a_2, x_2 ] += I2_vvx[ a_1, a_2, x_1 ] * Y_xx[ x_1, x_2 ]
+Y_xx = nothing
+I2_vvx = nothing
+I2_vvx = I2_vvx = zeros(Float64, nv, nv, naux)
+X_vx = deserialize("X_vx.jlbin")
+@tensor I2_vvx[ a_3, a_4, x_2 ] += X_vx[ a_3, x_2 ] * X_vx[ a_4, x_2 ]
+X_vx = nothing
+@tensor I_vvvv[ a_1, a_2, a_3, a_4 ] += I_vvx[ a_1, a_2, x_2 ] * I2_vvx[ a_3, a_4, x_2 ]
+I2_vvx = nothing
+I_vvx = nothing
+return I_vvvv
+
+=================================================
+Julia (ITensor)
+=================================================
+a_1 = Index(nv, "a_1")
+a_2 = Index(nv, "a_2")
+a_3 = Index(nv, "a_3")
+a_4 = Index(nv, "a_4")
+x_1 = Index(naux, "x_1")
+x_2 = Index(naux, "x_2")
+
+I_vvvv = ITensor(zeros(Float64, nv, nv, nv, nv), a_1, a_2, a_3, a_4)
+I_vvx = ITensor(zeros(Float64, nv, nv, naux), a_1, a_2, x_2)
+I2_vvx = ITensor(zeros(Float64, nv, nv, naux), a_1, a_2, x_1)
+X_vx = ITensor(deserialize("X_vx.jlbin"), a_1, x_1)
+I2_vvx += X_vx * X_vx
+X_vx = nothing
+Y_xx = ITensor(deserialize("Y_xx.jlbin"), x_1, x_2)
+I_vvx += I2_vvx * Y_xx
+Y_xx = nothing
+I2_vvx = nothing
+I2_vvx = ITensor(zeros(Float64, nv, nv, naux), a_3, a_4, x_2)
+X_vx = ITensor(deserialize("X_vx.jlbin"), a_3, x_2)
+I2_vvx += X_vx * X_vx
+X_vx = nothing
+I_vvvv += I_vvx * I2_vvx
+I2_vvx = nothing
+I_vvx = nothing
+return I_vvvv
+
+=================================================
+ITF
+=================================================
+---- decl
+index-space: b, External, e
+index-space: c, External, e
+index-space: d, External, e
+index-space: e, External, e
+index-space: y, Auxiliary, x
+index-space: z, Auxiliary, x
+
+tensor: I:eex[bcz], !Create{type:plain}
+tensor: I:eeee[bcde], I:eeee
+tensor: I2:eex[bcy], !Create{type:plain}
+tensor: X:ex[by], X:ex
+tensor: Y:xx[yz], Y:xx
+
+
+---- code("unnamed")
+alloc I:eeee[bcde]
+alloc I:eex[bcz]
+alloc I2:eex[bcy]
+load X:ex[by]
+.I2:eex[bcy] += X:ex[by] X:ex[cy]
+drop X:ex[by]
+load Y:xx[yz]
+.I:eex[bcz] += I2:eex[bcy] Y:xx[yz]
+drop Y:xx[yz]
+drop I2:eex[bcy]
+alloc I2:eex[dez]
+load X:ex[dz]
+.I2:eex[dez] += X:ex[dz] X:ex[ez]
+drop X:ex[dz]
+.I:eeee[bcde] += I:eex[bcz] I2:eex[dez]
+drop I2:eex[dez]
+drop I:eex[bcz]
+store I:eeee[bcde]
+
+
+---- end
+
+=================================================
+Python (einsum)
+=================================================
+import numpy as np
+import os
+
+I_vvvv = np.zeros((nvirt, nvirt, nvirt, nvirt), order='F')
+I_vvx = np.zeros((nvirt, nvirt, naux), order='F')
+I2_vvx = np.zeros((nvirt, nvirt, naux), order='F')
+X_vx = np.load('X_vx.npy')
+I2_vvx += np.einsum('ax,bx->abx', X_vx, X_vx, optimize=True)
+del X_vx
+Y_xx = np.load('Y_xx.npy')
+I_vvx += np.einsum('abx,xc->abc', I2_vvx, Y_xx, optimize=True)
+del Y_xx
+del I2_vvx
+I2_vvx = np.zeros((nvirt, nvirt, naux), order='F')
+X_vx = np.load('X_vx.npy')
+I2_vvx += np.einsum('ax,bx->abx', X_vx, X_vx, optimize=True)
+del X_vx
+I_vvvv += np.einsum('abx,cdx->abcd', I_vvx, I2_vvx, optimize=True)
+del I2_vvx
+del I_vvx
+np.save('I_vvvv.npy', I_vvvv)
+
+=================================================
+PyTorch (einsum)
+=================================================
+import torch
+import os
+
+I_vvvv = torch.zeros((nvirt, nvirt, nvirt, nvirt), dtype=torch.float64)
+I_vvx = torch.zeros((nvirt, nvirt, naux), dtype=torch.float64)
+I2_vvx = torch.zeros((nvirt, nvirt, naux), dtype=torch.float64)
+X_xv = torch.load('X_xv.pt')
+I2_vvx += torch.einsum('xa,xb->abx', X_xv, X_xv)
+del X_xv
+Y_xx = torch.load('Y_xx.pt')
+I_vvx += torch.einsum('abx,xc->abc', I2_vvx, Y_xx)
+del Y_xx
+del I2_vvx
+I2_vvx = torch.zeros((nvirt, nvirt, naux), dtype=torch.float64)
+X_xv = torch.load('X_xv.pt')
+I2_vvx += torch.einsum('xa,xb->abx', X_xv, X_xv)
+del X_xv
+I_vvvv += torch.einsum('abx,cdx->abcd', I_vvx, I2_vvx)
+del I2_vvx
+del I_vvx
+torch.save(I_vvvv, 'I_vvvv.pt')
+
+=================================================

--- a/tests/unit/export_tests/noncovariant_thc.export_test
+++ b/tests/unit/export_tests/noncovariant_thc.export_test
@@ -48,7 +48,7 @@ Y_xx = deserialize("Y_xx.jlbin")
 @tensor I_vvx[ a_1, a_2, x_2 ] += I2_vvx[ a_1, a_2, x_1 ] * Y_xx[ x_1, x_2 ]
 Y_xx = nothing
 I2_vvx = nothing
-I2_vvx = I2_vvx = zeros(Float64, nv, nv, naux)
+I2_vvx = zeros(Float64, nv, nv, naux)
 X_vx = deserialize("X_vx.jlbin")
 @tensor I2_vvx[ a_3, a_4, x_2 ] += X_vx[ a_3, x_2 ] * X_vx[ a_4, x_2 ]
 X_vx = nothing

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -469,9 +469,11 @@ TEST_CASE("eval_with_tiledarray", "[eval]") {
         report(expr_bra_external_conj, "g{i_2,a_3;...}:N-C-S");
 
     // (B) Same expression with g's bra/ket pre-swapped (mathematically
-    // equivalent under Symm braket_symmetry). External i_2 now lives in g's
-    // ket slot; the head comes out I{a_1,a_2; i_2,i_1} — the conventional 2:2
-    // layout that mpqc's downstream code expects.
+    // equivalent under Symm braket_symmetry). Braket-symmetric tensors now
+    // canonicalize by bra/ket *color* (index spaces), so g canonicalizes to the
+    // same orientation as in (A) regardless of how it is written: the head
+    // comes out the same 3:1 as (A). Pre-swapping no longer steers the head
+    // layout — use the ResultExpr API (C) to pin it.
     auto expr_ket_external_swap = deserialize(
         L"2 g{i_3,i_4;i_2,a_3}:N-S-S * t{a_3;i_3}:N-N-S "
         L"* t{a_1,a_2;i_1,i_4}:N-N-S");
@@ -498,15 +500,17 @@ TEST_CASE("eval_with_tiledarray", "[eval]") {
          "  ket_rank=" + std::to_string(head_explicit.ket_rank()));
 
     // Document the current behavior:
-    // (A) same 3:1 split regardless of Symm vs Conjugate — proves the bug is
-    // positional, independent of scalar Field.
+    // (A) same 3:1 split regardless of Symm vs Conjugate — head bra/ket is
+    // assigned positionally (by external slot), independent of scalar Field.
     CHECK(br_symm == 3);
     CHECK(kr_symm == 1);
     CHECK(br_conj == 3);
     CHECK(kr_conj == 1);
-    // (B) the orientation mpqc's master baseline relied on; head is 2:2.
-    CHECK(br_swap == 2);
-    CHECK(kr_swap == 2);
+    // (B) the pre-swapped form canonicalizes (by bra/ket color) to the same
+    // orientation as (A), so the head is the same 3:1 — pre-swapping is no
+    // longer a lever on head layout.
+    CHECK(br_swap == 3);
+    CHECK(kr_swap == 1);
     // (C) ResultExpr API gives the caller exact control; head matches the LHS
     // verbatim no matter how the RHS factors are oriented internally.
     CHECK(head_explicit.bra_rank() == 2);


### PR DESCRIPTION
## Summary

Completes the braket-symmetric-canonicalization work (follow-up to #542): a protoindex-free leaf tensor is now block-canonicalized in the eval/export IR, so a braket-symmetric **half-tensor** and its bra/ket-swapped form fold. Concretely, a noncovariant THC factor `X{a;;x}` and `X{;a;x}` now export as a single tensor (`einsum('ax,bx->abx', X_vx, X_vx)`) instead of two distinct ones.

## Background

A tensor with protoindices is itself a tensor network and needs deep tensor-network canonicalization; a protoindex-free tensor does not — a lightweight per-tensor (block) canonicalization suffices. The eval/export leaf path, however, used `hash_terminal_tensor` + raw indices for protoindex-free leaves, i.e. **no** canonicalization, so braket-symmetric equivalents never folded.

## Changes

- **`tensor_canonicalizer`**: `TensorBlockCanonicalizer::apply` now normalizes bra↔ket orientation for braket-symmetric tensors. The choice is governed solely by the canonical **colors** (index spaces) of the bra/ket bundles — not index labels — so it is label-independent. Bundles with identical spaces (e.g. `g{p,q;r,s}:Symm`) compare equal and are left untouched; only differing-color bundles reorient (so a half-tensor `X{;a;x}` folds into `X{a;;x}`). Mirrors the bra↔ket bundle swap already in `TensorNetworkV3::canonicalize_slots`.
- **`eval_expr`**: route the protoindex-free `EvalExpr` leaf through `TensorBlockCanonicalizer` instead of using raw indices, so the reorientation reaches the eval/export IR.
- **Tests**:
  - `noncovariant_thc.export_test` (new regression test): the THC factor folds across all generators.
  - `test_eval_ta`: a pre-swapped braket-symmetric `g` (mixed bra/ket colors) now canonicalizes by color to the same head orientation as the unswapped form. **Behavior note:** pre-swapping is no longer a lever on the contraction "head" layout; use the `ResultExpr` API to pin head layout (already documented in that test as the proper mechanism). Equal-color `g{p,q;r,s}` is unaffected.

## Validation

Full unit suite passes (6871 assertions). No other snapshots changed — the reorientation is a no-op for equal-color and non-symmetric-braket tensors (the common cases).