### PR TITLE
eval: gate batched custom evaluator on subtree persistence

### DIFF
--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -918,6 +918,11 @@ ResultPtr evaluate_antisymm(Args&&... args) {
 ///        possible.
 /// \param accept predicate selecting which contracted indices may be batched
 ///        (e.g. only those in the auxiliary/RI IndexSpace). Defaults to any.
+/// \param is_volatile predicate flagging a volatile leaf node (e.g. an
+///        amplitude tensor); the evaluator declines to batch any node whose
+///        subtree contains such a leaf, so only persistent (build-once)
+///        subtrees are streamed. Defaults to never_volatile (no persistence
+///        gate). Same classification as the eval cache's volatility predicate.
 /// \param make_scope_guard factory, called with the batch count, returning an
 ///        RAII object held for the duration of the batched partial
 ///        contractions; a backend may use it to relax block-sparse screening
@@ -945,17 +950,48 @@ struct make_no_scope_guard {
   }
 };
 
+/// Default node-volatility predicate for make_batched_custom_evaluator: no node
+/// is volatile, so batching is gated only by the index predicate. A caller may
+/// instead supply a predicate flagging volatile (e.g. amplitude-dependent) leaf
+/// nodes; the evaluator then declines to batch any node whose subtree contains
+/// such a leaf, so only persistent (build-once) subtrees are streamed over the
+/// batch axis (a volatile subtree is rebuilt every evaluation, so batching it
+/// would pay the partition + relaxed-screening cost on every pass for no
+/// lasting memory benefit).
+struct never_volatile {
+  template <typename Node>
+  bool operator()(Node const&) const noexcept {
+    return false;
+  }
+};
+
+/// \return whether any node in the subtree rooted at \p n satisfies \p pred.
+template <typename Node, typename Pred>
+[[nodiscard]] bool subtree_any(Node const& n, Pred const& pred) {
+  if (pred(n)) return true;
+  if (n.leaf()) return false;
+  return subtree_any(n.left(), pred) || subtree_any(n.right(), pred);
+}
+
 template <typename F, typename IndexPredicate = accept_any_index,
