### PR TITLE
fix: handle all-empty-inner ToT arrays

### DIFF
--- a/SeQuant/core/eval/backends/tiledarray/result.hpp
+++ b/SeQuant/core/eval/backends/tiledarray/result.hpp
@@ -69,19 +69,22 @@ auto column_symmetrize_ta(TA::DistArray<Args...> const& arr) {
 
   size_t const outer_rank = arr.trange().rank();
 
-  size_t const total_rank = [&] {
-    if constexpr (is_tot) {
-      size_t const inner_rank = tot_inner_rank(arr);
-      if (outer_rank != inner_rank)
-        throw Exception(
-            "ToT symmetrization requires equal outer and inner rank (outer=" +
-            std::to_string(outer_rank) +
-            ", inner=" + std::to_string(inner_rank) + ")");
-      return outer_rank + inner_rank;
-    } else {
-      return outer_rank;
-    }
-  }();
+  if constexpr (is_tot) {
+    size_t const inner_rank = tot_inner_rank(arr);
+    // All-empty-inner ToT (e.g. every CSV pair screened out): no populated tile
+    // to read a rank from, so tot_inner_rank() is 0. It represents zero, and
+    // symmetrizing zero is zero -- return unchanged instead of failing the
+    // equal-rank check below.
+    if (inner_rank == 0) return arr;
+    if (outer_rank != inner_rank)
+      throw Exception(
+          "ToT symmetrization requires equal outer and inner rank (outer=" +
+          std::to_string(outer_rank) + ", inner=" + std::to_string(inner_rank) +
+          ")");
+  }
+
+  // ToT (equal-rank, validated above): total rank = outer + inner = 2*outer.
+  size_t const total_rank = is_tot ? 2 * outer_rank : outer_rank;
 
   if (total_rank % 2 != 0)
     throw Exception("This function only supports even-ranked tensors");
@@ -641,12 +644,15 @@ class ResultTensorOfTensorTA final : public Result {
     auto const& o = other.get<ArrayT>();
 
     SEQUANT_ASSERT(t.trange() == o.trange());
-    // ToT array: the annotation must carry an inner block ("outer;inner") or
-    // DistArray::operator() rejects it (is_tot_index). dummy_annotation's
-    // second argument is the inner-mode count, read from the array's inner
-    // tiles.
-    auto ann = TA::detail::dummy_annotation(t.trange().rank(),
-                                            detail::tot_inner_rank(t));
+    // ToT annotation needs an inner block ("outer;inner"); tot_inner_rank()
+    // reads it from a populated inner tile and is 0 when an operand's inner
+    // tiles are all empty. Take the rank from whichever operand has data; if
+    // both are empty the add is an identity no-op (t += 0), nothing to
+    // annotate.
+    auto const inner_rank =
+        std::max(detail::tot_inner_rank(t), detail::tot_inner_rank(o));
+    if (inner_rank == 0) return;
+    auto ann = TA::detail::dummy_annotation(t.trange().rank(), inner_rank);
 
     detail::log_ta(ann, " += ", ann, "\n");
 
@@ -703,9 +709,33 @@ template <typename... Args>
   using value_type = typename TA::DistArray<Args...>::value_type;
   std::string annot;
   if constexpr (TA::detail::is_tensor_of_tensor_v<value_type>) {
-    annot = TA::detail::dummy_annotation(
-        static_cast<unsigned int>(rank),
-        static_cast<unsigned int>(detail::tot_inner_rank(arr)));
+    auto const inner_rank = detail::tot_inner_rank(arr);
+    if (inner_rank == 0) {
+      // All-empty-inner ToT: tot_inner_rank() is 0, so there's no inner rank to
+      // build the ToT annotation block() needs. The slice of zero is zero, so
+      // build the sliced outer trange by hand (mode cut to [tile_lo,tile_hi),
+      // each dim rebased to 0, matching block()) and return a zero ToT over it.
+      // The result is dense even if ArrayT's policy is sparse -- harmless, the
+      // array is identically zero.
+      std::vector<TA::TiledRange1> tr1s;
+      tr1s.reserve(rank);
+      for (std::size_t d = 0; d < rank; ++d) {
+        auto const& dim = arr.trange().dim(d);
+        std::size_t const base = dim.tile(lo[d]).first;
+        std::vector<std::size_t> bounds{0};
+        for (std::size_t t = lo[d]; t < hi[d]; ++t)
+          bounds.push_back(dim.tile(t).second - base);
+        tr1s.emplace_back(bounds.begin(), bounds.end());
+      }
+      TA::DistArray<Args...> out{arr.world(),
+                                 TA::TiledRange(tr1s.begin(), tr1s.end())};
+      for (auto it = out.begin(); it != out.end(); ++it)
+        if (out.is_local(it.index())) *it = value_type{it.make_range()};
+      out.world().gop.fence();
+      return out;
+    }
+    annot = TA::detail::dummy_annotation(static_cast<unsigned int>(rank),
+                                         static_cast<unsigned int>(inner_rank));
   } else {
     annot = detail::ords_to_annot(iota(std::size_t{0}, rank));
   }

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -410,6 +410,118 @@ bool equal_tarrays(Array const& arr1, Array const& arr2) {
 
 }  // namespace
 
+// Regression tests for tensor-of-tensor (ToT) ops on arrays whose inner tiles
+// are all empty (e.g. a fully screened CSV residual). tot_inner_rank() reads
+// the rank from a populated inner tile, so it returns 0 here; downstream ToT
+// ops must not turn that 0 into a degenerate (non-ToT) annotation. Reproduces
+// the mpqc4 PAO-CSV abort fixed in add_inplace and column_symmetrize_ta.
+TEST_CASE("tot_all_empty_inner", "[eval][tot]") {
+  using sequant::eval_result;
+  using sequant::ResultPtr;
+  using sequant::ResultTensorOfTensorTA;
+  using sequant::detail::tot_inner_rank;
+  using ToTArray = TA::DistArray<TA::Tensor<TA::Tensor<double>>>;
+  using ResultToT = ResultTensorOfTensorTA<ToTArray>;
+
+  auto& world = TA::get_default_world();
+
+  // Build a ToT array; `empty_inner` leaves every inner tensor empty.
+  auto build = [&world](unsigned outer_rank, bool empty_inner,
+                        TA::TiledRange1 outer_tr1 =
+                            TA::TiledRange1{0, 3}) -> ToTArray {
+    std::vector<TA::TiledRange1> tr1s(outer_rank, outer_tr1);
+    TA::TiledRange outer_tr(tr1s.begin(), tr1s.end());
+    std::vector<std::size_t> inner_ext(outer_rank, 4);
+    TA::Range inner_r(inner_ext);
+
+    auto tile_fn = [inner_r, empty_inner](TA::Range const& orng) {
+      TA::Tensor<TA::Tensor<double>> t{orng};
+      if (!empty_inner)
+        for (auto& inner : t) {
+          inner = TA::Tensor<double>{inner_r};
+          std::fill(inner.begin(), inner.end(), 1.0);
+        }
+      return t;
+    };
+
+    ToTArray arr{world, outer_tr};
+    for (auto it = arr.begin(); it != arr.end(); ++it)
+      if (arr.is_local(it.index()))
+        *it = world.taskq.add(tile_fn, it.make_range());
+    world.gop.fence();
+    return arr;
+  };
+
+  SECTION("add_inplace: empty += populated adopts the populated inner rank") {
+    auto empty = build(1, /*empty_inner=*/true);
+    auto full = build(1, /*empty_inner=*/false);
+    REQUIRE(tot_inner_rank(empty) == 0);
+    REQUIRE(tot_inner_rank(full) == 1);
+
+    auto r_empty = eval_result<ResultToT>(empty);
+    auto r_full = eval_result<ResultToT>(full);
+    REQUIRE_NOTHROW(r_empty->add_inplace(*r_full));
+    auto const& res = r_empty->get<ToTArray>();
+    REQUIRE(tot_inner_rank(res) == 1);
+    // the populated operand's data (all 1.0) must actually have landed.
+    for (auto it = res.begin(); it != res.end(); ++it)
+      if (res.is_local(it.index()))
+        for (auto const& inner : it->get()) {
+          REQUIRE_FALSE(inner.empty());
+          for (auto const& x : inner) REQUIRE(x == 1.0);
+        }
+  }
+
+  SECTION("add_inplace: populated += empty is a no-op") {
+    auto full = build(1, false);
+    auto empty = build(1, true);
+    auto r_full = eval_result<ResultToT>(full);
+    auto r_empty = eval_result<ResultToT>(empty);
+    REQUIRE_NOTHROW(r_full->add_inplace(*r_empty));
+    REQUIRE(tot_inner_rank(r_full->get<ToTArray>()) == 1);
+  }
+
+  SECTION("add_inplace: empty += empty is an identity no-op") {
+    auto e1 = build(1, true);
+    auto e2 = build(1, true);
+    auto r1 = eval_result<ResultToT>(e1);
+    auto r2 = eval_result<ResultToT>(e2);
+    REQUIRE_NOTHROW(r1->add_inplace(*r2));
+    REQUIRE(tot_inner_rank(r1->get<ToTArray>()) == 0);
+  }
+
+  SECTION("symmetrize: all-empty ToT is the identity") {
+    auto empty = build(1, true);
+    REQUIRE(tot_inner_rank(empty) == 0);
+    auto r_empty = eval_result<ResultToT>(empty);
+    ResultPtr sym;
+    REQUIRE_NOTHROW(sym = r_empty->symmetrize());
+    REQUIRE(tot_inner_rank(sym->get<ToTArray>()) == 0);
+  }
+
+  SECTION("slice_array_over_mode: all-empty ToT slices to a zero ToT") {
+    auto empty = build(1, true);
+    REQUIRE(tot_inner_rank(empty) == 0);
+    ToTArray sliced;
+    REQUIRE_NOTHROW(sliced = sequant::slice_array_over_mode(empty, 0, 0, 1));
+    REQUIRE(tot_inner_rank(sliced) == 0);
+    REQUIRE(sliced.trange().dim(0).tile_extent() == 1);
+  }
+
+  SECTION(
+      "slice_array_over_mode: rebasing matches block() on a multi-tile cut") {
+    // Slice across two tiles at a non-zero base; hand-built trange must match
+    // what the populated path gets from TA's block().
+    TA::TiledRange1 const tr1{0, 3, 6, 9};
+    auto empty = build(1, /*empty_inner=*/true, tr1);
+    auto full = build(1, /*empty_inner=*/false, tr1);
+    auto const s_empty = sequant::slice_array_over_mode(empty, 0, 1, 3);
+    auto const s_full = sequant::slice_array_over_mode(full, 0, 1, 3);
+    REQUIRE(tot_inner_rank(s_empty) == 0);
+    REQUIRE(s_empty.trange() == s_full.trange());
+  }
+}
+
 TEST_CASE("eval_with_tiledarray", "[eval]") {
   // Reproducer for the mpqc4 cck real-field NaN regression. The eval-graph
   // head's bra/ket split is purely positional: each external index ends up in


### PR DESCRIPTION
An all-empty-inner tensor-of-tensor (a fully screened term in CSV-CC) is logically zero, and `tot_inner_rank()` returns 0 for it. That 0 caused wrong annotation, tripping TA's i`s_tot_index()` check and aborting in `column_symmetrize_ta`, `ResultTensorOfTensorTA::add_inplace`, and `slice_array_over_mode`.

Treat inner-rank-0 as the zero array in each: 
- `symmetrize` returns it unchanged 
- `add_inplace` takes the rank from the populated operand (or no-ops when both are empty) 
- slice builds a zero ToT over the sliced trange
- Adds regression coverage in `test_eval_ta.cpp`

Needed for https://github.com/ValeevGroup/mpqc4/pull/758