### PR TITLE
Persistence-aware single-term optimizer cost (n_replay)

### DIFF
--- a/SeQuant/core/optimize/optimize.cpp
+++ b/SeQuant/core/optimize/optimize.cpp
@@ -35,11 +35,13 @@ index_to_extent_t default_idx_to_size() {
 ExprPtr opt_pure_product(Product const& prod, OptimizeOptions const& opts) {
   bool const subnet_cse = opts.subnet_cse == SubnetCSE::Enable;
   if (opts.opt_for == OptFor::Flops)
-    return opt::single_term_opt<OptFor::Flops>(prod, opts.idx_to_extent,
-                                               subnet_cse);
+    return opt::single_term_opt<OptFor::Flops>(
+        prod, opts.idx_to_extent, subnet_cse, opts.is_volatile_leaf,
+        opts.n_replay);
   SEQUANT_ASSERT(opts.opt_for == OptFor::Memsize);
-  return opt::single_term_opt<OptFor::Memsize>(prod, opts.idx_to_extent,
-                                               subnet_cse);
+  return opt::single_term_opt<OptFor::Memsize>(
+      prod, opts.idx_to_extent, subnet_cse, opts.is_volatile_leaf,
+      opts.n_replay);
 }
 
 /// Deliberately non-identifier label prefix used to stand in for non-Tensor,

--- a/SeQuant/core/optimize/options.hpp
+++ b/SeQuant/core/optimize/options.hpp
@@ -7,6 +7,7 @@
 namespace sequant {
 
 class Index;
+class Tensor;
 
 /// Cost metric to optimize for in single-term and top-level optimize routines.
 enum class OptFor { Flops, Memsize };
@@ -45,6 +46,22 @@ struct OptimizeOptions {
   /// Caller-supplied Index to extent provider. If empty, defaults to
   /// \c IndexSpace::approximate_size().
   index_to_extent_t idx_to_extent = {};
+
+  /// Marks a LEAF tensor as volatile: its value changes between replays of the
+  /// network, so any contraction depending on it is re-evaluated on every
+  /// replay. Empty (default) ⇒ no tensor is volatile ⇒ cost weighting is
+  /// disabled and n_replay is ignored (behavior identical to before this
+  /// feature). CC callers pass label==volatile_label, the same classification
+  /// the runtime eval cache uses, so the optimizer's cost model and the cache
+  /// agree.
+  std::function<bool(Tensor const&)> is_volatile_leaf = {};
+
+  /// Expected number of times the network is replayed with the volatile inputs
+  /// mutated; the cost of each volatile contraction is multiplied by this,
+  /// while persistent (volatile-independent) contractions are counted once.
+  /// Default 1 (no change). Only consulted when is_volatile_leaf is non-empty
+  /// and opt_for == Flops.
+  unsigned n_replay = 1;
 };
 
 }  // namespace sequant

--- a/SeQuant/core/optimize/single_term.hpp
+++ b/SeQuant/core/optimize/single_term.hpp
@@ -352,6 +352,15 @@ EvalSequence single_term_opt_impl(TensorNetwork const& network,
 /// \param idxsz An invocable on Index, that maps Index to its dimension.
 /// \param subnet_cse Whether to recognize equivalent subnetworks to try
 /// minimizing the ops counts.
+/// \param is_volatile_leaf Predicate marking a leaf tensor as volatile (its
+/// value changes on every replay); empty disables weighting. The predicate MUST
+/// be invariant under slot/index canonicalization — key on tensor label or
+/// structure, NOT on anonymous index identity — so that two subnetworks deemed
+/// equivalent by the subnet-CSE canonicalization also agree on volatility (the
+/// CSE path stores one cost per canonical subnet). Flops metric only.
+/// \param n_replay Multiplier applied to the cost of each volatile-result
+/// contraction (volatile contractions are re-evaluated on every replay);
+/// persistent contractions are counted once. 1 (default) disables weighting.
 /// \return Optimal evaluation sequence under the chosen cost metric. If there
 ///         are equivalent optimal sequences then the result is the one that
 ///         keeps the order of tensors in the network as original as possible.

--- a/SeQuant/core/optimize/single_term.hpp
+++ b/SeQuant/core/optimize/single_term.hpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <bit>
+#include <functional>
 #include <limits>
 #include <type_traits>
 
@@ -253,7 +254,8 @@ template <typename CostFn>
   }
 EvalSequence single_term_opt_impl(TensorNetwork const& network,
                                   meta::range_of<Index> auto const& tidxs,
-                                  CostFn&& cost_fn, bool subnet_cse) {
+                                  CostFn&& cost_fn, bool subnet_cse,
+                                  size_t volatile_mask, double n_replay) {
   using ranges::views::concat;
   auto const nt = network.tensors().size();
   if (nt == 1) return EvalSequence{0};
@@ -276,6 +278,10 @@ EvalSequence single_term_opt_impl(TensorNetwork const& network,
   // find the optimal evaluation sequence
   for (size_t n = 0; n < results.size(); ++n) {
     if (std::popcount(n) < 2) continue;
+    // A subset is volatile iff it contains any volatile leaf; the contraction
+    // that forms it is then re-executed on every replay. volatile_mask == 0
+    // (no predicate / Memsize / n_replay<=1) makes w == 1 everywhere.
+    double const w = (volatile_mask & n) ? n_replay : 1.0;
     for (auto& curr_cost = results[n].ops;
          auto&& [lp, rp] : bits::bipartitions(n)) {
       // do nothing with the trivial bipartition
@@ -290,16 +296,16 @@ EvalSequence single_term_opt_impl(TensorNetwork const& network,
         std::set_union(results[lp].subnets.begin(), results[lp].subnets.end(),
                        results[rp].subnets.begin(), results[rp].subnets.end(),
                        std::back_inserter(combined_subnets));
-        new_cost = cost_fn(results[lp].indices,  //
-                           results[rp].indices,  //
-                           results[n].indices);
+        new_cost = w * cost_fn(results[lp].indices,  //
+                               results[rp].indices,  //
+                               results[n].indices);
         for (auto id : combined_subnets) {
           new_cost += unique_meta_costs[id];
         }
       } else {
-        new_cost = cost_fn(results[lp].indices,  //
-                           results[rp].indices,  //
-                           results[n].indices)   //
+        new_cost = w * cost_fn(results[lp].indices,  //
+                               results[rp].indices,  //
+                               results[n].indices)   //
                    + results[lp].ops + results[rp].ops;
       }
 
@@ -319,8 +325,8 @@ EvalSequence single_term_opt_impl(TensorNetwork const& network,
       // sizes, so their cost is identical. Overwriting with a later bitmask's
       // cost is intentional and benign.
       unique_meta_costs[mid] =
-          cost_fn(results[results[n].lp].indices,
-                  results[results[n].rp].indices, results[n].indices);
+          w * cost_fn(results[results[n].lp].indices,
+                      results[results[n].rp].indices, results[n].indices);
       auto it = std::lower_bound(results[n].subnets.begin(),
                                  results[n].subnets.end(), mid);
       if (it == results[n].subnets.end() || *it != mid) {
@@ -351,17 +357,37 @@ EvalSequence single_term_opt_impl(TensorNetwork const& network,
 ///         keeps the order of tensors in the network as original as possible.
 ///
 template <OptFor Metric, has_index_extent IdxToSz>
-EvalSequence single_term_opt(TensorNetwork const& network, IdxToSz&& idxsz,
-                             bool subnet_cse) {
+EvalSequence single_term_opt(
+    TensorNetwork const& network, IdxToSz&& idxsz, bool subnet_cse,
+    std::function<bool(Tensor const&)> const& is_volatile_leaf = {},
+    unsigned n_replay = 1) {
   decltype(OptRes::indices) tidxs{};
+
+  // Volatility weighting is a Flops-only notion (persistent intermediates cost
+  // MORE memory, not less, so it is wrong-signed for Memsize). Build the
+  // volatile-leaf bitmask in network.tensors() bit order so it aligns with the
+  // DP's subset bits.
+  size_t volatile_mask = 0;
+  double nr = 1.0;
   if constexpr (Metric == OptFor::Flops) {
+    if (is_volatile_leaf && n_replay > 1) {
+      size_t i = 0;
+      for (auto&& t : network.tensors()) {
+        auto tp = std::dynamic_pointer_cast<Tensor>(t);
+        if (tp && is_volatile_leaf(*tp)) volatile_mask |= (size_t{1} << i);
+        ++i;
+      }
+      nr = static_cast<double>(n_replay);
+    }
     auto cost_fn = flops_counter(std::forward<IdxToSz>(idxsz));
-    return single_term_opt_impl(network, tidxs, cost_fn, subnet_cse);
+    return single_term_opt_impl(network, tidxs, cost_fn, subnet_cse,
+                                volatile_mask, nr);
   } else {
     static_assert(Metric == OptFor::Memsize,
                   "Only Flops and Memsize OptFor supported.");
     auto cost_fn = memsize_counter(std::forward<IdxToSz>(idxsz));
-    return single_term_opt_impl(network, tidxs, cost_fn, subnet_cse);
+    return single_term_opt_impl(network, tidxs, cost_fn, subnet_cse,
+                                volatile_mask, nr);
   }
 }
 
@@ -377,8 +403,10 @@ EvalSequence single_term_opt(TensorNetwork const& network, IdxToSz&& idxsz,
 /// @note @c prod is assumed to consist of only Tensor expressions
 ///
 template <OptFor Metric = OptFor::Flops, has_index_extent IdxToSz>
-ExprPtr single_term_opt(Product const& prod, IdxToSz&& idxsz,
-                        bool subnet_cse = false) {
+ExprPtr single_term_opt(
+    Product const& prod, IdxToSz&& idxsz, bool subnet_cse = false,
+    std::function<bool(Tensor const&)> const& is_volatile_leaf = {},
+    unsigned n_replay = 1) {
   using ranges::views::filter;
   using ranges::views::reverse;
 
@@ -388,7 +416,8 @@ ExprPtr single_term_opt(Product const& prod, IdxToSz&& idxsz,
   auto const tensors =
       prod | filter(&ExprPtr::template is<Tensor>) | ranges::to_vector;
   auto seq = detail::single_term_opt<Metric>(
-      TensorNetwork{tensors}, std::forward<IdxToSz>(idxsz), subnet_cse);
+      TensorNetwork{tensors}, std::forward<IdxToSz>(idxsz), subnet_cse,
+      is_volatile_leaf, n_replay);
   auto result = container::svector<ExprPtr>{};
   for (auto i : seq)
     if (i == -1) {

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -199,6 +199,76 @@ TEST_CASE("optimize", "[optimize]") {
       REQUIRE(extract(res8, {1, 1}) == prod8.at(3));
     }
 
+    SECTION("Single term optimization: n_replay volatility weighting") {
+      using namespace sequant;
+
+      // PPL-shaped motif, fully contracted to a scalar:
+      //   A = g_{i1,a1}^{x1}   (persistent integral)
+      //   B = g_{i2,a2}^{x1}   (persistent integral)
+      //   t = t_{a1,a2}^{i1,i2} (VOLATILE amplitude)
+      // sizes: i=10 (O), a=100 (V), x=4 (X).
+      //
+      // (A*B)*t : build I=A*B over x  -> {i1,a1,i2,a2}  cost O^2 V^2 X
+      // (persistent)
+      //           then I*t            -> scalar         cost O^2 V^2 (volatile)
+      // (A*t)*B : build J=A*t over i1,a1 -> {x,i2,a2}   cost O^2 V^2 X
+      // (VOLATILE)
+      //           then J*B               -> scalar      cost X O V (volatile)
+      //
+      // n_replay=1  : (A*t)*B wins (O^2 V^2 X + X O V  <  O^2 V^2 X + O^2 V^2)
+      //               => t buried in an inner volatile intermediate.
+      // n_replay=10 : (A*B)*t wins (persistent build counted once; the only
+      //               x10 term is the cheap O^2 V^2 final step)
+      //               => t contracted LAST, persistent integral formed first.
+      auto idxsz = [](Index const& ix) {
+        return ix.nonnull() ? ix.space().approximate_size() : std::size_t{1};
+      };
+
+      auto prod = parse_expr_antisymm(
+                      L"g_{i1,a1}^{x1}"
+                      L" * g_{i2,a2}^{x1}"
+                      L" * t_{a1,a2}^{i1,i2}")
+                      ->as<Product>();
+
+      auto is_t = [](Tensor const& t) { return t.label() == L"t"; };
+
+      OptimizeOptions base;
+      base.idx_to_extent = idxsz;
+
+      // baseline: no predicate => weighting disabled => current behavior
+      auto opts1 = base;
+      opts1.is_volatile_leaf = is_t;
+      opts1.n_replay = 1;
+      auto res1 = optimize(ex<Product>(prod), opts1);
+
+      auto opts10 = base;
+      opts10.is_volatile_leaf = is_t;
+      opts10.n_replay = 10;
+      auto res10 = optimize(ex<Product>(prod), opts10);
+
+      // a bare top-level t leaf means t was contracted last (persistent-first)
+      auto top_has_bare_t = [](ExprPtr const& e) {
+        if (!e->is<Product>()) return false;
+        for (auto const& c : *e)
+          if (c->is<Tensor>() && c->as<Tensor>().label() == L"t") return true;
+        return false;
+      };
+
+      // weighting flips the chosen factorization
+      REQUIRE(res1 != res10);
+      // n_replay=1 reproduces today's behavior: t buried in an inner
+      // intermediate
+      REQUIRE_FALSE(top_has_bare_t(res1));
+      // n_replay=10: persistent g*g built first, t contracted last
+      REQUIRE(top_has_bare_t(res10));
+
+      // empty predicate => weighting off => identical to n_replay=1 regardless
+      auto opts_off = base;
+      opts_off.n_replay = 10;  // ignored: predicate empty
+      auto res_off = optimize(ex<Product>(prod), opts_off);
+      REQUIRE(res_off == res1);
+    }
+
     SECTION("Ensure single-value sums/products are not discarded") {
       auto sum = ex<Sum>();
       sum->as<Sum>().append(

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -235,7 +235,9 @@ TEST_CASE("optimize", "[optimize]") {
       OptimizeOptions base;
       base.idx_to_extent = idxsz;
 
-      // baseline: no predicate => weighting disabled => current behavior
+      // baseline: predicate set but n_replay==1 => weight is 1 everywhere =>
+      // reverts to current behavior. (The empty-predicate no-op is checked
+      // separately via opts_off below.)
       auto opts1 = base;
       opts1.is_volatile_leaf = is_t;
       opts1.n_replay = 1;


### PR DESCRIPTION
## Summary

Adds a persistence-aware cost option to the single-term optimizer. Contractions whose result depends on a "volatile" leaf (e.g. CC amplitudes, recomputed every iteration) can be weighted by an expected replay count `n_replay`, while amplitude-independent ("persistent", computed once) contractions are weighted by 1. This makes the optimizer's cost model match how an iterative solver with intermediate caching actually pays — persistent integral intermediates are built once, volatile work repeats per replay — so factorizations that form amplitude-free integral intermediates up front are correctly preferred.

## API (`OptimizeOptions`)

- `std::function<bool(Tensor const&)> is_volatile_leaf = {}` — marks a leaf tensor as volatile (its value changes between replays). **Empty (default) ⇒ weighting disabled ⇒ behavior identical to before this PR.**
- `unsigned n_replay = 1` — multiplier applied to each volatile contraction's cost; persistent contractions are counted once. Default `1` ⇒ no change. Flops metric only (for Memsize the weight is wrong-signed and is not applied).

## Mechanism

A subset `n` in the bitmask DP is volatile iff it shares a bit with a precomputed `volatile_mask` (built from the volatile leaves in `network.tensors()` order), so the taint propagates through every containing intermediate automatically. The forming-contraction cost is multiplied by `w = (n & volatile_mask) ? n_replay : 1`, yielding a subtree total of `Σ_nodes flops(node) × (n_replay if volatile else 1)`. Applied in both the plain and subnet-CSE cost paths. The CSE path requires the predicate to be invariant under slot/index canonicalization (key on tensor label/structure, not anonymous index identity) — documented on the API.

## Backward compatibility

With the default empty predicate (or `n_replay == 1`), `volatile_mask == 0` and `w == 1` everywhere — existing callers and all `[optimize]` tests are byte-identically unaffected.

## Tests

New `test_optimize.cpp` section on a PPL-shaped motif `g·g·t` with extents chosen so the optimum flips strictly (not tie-dependent): `n_replay=1` buries `t` in an inner intermediate, while large `n_replay` forms the amplitude-free integral first and contracts `t` last. Also asserts the empty-predicate no-op path.

## Downstream

mpqc4's CC solver consumes this for residual factorization (the per-pair 4-PNO particle-particle-ladder integral is built once instead of rebuilt each iteration; ~2× per-iteration speedup observed on PNO-CCSD). The mpqc4 wiring and version repin are a separate change.