+          typename IsVolatile = never_volatile,
           typename ScopeGuardFactory = make_no_scope_guard>
 [[nodiscard]] auto make_batched_custom_evaluator(
     F le, std::size_t target_batch_size, IndexPredicate accept = {},
-    ScopeGuardFactory make_scope_guard = {}) {
-  return [le = std::move(le), target_batch_size, accept, make_scope_guard](
-             auto const& node, auto& cache) -> ResultPtr {
+    IsVolatile is_volatile = {}, ScopeGuardFactory make_scope_guard = {}) {
+  return [le = std::move(le), target_batch_size, accept, is_volatile,
+          make_scope_guard](auto const& node, auto& cache) -> ResultPtr {
     using cache_t = std::remove_reference_t<decltype(cache)>;
 
     auto const K = batch_axis(node, accept);
     if (!K) return nullptr;
+
+    // Persistence gate: only stream subtrees that are amplitude-independent
+    // (built once). If the subtree contains a volatile leaf it is rebuilt on
+    // every evaluation, so batching pays the partition + relaxed-screening cost
+    // each pass for no lasting memory benefit -- decline to the standard
+    // scheme. Default never_volatile => no gating (original behavior).
+    if (subtree_any(node, is_volatile)) return nullptr;
 
     auto const leaf = find_leaf_carrying(node, *K);
     if (!leaf) return nullptr;

--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -918,17 +918,19 @@ ResultPtr evaluate_antisymm(Args&&... args) {
 ///        possible.
 /// \param accept predicate selecting which contracted indices may be batched
 ///        (e.g. only those in the auxiliary/RI IndexSpace). Defaults to any.
-/// \param is_volatile predicate flagging a volatile leaf node (e.g. an
-///        amplitude tensor); the evaluator declines to batch any node whose
-///        subtree contains such a leaf, so only persistent (build-once)
-///        subtrees are streamed. Defaults to never_volatile (no persistence
-///        gate). Same classification as the eval cache's volatility predicate.
 /// \param make_scope_guard factory, called with the batch count, returning an
 ///        RAII object held for the duration of the batched partial
 ///        contractions; a backend may use it to relax block-sparse screening
 ///        (scaled by the batch count) so per-batch screening does not drop
 ///        small contributions that are significant once summed over the full
 ///        batch axis. Defaults to a no-op (make_no_scope_guard).
+/// \param is_volatile predicate flagging a volatile leaf node (e.g. an
+///        amplitude tensor); the evaluator declines to batch any node whose
+///        subtree contains such a leaf, so only persistent (build-once)
+///        subtrees are streamed. Defaults to never_volatile (no persistence
+///        gate). Same classification as the eval cache's volatility predicate.
+///        Kept last so the prior 4-argument form (…, accept, make_scope_guard)
+///        still compiles unchanged.
 struct accept_any_index {
   bool operator()(Index const&) const noexcept { return true; }
 };
@@ -974,11 +976,11 @@ template <typename Node, typename Pred>
 }
 
 template <typename F, typename IndexPredicate = accept_any_index,
-          typename IsVolatile = never_volatile,
-          typename ScopeGuardFactory = make_no_scope_guard>
+          typename ScopeGuardFactory = make_no_scope_guard,
+          typename IsVolatile = never_volatile>
 [[nodiscard]] auto make_batched_custom_evaluator(
     F le, std::size_t target_batch_size, IndexPredicate accept = {},
-    IsVolatile is_volatile = {}, ScopeGuardFactory make_scope_guard = {}) {
+    ScopeGuardFactory make_scope_guard = {}, IsVolatile is_volatile = {}) {
   return [le = std::move(le), target_batch_size, accept, is_volatile,
           make_scope_guard](auto const& node, auto& cache) -> ResultPtr {
     using cache_t = std::remove_reference_t<decltype(cache)>;

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -1591,6 +1591,67 @@ TEST_CASE("eval_batched_custom_evaluator", "[eval]") {
   }
 }
 
+TEST_CASE("eval_batched_custom_evaluator persistence gate", "[eval]") {
+  using sequant::evaluate;
+  using sequant::make_batched_custom_evaluator;
+  using TA::TArrayD;
+  using node_t = sequant::FullBinaryNode<sequant::EvalExprTA>;
+  using cache_t = sequant::CacheManager<node_t>;
+
+  auto& world = TA::get_default_world();
+  rand_tensor_yield<double, TA::DensePolicy> yield_{world, 4, 12};
+  yield_.set_max_tile(4);
+
+  // Contracts a1,a2 (unoccupied, 3 tiles) -> batchable over an unoccupied axis.
+  // The subtree contains a "t" leaf, which we treat as volatile.
+  auto const expr = sequant::deserialize<sequant::ExprPtr>(
+      L"g_{i1,i2}^{a1,a2} * t_{a1,a2}^{i3,i4}");
+  std::string const target = "i_1,i_2,i_3,i_4";
+  auto const node = eval_node(expr);
+  auto const ref = evaluate(node, target, yield_)->get<TArrayD>();
+
+  // Volatile-leaf predicate: the amplitude "t".
+  auto is_volatile_t = [](node_t const& n) {
+    return n.leaf() && n->is_tensor() && n->as_tensor().label() == L"t";
+  };
+
+  // (1) Gate ON: the subtree contains a volatile "t" leaf, so batching is
+  // DECLINED -- the spy scope-guard (invoked only once a node passes every gate
+  // and yields >1 batch) is never called, yet the standard scheme still gives
+  // the correct result.
+  {
+    bool batched = false;
+    auto spy = [&batched](std::size_t) {
+      batched = true;
+      return sequant::no_scope_guard{};
+    };
+    auto cache = cache_t::empty();
+    cache.set_custom_evaluator(make_batched_custom_evaluator(
+        yield_, std::size_t{4}, sequant::accept_any_index{}, is_volatile_t,
+        spy));
+    auto const res = evaluate(node, target, yield_, cache)->get<TArrayD>();
+    REQUIRE_FALSE(batched);  // volatile subtree -> not batched
+    REQUIRE(equal_tarrays<Loose>(res, ref));
+  }
+
+  // (2) No gate (default never_volatile): the SAME node DOES batch -- confirms
+  // (1)'s decline is due to the volatility gate, not the index/tiling setup.
+  {
+    bool batched = false;
+    auto spy = [&batched](std::size_t) {
+      batched = true;
+      return sequant::no_scope_guard{};
+    };
+    auto cache = cache_t::empty();
+    cache.set_custom_evaluator(make_batched_custom_evaluator(
+        yield_, std::size_t{4}, sequant::accept_any_index{},
+        sequant::never_volatile{}, spy));
+    auto const res = evaluate(node, target, yield_, cache)->get<TArrayD>();
+    REQUIRE(batched);  // no gate -> batched as before
+    REQUIRE(equal_tarrays<Loose>(res, ref));
+  }
+}
+
 TEST_CASE("eval_batched_custom_evaluator_tot", "[eval]") {
   using sequant::evaluate;
   using sequant::make_batched_custom_evaluator;

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -1627,8 +1627,8 @@ TEST_CASE("eval_batched_custom_evaluator persistence gate", "[eval]") {
     };
     auto cache = cache_t::empty();
     cache.set_custom_evaluator(make_batched_custom_evaluator(
-        yield_, std::size_t{4}, sequant::accept_any_index{}, is_volatile_t,
-        spy));
+        yield_, std::size_t{4}, sequant::accept_any_index{}, spy,
+        is_volatile_t));
     auto const res = evaluate(node, target, yield_, cache)->get<TArrayD>();
     REQUIRE_FALSE(batched);  // volatile subtree -> not batched
     REQUIRE(equal_tarrays<Loose>(res, ref));
@@ -1644,8 +1644,8 @@ TEST_CASE("eval_batched_custom_evaluator persistence gate", "[eval]") {
     };
     auto cache = cache_t::empty();
     cache.set_custom_evaluator(make_batched_custom_evaluator(
-        yield_, std::size_t{4}, sequant::accept_any_index{},
-        sequant::never_volatile{}, spy));
+        yield_, std::size_t{4}, sequant::accept_any_index{}, spy,
+        sequant::never_volatile{}));
     auto const res = evaluate(node, target, yield_, cache)->get<TArrayD>();
     REQUIRE(batched);  // no gate -> batched as before
     REQUIRE(equal_tarrays<Loose>(res, ref));


### PR DESCRIPTION
## Summary

Follow-up to #528 (batched custom evaluator). Adds an optional **node-volatility gate** to `make_batched_custom_evaluator`, so a Κ-contraction is streamed in batches **only when the subtree it would stream is persistent** (amplitude-independent, built once). A subtree containing a volatile leaf (e.g. an amplitude `t`) is rebuilt on every evaluation, so batching it pays the partition + relaxed-screening cost on *every* pass for no lasting memory benefit — the gate declines it and falls back to the standard scheme.

## API

`make_batched_custom_evaluator` gains one predicate parameter:

```cpp
make_batched_custom_evaluator(le, target_batch_size,
                              accept /*index predicate*/,
                              is_volatile /*NEW: leaf-volatility predicate*/,
                              make_scope_guard);
```

- `is_volatile(node)` flags a volatile leaf (same classification the eval cache uses, `cache_manager(nodes, is_volatile)`). The evaluator declines to batch any node whose subtree contains such a leaf (`subtree_any`).
- Defaults to `never_volatile` ⇒ **no gate, byte-identical to before this PR.**

## Why

Batching a contracted index streams the Κ-carrying intermediates one batch-slice at a time into a Κ-free accumulator — a clear win when those intermediates are large and built once (persistent integral space). But applied indiscriminately to *every* Κ-contraction, it also batches the small, per-iteration (volatile) ops where there is no memory to save, multiplying their cost.

Measured downstream (mpqc PNO-CCSD, n-hexane/cc-pVDZ): batching *all* Κ-contractions was a **2.5× eval-time regression** (90.8 → 224.9 s) to save ~5 GB peak. With this gate (batch persistent only): **131.2 s**, the full memory win retained (peak RSS 17.3 → 12.4 G), and energy *closer* to the un-batched reference (the volatile ops no longer get the `1/n` screening relaxation).

## Tests

`tests/unit/test_eval_ta.cpp`: new section asserts a node whose subtree contains a volatile `t` leaf is **declined** (a spy scope-guard, invoked only once batching actually proceeds, never fires) while still producing the correct result, and that the *same* node **does** batch with the gate off. Existing batched-evaluator tests unchanged and passing.
