### PR TITLE
eval: group replay of persistent batchable intermediates (within-batch + cross-final CSE)

### DIFF
--- a/SeQuant/core/eval/cache_manager.hpp
+++ b/SeQuant/core/eval/cache_manager.hpp
@@ -234,6 +234,19 @@ class CacheManager {
     return cache_map_.find(key) != cache_map_.end();
   }
 
+  ///
+  /// \brief Invokes \p fn with a const reference to every registered key.
+  ///
+  /// Keys are the canonical evaluation-tree nodes registered at construction;
+  /// iteration order is unspecified. Use together with persistent()/alive() to
+  /// enumerate, e.g., persistent entries that have not been populated yet.
+  ///
+  template <typename F>
+    requires std::invocable<F&, key_type const&>
+  void for_each_key(F&& fn) const {
+    for (auto const& [k, v] : cache_map_) fn(k);
+  }
+
   /// if the key exists in the database, return the current lifetime count of
   /// the cached data otherwise return -1
   [[nodiscard]] int life(key_type const& key) const noexcept {

--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -904,14 +904,26 @@ ResultPtr evaluate_antisymm(Args&&... args) {
 /// backend to partition \c K into contiguous element-range batches of about
 /// \p target_batch_size elements each (Result::mode_batches); if that yields at
 /// most one batch it declines (so small / unselected indices are left to the
-/// standard scheme). Otherwise, for each batch it evaluates the subtree by the
-/// standard scheme on a *registered* scratch cache (see
-/// detail::make_batched_scratch) -- repeated subtrees, e.g. canonically-equal
-/// siblings, are evaluated once per batch and shared, exactly as the real
-/// cache would share them -- with every leaf carrying \c K sliced to the
-/// batch's element range, and sums the partial results. This is exact because
-/// `sum_K = sum_{batches} sum_{K in batch}`, and never materializes the whole
-/// \c K extent of any intermediate at once.
+/// standard scheme).
+///
+/// Otherwise it *replays the build of every compatible persistent final* in
+/// the same batch passes: the group is the trigger node plus every key of
+/// \p cache that is registered persistent, not yet alive, and batches over an
+/// axis with the identical realized partition. Per batch, each group member is
+/// evaluated by the standard scheme -- with every leaf carrying the member's
+/// batch axis sliced to the batch's element range -- on a shared *registered*
+/// scratch cache (see detail::make_batched_scratch), so sub-intermediates
+/// repeated within a member (canonically-equal siblings) or shared between
+/// members are evaluated once per batch, exactly as the real cache would share
+/// them; the per-member partials are summed across batches. This is exact
+/// because `sum_K = sum_{batches} sum_{K in batch}`, and never materializes
+/// the whole batch-axis extent of any intermediate at once. Completed members
+/// are stored into \p cache (canonical-phase convention); the trigger's result
+/// is returned for evaluate() to cache as usual. Members nested inside other
+/// members evaluate in earlier passes and are then seeded (slice-free w.r.t.
+/// the outer batch axis) or re-derived sliced in the outer pass. Considering a
+/// group candidate costs one leaf evaluation (the mode_batches probe); with an
+/// unregistered (empty) cache the group is just the trigger.
 ///
 /// \param le the leaf evaluator (captured).
 /// \param target_batch_size the desired size of each batch *in elements* (a
@@ -1095,6 +1107,65 @@ template <typename F, typename IndexPredicate = accept_any_index,
     if (batches.size() <= 1)
       return nullptr;  // nothing to gain (or unbatchable)
 
+    using node_t = std::remove_cvref_t<decltype(node)>;
+    using member_t = std::pair<node_t const*, Index>;
+    TreeNodeEqualityComparator<node_t> const eq;
+
+    // The replay group: the trigger plus every registered persistent key that
+    // is not yet alive and batches over an axis with the identical realized
+    // partition. All compatible persistent finals stream over the batch axis
+    // in the same passes, so sub-intermediates shared between them (wherever
+    // the scratch's slicing-signature guard admits sharing -- equal canonical
+    // positions of the batch axis plus equal element ranges imply identical
+    // slices) are evaluated once per batch instead of once per consumer.
+    // The cost of considering a candidate is one leaf evaluation (the
+    // mode_batches probe). With an unregistered (empty) real cache the group
+    // is just the trigger.
+    std::vector<member_t> group{{&node, *K}};
+    cache.for_each_key([&](node_t const& k) {
+      if (!cache.persistent(k) || cache.alive(k)) return;
+      if (eq(k, node)) return;  // the trigger occupies its own slot
+      auto const Kk = batch_axis(k, accept);
+      if (!Kk) return;
+      if (subtree_any(k, is_volatile)) return;  // defensive: P implies NV
+      auto const lk = find_leaf_carrying(k, *Kk);
+      if (!lk) return;
+      if (le(lk->first)->mode_batches(lk->second, target_batch_size) != batches)
+        return;
+      group.emplace_back(&k, *Kk);
+    });
+
+    // Layer by nesting: a member whose subtree contains another member
+    // evaluates in a later layer, with the inner result by then alive in the
+    // real cache -- seeded into the outer pass when slice-free w.r.t. the
+    // outer batch axis, re-derived sliced (correct, unshared) otherwise.
+    auto contains = [&eq](node_t const& outer, node_t const& inner) -> bool {
+      auto rec = [&eq, &inner](auto&& self, node_t const& n) -> bool {
+        if (eq(n, inner)) return true;
+        if (n.leaf()) return false;
+        return self(self, n.left()) || self(self, n.right());
+      };
+      if (outer.leaf()) return false;
+      return rec(rec, outer.left()) || rec(rec, outer.right());
+    };
+    std::vector<std::vector<member_t>> layers;
+    {
+      std::vector<member_t> remaining = std::move(group);
+      while (!remaining.empty()) {
+        std::vector<member_t> layer, rest;
+        for (auto const& m : remaining) {
+          bool const outer = std::any_of(
+              remaining.begin(), remaining.end(), [&](member_t const& o) {
+                return m.first != o.first && contains(*m.first, *o.first);
+              });
+          (outer ? rest : layer).push_back(m);
+        }
+        SEQUANT_ASSERT(!layer.empty());  // containment is a strict order
+        layers.push_back(std::move(layer));
+        remaining = std::move(rest);
+      }
+    }
+
     // RAII scope for the batched partial contractions; a backend-supplied
     // factory may relax block-sparse screening here (scaled by the batch count)
     // so per-batch screening does not drop contributions that survive over the
@@ -1102,41 +1173,61 @@ template <typename F, typename IndexPredicate = accept_any_index,
     auto const scope_guard = make_scope_guard(batches.size());
     (void)scope_guard;
 
-    // The scratch cache for the per-batch replays: registered from the
-    // subtree itself (same canonical-equality counting as the real cache), so
-    // repeated subtrees -- e.g. two canonically-equal children of the node --
-    // are evaluated once per batch and shared, not re-derived per occurrence.
-    // Carries no custom evaluator (no re-interception) and keeps the partial,
-    // sliced intermediates out of the real cache; reset() between batches
-    // drops the previous batch's partials (seeded entries are registered
-    // persistent and survive).
-    using node_t = std::remove_cvref_t<decltype(node)>;
-    std::vector<std::pair<node_t const*, Index>> const members{{&node, *K}};
-    auto bs = detail::make_batched_scratch(members, cache);
-    for (auto const* s : bs.seeds) (void)bs.cache.store(*s, cache.access(*s));
+    ResultPtr trigger_result;
+    for (auto const& layer : layers) {
+      // The layer's scratch cache: registered from the member subtrees (same
+      // canonical-equality counting as the real cache), so repeated subtrees
+      // -- canonically-equal siblings within a member as well as
+      // sub-intermediates shared between members -- are evaluated once per
+      // batch. Carries no custom evaluator (no re-interception) and keeps the
+      // partial, sliced intermediates out of the real cache; reset() between
+      // batches drops the previous batch's partials, while pre-seeded alive
+      // persistent entries (registered persistent in the scratch) survive.
+      auto bs = detail::make_batched_scratch(layer, cache);
+      for (auto const* s : bs.seeds) (void)bs.cache.store(*s, cache.access(*s));
 
-    ResultPtr acc;
-    for (auto const& [e_lo, e_hi] : batches) {
-      if (e_lo == e_hi) continue;
-      bs.cache.reset();
+      std::vector<ResultPtr> acc(layer.size());
+      for (auto const& [e_lo, e_hi] : batches) {
+        if (e_lo == e_hi) continue;
+        bs.cache.reset();
+        for (std::size_t m = 0; m != layer.size(); ++m) {
+          auto const& [mem, Km] = layer[m];
+          // leaf evaluator that slices every leaf carrying the member's batch
+          // axis to this element batch; others pass through unchanged.
+          auto le_g = [&le, &Km, e_lo = e_lo,
+                       e_hi = e_hi](auto const& leaf_node) -> ResultPtr {
+            ResultPtr r = le(leaf_node);
+            if (auto const p = index_position(leaf_node, Km))
+              return r->slice_mode(*p, e_lo, e_hi);
+            return r;
+          };
+          ResultPtr part = evaluate(*mem, le_g, bs.cache);
+          if (!acc[m])
+            acc[m] = std::move(part);
+          else
+            acc[m]->add_inplace(*part);
+        }
+      }
 
-      // leaf evaluator that slices every leaf carrying K to this element batch;
-      // others pass through unchanged.
-      auto le_g = [&le, &K, e_lo = e_lo,
-                   e_hi = e_hi](auto const& leaf_node) -> ResultPtr {
-        ResultPtr r = le(leaf_node);
-        if (auto const p = index_position(leaf_node, *K))
-          return r->slice_mode(*p, e_lo, e_hi);
-        return r;
-      };
-
-      ResultPtr part = evaluate(node, le_g, bs.cache);
-      if (!acc)
-        acc = std::move(part);
-      else
-        acc->add_inplace(*part);
+      // Store the members into the real cache under the canonical-phase
+      // convention (mirroring evaluate()'s Checked store), eagerly per layer
+      // so later layers can seed them. The trigger is returned instead: its
+      // Checked wrapper stores it (a direct store here would double-decay a
+      // non-persistent trigger's life count).
+      for (std::size_t m = 0; m != layer.size(); ++m) {
+        auto const* mem = layer[m].first;
+        if (mem == &node) {
+          trigger_result = std::move(acc[m]);
+          continue;
+        }
+        ResultPtr v = std::move(acc[m]);
+        if (auto const ph = (*mem)->canon_phase(); ph != 1)
+          v = v->mult_by_phase(ph);
+        (void)cache.store(*mem, std::move(v));
+      }
     }
-    return acc;
+    SEQUANT_ASSERT(trigger_result);
+    return trigger_result;
   };
 }
 

--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -1005,8 +1005,11 @@ struct BatchedScratch {
 /// \p members (each a subtree root paired with its batch axis).
 ///
 /// Walks every member subtree with the same pruned counting walk as
-/// cache_manager() (descend only on first visit of a canonical-equal node, so
-/// counts match access counts under caching) and registers every internal
+/// cache_manager() (descend on first visit of a canonical-equal node, so
+/// counts match access counts under caching -- and also on a re-encounter
+/// whose slicing signature differs from the first visit's, so that
+/// descendants' signatures under an inconsistently-sliced occurrence are
+/// recorded rather than hidden by the prune) and registers every internal
 /// subnode that repeats AND has a consistent slicing signature -- the position
 /// of the containing member's batch axis in the subnode's canon_indices(), or
 /// its absence -- across all occurrences. Signature consistency is what makes
@@ -1047,7 +1050,17 @@ template <typename TreeNode, bool FHC, typename Members>
     else if (e.sig != sig)
       e.consistent = false;
     ++e.count;
-    if (!first) return;  // equal node already walked: deeper accesses shared
+    // Prune a re-encounter only when its signature matches the first one:
+    // canonical equality maps canonical position p to position p, so an equal
+    // signature here implies the descendants' signatures equal those already
+    // recorded on the first walk (deeper accesses shared and counted). A
+    // differing signature gives no such guarantee -- descend so descendants'
+    // signatures under this occurrence are recorded too; otherwise a
+    // descendant sliced differently only under this (unshared, pruned)
+    // occurrence could pass the guard and serve wrong slices. The extra
+    // descendant counts are real accesses: an inconsistently-sliced occurrence
+    // is evaluated per occurrence, not served from the scratch at n.
+    if (!first && e.sig == sig) return;
     self(self, n.left(), axis);
     self(self, n.right(), axis);
   };

--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -905,10 +905,13 @@ ResultPtr evaluate_antisymm(Args&&... args) {
 /// \p target_batch_size elements each (Result::mode_batches); if that yields at
 /// most one batch it declines (so small / unselected indices are left to the
 /// standard scheme). Otherwise, for each batch it evaluates the subtree by the
-/// standard scheme on a fresh scratch cache, with every leaf carrying \c K
-/// sliced to the batch's element range, and sums the partial results. This is
-/// exact because `sum_K = sum_{batches} sum_{K in batch}`, and never
-/// materializes the whole \c K extent of any intermediate at once.
+/// standard scheme on a *registered* scratch cache (see
+/// detail::make_batched_scratch) -- repeated subtrees, e.g. canonically-equal
+/// siblings, are evaluated once per batch and shared, exactly as the real
+/// cache would share them -- with every leaf carrying \c K sliced to the
+/// batch's element range, and sums the partial results. This is exact because
+/// `sum_K = sum_{batches} sum_{K in batch}`, and never materializes the whole
+/// \c K extent of any intermediate at once.
 ///
 /// \param le the leaf evaluator (captured).
 /// \param target_batch_size the desired size of each batch *in elements* (a
@@ -1074,8 +1077,6 @@ template <typename F, typename IndexPredicate = accept_any_index,
     ScopeGuardFactory make_scope_guard = {}, IsVolatile is_volatile = {}) {
   return [le = std::move(le), target_batch_size, accept, is_volatile,
           make_scope_guard](auto const& node, auto& cache) -> ResultPtr {
-    using cache_t = std::remove_reference_t<decltype(cache)>;
-
     auto const K = batch_axis(node, accept);
     if (!K) return nullptr;
 
@@ -1101,9 +1102,23 @@ template <typename F, typename IndexPredicate = accept_any_index,
     auto const scope_guard = make_scope_guard(batches.size());
     (void)scope_guard;
 
+    // The scratch cache for the per-batch replays: registered from the
+    // subtree itself (same canonical-equality counting as the real cache), so
+    // repeated subtrees -- e.g. two canonically-equal children of the node --
+    // are evaluated once per batch and shared, not re-derived per occurrence.
+    // Carries no custom evaluator (no re-interception) and keeps the partial,
+    // sliced intermediates out of the real cache; reset() between batches
+    // drops the previous batch's partials (seeded entries are registered
+    // persistent and survive).
+    using node_t = std::remove_cvref_t<decltype(node)>;
+    std::vector<std::pair<node_t const*, Index>> const members{{&node, *K}};
+    auto bs = detail::make_batched_scratch(members, cache);
+    for (auto const* s : bs.seeds) (void)bs.cache.store(*s, cache.access(*s));
+
     ResultPtr acc;
     for (auto const& [e_lo, e_hi] : batches) {
       if (e_lo == e_hi) continue;
+      bs.cache.reset();
 
       // leaf evaluator that slices every leaf carrying K to this element batch;
       // others pass through unchanged.
@@ -1115,10 +1130,7 @@ template <typename F, typename IndexPredicate = accept_any_index,
         return r;
       };
 
-      // standard scheme on a fresh scratch cache: no re-interception, and the
-      // (partial, sliced) intermediates do not pollute the real cache.
-      auto scratch = cache_t::empty();
-      ResultPtr part = evaluate(node, le_g, scratch);
+      ResultPtr part = evaluate(node, le_g, bs.cache);
       if (!acc)
         acc = std::move(part);
       else

--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -975,6 +975,97 @@ template <typename Node, typename Pred>
   return subtree_any(n.left(), pred) || subtree_any(n.right(), pred);
 }
 
+namespace detail {
+
+/// The scratch cache for one batched replay pass, plus the alive persistent
+/// real-cache entries to pre-seed it with (registered persistent in the
+/// scratch, so they survive the per-batch reset()).
+template <typename TreeNode, bool FHC>
+struct BatchedScratch {
+  CacheManager<TreeNode, FHC> cache;
+  std::vector<TreeNode const*> seeds;
+};
+
+/// \brief Builds the scratch CacheManager for one batched replay pass over
+/// \p members (each a subtree root paired with its batch axis).
+///
+/// Walks every member subtree with the same pruned counting walk as
+/// cache_manager() (descend only on first visit of a canonical-equal node, so
+/// counts match access counts under caching) and registers every internal
+/// subnode that repeats AND has a consistent slicing signature -- the position
+/// of the containing member's batch axis in the subnode's canon_indices(), or
+/// its absence -- across all occurrences. Signature consistency is what makes
+/// a scratch hit exact across members: canonical equality maps the index at
+/// canonical position p to the index at position p, so equal signatures plus
+/// equal realized element ranges (guaranteed by the caller's grouping) imply
+/// identical slices. Inconsistently-sliced subnodes are not registered and so
+/// are evaluated per occurrence, unshared. Count inexactness arising from the
+/// pruned walk is benign: an undercount makes evaluate() recompute a drained
+/// entry, an overcount keeps an entry until the per-batch reset().
+///
+/// Subnodes whose signature is consistently 'absent' (no leaf below carries
+/// the axis -- the axis is contracted at the member's root, so a subtree
+/// containing an axis-carrying leaf carries the axis free in its
+/// canon_indices()) have batch-invariant full values; those that are alive
+/// persistent entries of \p real are returned as seeds, and the caller copies
+/// their values into the scratch before the batch loop.
+template <typename TreeNode, bool FHC, typename Members>
+[[nodiscard]] BatchedScratch<TreeNode, FHC> make_batched_scratch(
+    Members const& members, CacheManager<TreeNode, FHC> const& real) {
+  using Hasher = TreeNodeHasher<TreeNode, FHC>;
+  using Comp = TreeNodeEqualityComparator<TreeNode>;
+  struct Meta {
+    std::size_t count = 0;
+    std::optional<std::size_t> sig;
+    bool consistent = true;
+  };
+  std::unordered_map<TreeNode const*, Meta, Hasher, Comp> meta;
+
+  auto visit = [&meta](auto&& self, TreeNode const& n,
+                       Index const& axis) -> void {
+    if (n.leaf()) return;
+    auto const sig = index_position(n, axis);
+    auto const [it, first] = meta.try_emplace(&n);
+    auto& e = it->second;
+    if (first)
+      e.sig = sig;
+    else if (e.sig != sig)
+      e.consistent = false;
+    ++e.count;
+    if (!first) return;  // equal node already walked: deeper accesses shared
+    self(self, n.left(), axis);
+    self(self, n.right(), axis);
+  };
+  for (auto const& [root, axis] : members) {
+    // member roots themselves are accumulated by the caller, not cached here
+    if (root->leaf()) continue;
+    visit(visit, root->left(), axis);
+    visit(visit, root->right(), axis);
+  }
+
+  std::unordered_map<TreeNode, std::size_t, Hasher, Comp> reg;
+  std::unordered_set<TreeNode, Hasher, Comp> seed_keys;
+  std::vector<TreeNode const*> seeds;
+  for (auto const& [ptr, e] : meta) {
+    if (!e.consistent) continue;  // ambiguous slicing: never share
+    bool const seedable = !e.sig && real.persistent(*ptr) && real.alive(*ptr);
+    if (seedable) {
+      seeds.push_back(ptr);
+      seed_keys.insert(*ptr);
+      reg.emplace(*ptr, e.count);  // count is ignored for persistent entries
+    } else if (e.count >= 2) {
+      reg.emplace(*ptr, e.count);
+    }
+  }
+  auto is_persistent = [seed_keys = std::move(seed_keys)](TreeNode const& n) {
+    return seed_keys.contains(n);
+  };
+  return {CacheManager<TreeNode, FHC>{std::move(reg), std::move(is_persistent)},
+          std::move(seeds)};
+}
+
+}  // namespace detail
+
 template <typename F, typename IndexPredicate = accept_any_index,
           typename ScopeGuardFactory = make_no_scope_guard,
           typename IsVolatile = never_volatile>

--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -925,6 +925,21 @@ ResultPtr evaluate_antisymm(Args&&... args) {
 /// group candidate costs one leaf evaluation (the mode_batches probe); with an
 /// unregistered (empty) cache the group is just the trigger.
 ///
+/// Why a *group* of trees rather than the trigger alone: sub-intermediates are
+/// shared between separately-intercepted finals, and a scratch scoped to one
+/// final cannot see the other consumers. Concretely, in DF-based PNO-CCSD the
+/// half-transformed DF factor gC = g.C (g the 3-index DF factor carrying the
+/// aux index K, C the PNO coefficients) feeds both canonically-equal gCC
+/// children of the particle-particle-ladder intermediate W = gCC.gCC *and* the
+/// triply-transformed final gCCC. Unbatched, the real cache builds gC once and
+/// serves all three uses (its keys are canonical, max_life = 3). Batching each
+/// final in isolation rebuilds gC n_batches times *per final* -- the shared
+/// scratch of a single pass dedups W's two gCC children within each batch, but
+/// cross-final sharing with gCCC is restored only by streaming both finals
+/// over the same batch partition in the same passes, which brings gC back to
+/// one evaluation per batch (work parity with the unbatched path, at sliced
+/// rather than full intermediate peak memory).
+///
 /// \param le the leaf evaluator (captured).
 /// \param target_batch_size the desired size of each batch *in elements* (a
 ///        user knob; no memory model is assumed). Backend-neutral: a tiled

--- a/tests/unit/test_cache_manager.cpp
+++ b/tests/unit/test_cache_manager.cpp
@@ -159,6 +159,20 @@ TEST_CASE("cache_manager", "[cache_manager]") {
     }
   }
 
+  SECTION("for_each_key enumerates every registered key") {
+    auto const& man = man_const;
+    size_t count = 0;
+    man.for_each_key([&](node_type const& k) {
+      ++count;
+      REQUIRE(man.exists(k));
+    });
+    REQUIRE(count == n_decaying);
+
+    // empty manager: no keys, no invocations
+    auto const empty = manager_type::empty();
+    empty.for_each_key([](node_type const&) { FAIL("no keys expected"); });
+  }
+
   SECTION("Hash collision safety") {
     // Two structurally different nodes
     auto const n1 = make_node(L"R{a1;i1} = f{a1;i1}");

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -1798,6 +1798,49 @@ TEST_CASE("eval_batched_scratch", "[eval]") {
     auto bs = sequant::detail::make_batched_scratch(members, real);
     REQUIRE_FALSE(bs.cache.exists(node.left()));
   }
+
+  SECTION("descends through inconsistently-sliced re-encounters") {
+    // M1 (axis x_1) = X * D2 with X = (D * u): D's two occurrences (inside X
+    // and as the root's sibling D2) are visited with the same signature, so D
+    // alone would be registered. M2 (bogus axis) re-encounters X with
+    // signature 'absent' -- inconsistent, unshared. The walk must descend
+    // through that re-encounter: under it D's signature is also 'absent', so
+    // sharing D would serve M2's (per-occurrence) evaluation of X a wrongly
+    // sliced value. D must end up unregistered.
+    auto const expr_m1 = sequant::deserialize<sequant::ExprPtr>(
+        L"((g{a_2;i_1;x_1} * h{i_3;a_2}) * u{i_5;i_3}) * "
+        L"(g{a_3;i_2;x_1} * h{i_4;a_3})");
+    auto const m1 = eval_node(expr_m1);
+    auto const expr_m2 = sequant::deserialize<sequant::ExprPtr>(
+        L"((g{a_2;i_1;x_1} * h{i_3;a_2}) * u{i_5;i_3}) * p{i_6;i_7;x_1}");
+    auto const m2 = eval_node(expr_m2);
+    // structural preconditions: m1 = X * D2, X = D * u, D2 == D == m2's X
+    // child canonically
+    sequant::TreeNodeEqualityComparator<node_t> const eq;
+    REQUIRE_FALSE(m1.left().leaf());
+    REQUIRE_FALSE(m1.left().left().leaf());
+    auto const& D = m1.left().left();
+    REQUIRE(eq(D, m1.right()));
+    REQUIRE(eq(m1.left(), m2.left()));
+
+    // positive control: M1 alone registers D (count 2, consistent signature)
+    {
+      std::vector<std::pair<node_t const*, Index>> const members{{&m1, x1}};
+      auto bs = sequant::detail::make_batched_scratch(members, real);
+      REQUIRE(bs.cache.exists(D));
+      REQUIRE(bs.cache.max_life(D) == 2);
+    }
+    // adding M2 makes X inconsistent AND must expose D's 'absent' signature
+    // beneath X's second occurrence
+    {
+      auto const bogus_axis = Index(L"i_9");
+      std::vector<std::pair<node_t const*, Index>> const members{
+          {&m1, x1}, {&m2, bogus_axis}};
+      auto bs = sequant::detail::make_batched_scratch(members, real);
+      REQUIRE_FALSE(bs.cache.exists(m1.left()));  // X: inconsistent
+      REQUIRE_FALSE(bs.cache.exists(D));  // D: inconsistent via pruned branch
+    }
+  }
 }
 
 TEST_CASE("eval_batched_custom_evaluator dedups within-batch repeats",

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -1797,3 +1797,44 @@ TEST_CASE("eval_batched_scratch", "[eval]") {
     REQUIRE_FALSE(bs.cache.exists(node.left()));
   }
 }
+
+TEST_CASE("eval_batched_custom_evaluator dedups within-batch repeats",
+          "[eval]") {
+  using sequant::evaluate;
+  using sequant::make_batched_custom_evaluator;
+  using TA::TArrayD;
+  using node_t = sequant::FullBinaryNode<sequant::EvalExprTA>;
+  using cache_t = sequant::CacheManager<node_t>;
+
+  auto& world = TA::get_default_world();
+  rand_tensor_yield<double, TA::DensePolicy> yield_{world, 4, 12};
+  yield_.set_max_tile(4);
+
+  // W-analog: root contracts a1; the two children are canonically equal
+  auto const expr = sequant::deserialize<sequant::ExprPtr>(
+      L"(g_{a2}^{i1} * h_{a1,i3}^{a2}) * (g_{a3}^{i2} * h_{a1,i4}^{a3})");
+  std::string const target = "i_1,i_3,i_2,i_4";
+  auto const node = eval_node(expr);
+  auto const ref = evaluate(node, target, yield_)->get<TArrayD>();
+
+  std::map<std::wstring, int> n_yield;
+  auto counting_yield = [&yield_, &n_yield](node_t const& n) {
+    if (n->is_tensor()) ++n_yield[std::wstring(n->as_tensor().label())];
+    return yield_(n);
+  };
+
+  // a1 is unoccupied: extent 12, tiles of 4; target 4 elements -> 3 batches
+  int const n_b = 3;
+  auto cache = cache_t::empty();
+  cache.set_custom_evaluator(
+      make_batched_custom_evaluator(counting_yield, std::size_t{4}));
+  auto const res =
+      evaluate(node, target, counting_yield, cache)->get<TArrayD>();
+  REQUIRE(equal_tarrays<Loose>(res, ref));
+
+  // with within-batch dedup: per batch the left child evaluates (g and h
+  // yielded once each), the right child is a scratch cache hit; plus one h
+  // from the evaluator's mode_batches probe of the a1-carrying leaf
+  CHECK(n_yield[L"h"] == n_b + 1);
+  CHECK(n_yield[L"g"] == n_b);
+}

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -1838,3 +1838,138 @@ TEST_CASE("eval_batched_custom_evaluator dedups within-batch repeats",
   CHECK(n_yield[L"h"] == n_b + 1);
   CHECK(n_yield[L"g"] == n_b);
 }
+
+TEST_CASE("eval_batched_custom_evaluator group replay", "[eval]") {
+  using sequant::evaluate;
+  using sequant::make_batched_custom_evaluator;
+  using TA::TArrayD;
+  using node_t = sequant::FullBinaryNode<sequant::EvalExprTA>;
+
+  auto& world = TA::get_default_world();
+  rand_tensor_yield<double, TA::DensePolicy> yield_{world, 4, 12};
+  yield_.set_max_tile(4);
+
+  // Two persistent finals sharing the sub-intermediate S = g*h (carries the
+  // batch axis a1):
+  //   F1 = S * S'   (canonically-equal siblings; contracts a1)
+  //   F2 = S * p    (contracts a1)
+  // Volatile heads (label "t") make F1 and F2 persistent.
+  auto const t1 = sequant::deserialize<sequant::ExprPtr>(
+      L"((g_{a2}^{i1} * h_{a1,i3}^{a2}) * (g_{a3}^{i2} * h_{a1,i4}^{a3}))"
+      L" * t_{i1,i3}^{i5,i6}");
+  auto const t2 = sequant::deserialize<sequant::ExprPtr>(
+      L"((g_{a2}^{i1} * h_{a1,i3}^{a2}) * p_{a1}^{i5}) * t_{i1,i3}^{i6,i7}");
+  std::string const tgt1 = "i_2,i_4,i_5,i_6";
+  std::string const tgt2 = "i_5,i_6,i_7";
+  auto const n1 = eval_node(t1);
+  auto const n2 = eval_node(t2);
+
+  auto is_volatile_t = [](node_t const& n) {
+    return n.leaf() && n->is_tensor() && n->as_tensor().label() == L"t";
+  };
+
+  // references (unbatched, uncached, uncounted)
+  auto const ref1 = evaluate(n1, tgt1, yield_)->get<TArrayD>();
+  auto const ref2 = evaluate(n2, tgt2, yield_)->get<TArrayD>();
+
+  // real cache over the two-term forest; F1 and F2 must classify persistent
+  auto cache = sequant::cache_manager(std::vector{n1, n2}, is_volatile_t);
+  REQUIRE(cache.persistent(n1.left()));
+  REQUIRE(cache.persistent(n2.left()));
+
+  std::map<std::wstring, int> n_yield;
+  auto counting_yield = [&yield_, &n_yield](node_t const& n) {
+    if (n->is_tensor()) ++n_yield[std::wstring(n->as_tensor().label())];
+    return yield_(n);
+  };
+  cache.set_custom_evaluator(make_batched_custom_evaluator(
+      counting_yield, std::size_t{4}, sequant::accept_any_index{},
+      sequant::make_no_scope_guard{}, is_volatile_t));
+
+  // evaluating term 1 triggers at F1 and must prebuild F2 in the same passes
+  auto const res1 = evaluate(n1, tgt1, counting_yield, cache)->get<TArrayD>();
+  REQUIRE(cache.alive(n2.left()));  // F2 prebuilt by the group replay
+
+  auto const res2 = evaluate(n2, tgt2, counting_yield, cache)->get<TArrayD>();
+  REQUIRE(equal_tarrays<Loose>(res1, ref1));
+  REQUIRE(equal_tarrays<Loose>(res2, ref2));
+
+  // S evaluated once per batch (n_b = 3), shared by F1 (x2) and F2 (x1):
+  // h: 3 (S evals) + 1 (trigger probe) + 1 (F2 candidacy probe) = 5
+  // g: 3; p: 3 (sliced, once per batch); t: 2 (one per term head)
+  CHECK(n_yield[L"h"] == 5);
+  CHECK(n_yield[L"g"] == 3);
+  CHECK(n_yield[L"p"] == 3);
+  CHECK(n_yield[L"t"] == 2);
+}
+
+TEST_CASE("eval_batched_custom_evaluator group replay layers nested finals",
+          "[eval]") {
+  using sequant::evaluate;
+  using sequant::make_batched_custom_evaluator;
+  using TA::TArrayD;
+  using node_t = sequant::FullBinaryNode<sequant::EvalExprTA>;
+
+  auto& world = TA::get_default_world();
+  rand_tensor_yield<double, TA::DensePolicy> yield_{world, 4, 12};
+  yield_.set_max_tile(4);
+
+  // F_in = (g*h)*p (contracts a1; persistent) nests inside F_out, which
+  // contracts its own axis a6:  F_out = ((F_in * r) * q), r and q carry a6.
+  // Triggering at F_out must build F_in in an inner layer first, then seed
+  // its full value into F_out's pass (F_in carries no a6).
+  auto const t_out = sequant::deserialize<sequant::ExprPtr>(
+      L"((((g_{a2}^{i1} * h_{a1,i3}^{a2}) * p_{a1}^{i5}) * r_{i5}^{a6})"
+      L" * q_{a6}^{i7}) * t_{i1,i3}^{i8,i9}");
+  auto const t_in = sequant::deserialize<sequant::ExprPtr>(
+      L"((g_{a2}^{i1} * h_{a1,i3}^{a2}) * p_{a1}^{i5}) * t_{i1,i3}^{i6,i7}");
+  std::string const tgt_out = "i_7,i_8,i_9";
+  std::string const tgt_in = "i_5,i_6,i_7";
+  auto const n_out = eval_node(t_out);
+  auto const n_in = eval_node(t_in);
+
+  auto is_volatile_t = [](node_t const& n) {
+    return n.leaf() && n->is_tensor() && n->as_tensor().label() == L"t";
+  };
+
+  auto const ref_out = evaluate(n_out, tgt_out, yield_)->get<TArrayD>();
+  auto const ref_in = evaluate(n_in, tgt_in, yield_)->get<TArrayD>();
+
+  auto cache = sequant::cache_manager(std::vector{n_out, n_in}, is_volatile_t);
+  // structural preconditions: both finals persistent; F_in nests in F_out
+  REQUIRE(cache.persistent(n_out.left()));
+  REQUIRE(cache.persistent(n_in.left()));
+  {
+    sequant::TreeNodeEqualityComparator<node_t> const eq;
+    REQUIRE(eq(n_out.left().left().left(), n_in.left()));
+  }
+
+  std::map<std::wstring, int> n_yield;
+  auto counting_yield = [&yield_, &n_yield](node_t const& n) {
+    if (n->is_tensor()) ++n_yield[std::wstring(n->as_tensor().label())];
+    return yield_(n);
+  };
+  cache.set_custom_evaluator(make_batched_custom_evaluator(
+      counting_yield, std::size_t{4}, sequant::accept_any_index{},
+      sequant::make_no_scope_guard{}, is_volatile_t));
+
+  auto const res_out =
+      evaluate(n_out, tgt_out, counting_yield, cache)->get<TArrayD>();
+  REQUIRE(cache.alive(n_in.left()));  // inner layer built and stored
+
+  auto const res_in =
+      evaluate(n_in, tgt_in, counting_yield, cache)->get<TArrayD>();
+  REQUIRE(equal_tarrays<Loose>(res_out, ref_out));
+  REQUIRE(equal_tarrays<Loose>(res_in, ref_in));
+
+  // layer 1 (F_in over a1, 3 batches): g,h,p once per batch; layer 2 (F_out
+  // over a6): F_in SEEDED (g,h,p untouched), r,q sliced once per batch.
+  // Probes: +1 r (trigger, a6-carrying leaf), +1 h (F_in candidacy, a1 leaf).
+  // If seeding failed and F_in were re-derived per batch, g/h/p would be 6+.
+  CHECK(n_yield[L"h"] == 4);
+  CHECK(n_yield[L"g"] == 3);
+  CHECK(n_yield[L"p"] == 3);
+  CHECK(n_yield[L"r"] == 4);
+  CHECK(n_yield[L"q"] == 3);
+  CHECK(n_yield[L"t"] == 2);
+}

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -21,6 +21,7 @@
 #include <range/v3/view/concat.hpp>
 #include <range/v3/view/intersperse.hpp>
 #include <range/v3/view/join.hpp>
+#include <range/v3/view/single.hpp>
 #include <range/v3/view/transform.hpp>
 
 #include <cmath>
@@ -1744,5 +1745,55 @@ TEST_CASE("ta_tot_conj_complex", "[eval]") {
         CHECK(cinner[k].imag() == Catch::Approx(-sinner[k].imag()));
       }
     }
+  }
+}
+
+TEST_CASE("eval_batched_scratch", "[eval]") {
+  using node_t = sequant::FullBinaryNode<sequant::EvalExprTA>;
+  using cache_t = sequant::CacheManager<node_t>;
+  using sequant::Index;
+
+  // W-analog: two canonically-equal internal siblings, both carrying the
+  // batch axis a_1 (free at the children, contracted at the root)
+  auto const expr = sequant::deserialize<sequant::ExprPtr>(
+      L"(g_{a2}^{i1} * h_{a1,i3}^{a2}) * (g_{a3}^{i2} * h_{a1,i4}^{a3})");
+  auto const node = eval_node(expr);
+  REQUIRE_FALSE(node.leaf());
+  REQUIRE_FALSE(node.left().leaf());
+  REQUIRE_FALSE(node.right().leaf());
+  // structural precondition: the two children ARE canonically equal
+  {
+    auto cm = sequant::cache_manager(ranges::views::single(node), 2);
+    REQUIRE(cm.max_life(node.left()) == 2);
+  }
+  auto const a1 = [&] {  // the contracted (batch) axis
+    auto axes = sequant::contracted_indices(node);
+    REQUIRE(axes.size() == 1);
+    return axes[0];
+  }();
+
+  auto real = cache_t::empty();
+
+  SECTION("registers consistent repeats with in-pass counts") {
+    std::vector<std::pair<node_t const*, Index>> const members{{&node, a1}};
+    auto bs = sequant::detail::make_batched_scratch(members, real);
+    REQUIRE(bs.cache.exists(node.left()));
+    REQUIRE(bs.cache.max_life(node.left()) == 2);
+    REQUIRE_FALSE(bs.cache.exists(node));  // member roots are not registered
+    REQUIRE(bs.seeds.empty());
+  }
+
+  SECTION("signature-inconsistent subnodes are not registered") {
+    // the same subtree appears under two members, but the second member's
+    // axis (an index the shared subnode does not carry) gives it signature
+    // 'absent' while the first gives a position -> inconsistent -> unshared
+    auto const expr2 = sequant::deserialize<sequant::ExprPtr>(
+        L"(g_{a2}^{i1} * h_{a1,i3}^{a2}) * p_{a1}^{i5}");
+    auto const node2 = eval_node(expr2);
+    auto const bogus_axis = Index(L"i_9");
+    std::vector<std::pair<node_t const*, Index>> const members{
+        {&node, a1}, {&node2, bogus_axis}};
+    auto bs = sequant::detail::make_batched_scratch(members, real);
+    REQUIRE_FALSE(bs.cache.exists(node.left()));
   }
 }

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -1753,10 +1753,12 @@ TEST_CASE("eval_batched_scratch", "[eval]") {
   using cache_t = sequant::CacheManager<node_t>;
   using sequant::Index;
 
-  // W-analog: two canonically-equal internal siblings, both carrying the
-  // batch axis a_1 (free at the children, contracted at the root)
+  // W-analog of the PNO-CCSD PPL intermediate: two canonically-equal internal
+  // siblings, both carrying the auxiliary batch axis x_1 (free at the
+  // children, contracted at the root; an aux-aux edge, like the DF index K).
+  // Every orbital contraction pairs a bra with a ket.
   auto const expr = sequant::deserialize<sequant::ExprPtr>(
-      L"(g_{a2}^{i1} * h_{a1,i3}^{a2}) * (g_{a3}^{i2} * h_{a1,i4}^{a3})");
+      L"(g{a_2;i_1;x_1} * h{i_3;a_2}) * (g{a_3;i_2;x_1} * h{i_4;a_3})");
   auto const node = eval_node(expr);
   REQUIRE_FALSE(node.leaf());
   REQUIRE_FALSE(node.left().leaf());
@@ -1766,7 +1768,7 @@ TEST_CASE("eval_batched_scratch", "[eval]") {
     auto cm = sequant::cache_manager(ranges::views::single(node), 2);
     REQUIRE(cm.max_life(node.left()) == 2);
   }
-  auto const a1 = [&] {  // the contracted (batch) axis
+  auto const x1 = [&] {  // the contracted (batch) axis
     auto axes = sequant::contracted_indices(node);
     REQUIRE(axes.size() == 1);
     return axes[0];
@@ -1775,7 +1777,7 @@ TEST_CASE("eval_batched_scratch", "[eval]") {
   auto real = cache_t::empty();
 
   SECTION("registers consistent repeats with in-pass counts") {
-    std::vector<std::pair<node_t const*, Index>> const members{{&node, a1}};
+    std::vector<std::pair<node_t const*, Index>> const members{{&node, x1}};
     auto bs = sequant::detail::make_batched_scratch(members, real);
     REQUIRE(bs.cache.exists(node.left()));
     REQUIRE(bs.cache.max_life(node.left()) == 2);
@@ -1788,11 +1790,11 @@ TEST_CASE("eval_batched_scratch", "[eval]") {
     // axis (an index the shared subnode does not carry) gives it signature
     // 'absent' while the first gives a position -> inconsistent -> unshared
     auto const expr2 = sequant::deserialize<sequant::ExprPtr>(
-        L"(g_{a2}^{i1} * h_{a1,i3}^{a2}) * p_{a1}^{i5}");
+        L"(g{a_2;i_1;x_1} * h{i_3;a_2}) * p{i_5;i_6;x_1}");
     auto const node2 = eval_node(expr2);
     auto const bogus_axis = Index(L"i_9");
     std::vector<std::pair<node_t const*, Index>> const members{
-        {&node, a1}, {&node2, bogus_axis}};
+        {&node, x1}, {&node2, bogus_axis}};
     auto bs = sequant::detail::make_batched_scratch(members, real);
     REQUIRE_FALSE(bs.cache.exists(node.left()));
   }
@@ -1807,12 +1809,13 @@ TEST_CASE("eval_batched_custom_evaluator dedups within-batch repeats",
   using cache_t = sequant::CacheManager<node_t>;
 
   auto& world = TA::get_default_world();
-  rand_tensor_yield<double, TA::DensePolicy> yield_{world, 4, 12};
+  rand_tensor_yield<double, TA::DensePolicy> yield_{world, 4, 12, 12};
   yield_.set_max_tile(4);
 
-  // W-analog: root contracts a1; the two children are canonically equal
+  // W-analog: root contracts the aux index x_1; the two children are
+  // canonically equal
   auto const expr = sequant::deserialize<sequant::ExprPtr>(
-      L"(g_{a2}^{i1} * h_{a1,i3}^{a2}) * (g_{a3}^{i2} * h_{a1,i4}^{a3})");
+      L"(g{a_2;i_1;x_1} * h{i_3;a_2}) * (g{a_3;i_2;x_1} * h{i_4;a_3})");
   std::string const target = "i_1,i_3,i_2,i_4";
   auto const node = eval_node(expr);
   auto const ref = evaluate(node, target, yield_)->get<TArrayD>();
@@ -1823,7 +1826,7 @@ TEST_CASE("eval_batched_custom_evaluator dedups within-batch repeats",
     return yield_(n);
   };
 
-  // a1 is unoccupied: extent 12, tiles of 4; target 4 elements -> 3 batches
+  // x_1 is auxiliary: extent 12, tiles of 4; target 4 elements -> 3 batches
   int const n_b = 3;
   auto cache = cache_t::empty();
   cache.set_custom_evaluator(
@@ -1833,10 +1836,10 @@ TEST_CASE("eval_batched_custom_evaluator dedups within-batch repeats",
   REQUIRE(equal_tarrays<Loose>(res, ref));
 
   // with within-batch dedup: per batch the left child evaluates (g and h
-  // yielded once each), the right child is a scratch cache hit; plus one h
-  // from the evaluator's mode_batches probe of the a1-carrying leaf
-  CHECK(n_yield[L"h"] == n_b + 1);
-  CHECK(n_yield[L"g"] == n_b);
+  // yielded once each), the right child is a scratch cache hit; plus one g
+  // from the evaluator's mode_batches probe of the x_1-carrying leaf
+  CHECK(n_yield[L"g"] == n_b + 1);
+  CHECK(n_yield[L"h"] == n_b);
 }
 
 TEST_CASE("eval_batched_custom_evaluator group replay", "[eval]") {
@@ -1846,21 +1849,22 @@ TEST_CASE("eval_batched_custom_evaluator group replay", "[eval]") {
   using node_t = sequant::FullBinaryNode<sequant::EvalExprTA>;
 
   auto& world = TA::get_default_world();
-  rand_tensor_yield<double, TA::DensePolicy> yield_{world, 4, 12};
+  rand_tensor_yield<double, TA::DensePolicy> yield_{world, 4, 12, 12};
   yield_.set_max_tile(4);
 
   // Two persistent finals sharing the sub-intermediate S = g*h (carries the
-  // batch axis a1):
-  //   F1 = S * S'   (canonically-equal siblings; contracts a1)
-  //   F2 = S * p    (contracts a1)
-  // Volatile heads (label "t") make F1 and F2 persistent.
+  // auxiliary batch axis x_1):
+  //   F1 = S * S'   (canonically-equal siblings; contracts x_1, aux-aux)
+  //   F2 = S * p    (contracts x_1, aux-aux)
+  // Volatile heads (label "t") make F1 and F2 persistent. Every orbital
+  // contraction pairs a bra with a ket.
   auto const t1 = sequant::deserialize<sequant::ExprPtr>(
-      L"((g_{a2}^{i1} * h_{a1,i3}^{a2}) * (g_{a3}^{i2} * h_{a1,i4}^{a3}))"
-      L" * t_{i1,i3}^{i5,i6}");
+      L"((g{a_2;i_1;x_1} * h{i_3;a_2}) * (g{a_3;i_2;x_1} * h{i_4;a_3}))"
+      L" * t{i_1,i_2;i_3,i_9}");
   auto const t2 = sequant::deserialize<sequant::ExprPtr>(
-      L"((g_{a2}^{i1} * h_{a1,i3}^{a2}) * p_{a1}^{i5}) * t_{i1,i3}^{i6,i7}");
-  std::string const tgt1 = "i_2,i_4,i_5,i_6";
-  std::string const tgt2 = "i_5,i_6,i_7";
+      L"((g{a_2;i_1;x_1} * h{i_3;a_2}) * p{i_5;i_6;x_1}) * t{i_1;i_3}");
+  std::string const tgt1 = "i_4,i_9";
+  std::string const tgt2 = "i_5,i_6";
   auto const n1 = eval_node(t1);
   auto const n2 = eval_node(t2);
 
@@ -1894,11 +1898,11 @@ TEST_CASE("eval_batched_custom_evaluator group replay", "[eval]") {
   REQUIRE(equal_tarrays<Loose>(res1, ref1));
   REQUIRE(equal_tarrays<Loose>(res2, ref2));
 
-  // S evaluated once per batch (n_b = 3), shared by F1 (x2) and F2 (x1):
-  // h: 3 (S evals) + 1 (trigger probe) + 1 (F2 candidacy probe) = 5
-  // g: 3; p: 3 (sliced, once per batch); t: 2 (one per term head)
-  CHECK(n_yield[L"h"] == 5);
-  CHECK(n_yield[L"g"] == 3);
+  // S evaluated once per batch (n_b = 3), shared by F1 (twice) and F2 (once):
+  // g: 3 (S evals) + 1 (trigger probe) + 1 (F2 candidacy probe) = 5
+  // h: 3; p: 3 (sliced, once per batch); t: 2 (one per term head)
+  CHECK(n_yield[L"g"] == 5);
+  CHECK(n_yield[L"h"] == 3);
   CHECK(n_yield[L"p"] == 3);
   CHECK(n_yield[L"t"] == 2);
 }
@@ -1911,19 +1915,20 @@ TEST_CASE("eval_batched_custom_evaluator group replay layers nested finals",
   using node_t = sequant::FullBinaryNode<sequant::EvalExprTA>;
 
   auto& world = TA::get_default_world();
-  rand_tensor_yield<double, TA::DensePolicy> yield_{world, 4, 12};
+  rand_tensor_yield<double, TA::DensePolicy> yield_{world, 4, 12, 12};
   yield_.set_max_tile(4);
 
-  // F_in = (g*h)*p (contracts a1; persistent) nests inside F_out, which
-  // contracts its own axis a6:  F_out = ((F_in * r) * q), r and q carry a6.
-  // Triggering at F_out must build F_in in an inner layer first, then seed
-  // its full value into F_out's pass (F_in carries no a6).
+  // F_in = (g*h)*p (contracts the aux index x_1; persistent) nests inside
+  // F_out, which contracts its own aux axis x_2:  F_out = (F_in * r) * q,
+  // with r and q carrying x_2. Triggering at F_out must build F_in in an
+  // inner layer first, then seed its full value into F_out's pass (F_in
+  // carries no x_2). Every orbital contraction pairs a bra with a ket.
   auto const t_out = sequant::deserialize<sequant::ExprPtr>(
-      L"((((g_{a2}^{i1} * h_{a1,i3}^{a2}) * p_{a1}^{i5}) * r_{i5}^{a6})"
-      L" * q_{a6}^{i7}) * t_{i1,i3}^{i8,i9}");
+      L"((((g{a_2;i_1;x_1} * h{i_3;a_2}) * p{i_5;i_6;x_1}) * r{i_6;i_7;x_2})"
+      L" * q{i_7;i_8;x_2}) * t{i_1;i_3,i_9}");
   auto const t_in = sequant::deserialize<sequant::ExprPtr>(
-      L"((g_{a2}^{i1} * h_{a1,i3}^{a2}) * p_{a1}^{i5}) * t_{i1,i3}^{i6,i7}");
-  std::string const tgt_out = "i_7,i_8,i_9";
+      L"((g{a_2;i_1;x_1} * h{i_3;a_2}) * p{i_5;i_6;x_1}) * t{i_1;i_3,i_7}");
+  std::string const tgt_out = "i_5,i_8,i_9";
   std::string const tgt_in = "i_5,i_6,i_7";
   auto const n_out = eval_node(t_out);
   auto const n_in = eval_node(t_in);
@@ -1949,8 +1954,14 @@ TEST_CASE("eval_batched_custom_evaluator group replay layers nested finals",
     if (n->is_tensor()) ++n_yield[std::wstring(n->as_tensor().label())];
     return yield_(n);
   };
+  // batch only over auxiliary indices (as a DF-batched application would)
+  auto const aux_space =
+      sequant::get_default_context().index_space_registry()->retrieve(L"x");
+  auto accept_aux = [aux_space](sequant::Index const& ix) {
+    return ix.space() == aux_space;
+  };
   cache.set_custom_evaluator(make_batched_custom_evaluator(
-      counting_yield, std::size_t{4}, sequant::accept_any_index{},
+      counting_yield, std::size_t{4}, accept_aux,
       sequant::make_no_scope_guard{}, is_volatile_t));
 
   auto const res_out =
@@ -1962,12 +1973,13 @@ TEST_CASE("eval_batched_custom_evaluator group replay layers nested finals",
   REQUIRE(equal_tarrays<Loose>(res_out, ref_out));
   REQUIRE(equal_tarrays<Loose>(res_in, ref_in));
 
-  // layer 1 (F_in over a1, 3 batches): g,h,p once per batch; layer 2 (F_out
-  // over a6): F_in SEEDED (g,h,p untouched), r,q sliced once per batch.
-  // Probes: +1 r (trigger, a6-carrying leaf), +1 h (F_in candidacy, a1 leaf).
-  // If seeding failed and F_in were re-derived per batch, g/h/p would be 6+.
-  CHECK(n_yield[L"h"] == 4);
-  CHECK(n_yield[L"g"] == 3);
+  // layer 1 (F_in over x_1, 3 batches): g,h,p once per batch; layer 2 (F_out
+  // over x_2): F_in SEEDED (g,h,p untouched), r,q sliced once per batch.
+  // Probes: +1 r (trigger, x_2-carrying leaf), +1 g (F_in candidacy, x_1
+  // leaf). If seeding failed and F_in were re-derived per batch, g/h/p
+  // would be 6+.
+  CHECK(n_yield[L"g"] == 4);
+  CHECK(n_yield[L"h"] == 3);
   CHECK(n_yield[L"p"] == 3);
   CHECK(n_yield[L"r"] == 4);
   CHECK(n_yield[L"q"] == 3);


### PR DESCRIPTION
## Problem

`make_batched_custom_evaluator` evaluates each batch of an intercepted subtree on `CacheManager::empty()`. Since `CacheManager` only caches keys registered at construction, per-batch evaluation caches **nothing**:

- canonically-equal sibling subtrees are re-derived per occurrence within every batch, and
- separately-intercepted persistent finals rebuild shared sub-intermediates per batch with no cross-consumer sharing.

### Motivation: why the unit of replay must be a *group* of trees

In DF-based PNO-CCSD the half-transformed DF factor `gC = g·C` (`g(μ̃,μ̃;K)` the 3-index DF factor carrying the aux index `K`, `C` the PNO coefficients) feeds three consumers: the two canonically-equal `gCC` children of the particle-particle-ladder intermediate `W = gCC·gCC`, and the triply-transformed final `gCCC`. Unbatched, one real-cache entry serves all three uses (`max_life=3`): keys are canonical TreeNodes, so both `gCC` occurrences and the `gCCC` subtree resolve to the same `gC` key.

Batched, `W` and `gCCC` are intercepted *separately*, each streamed over `K` on an empty cache, so `gC` is rebuilt once per occurrence per batch: 3 batches × 2 `W`-children + 3 × 1 in `gCCC` = **×9** per build vs ×1 unbatched. Measured on c6h14/cc-pVDZ PNO-CCSD (mpqc, 3 aux batches) that is the 2.9 GB `gC` built 9 times, and iteration-1 wall time of 40.4 s vs 24.9 s unbatched — batching traded its memory win for a 1.6× slowdown.

A scratch cache scoped to a single intercepted final only fixes the first bullet (the within-batch `W`-sibling duplication: ×9 → ×6). It cannot recover the cross-final sharing: while `W` is being batch-evaluated, `gCCC` is not in scope, so its `gC` use is invisible; and the per-batch partials are *slices*, which must not enter the real cache (its entries are full tensors with use counts derived from the whole expression). The cross-final sharing can only be recovered **inside the batch loop**: every final that batches over the same realized partition must stream through the same passes against one shared scratch, bringing `gC` back to one evaluation per batch (×3 = n_batches, work parity with unbatched). That is what forces the unit of replay to be a group of trees — the trigger plus all compatible registered persistent finals — rather than the single intercepted subtree.

## Fix: replay the persistent-final builds per batch through the standard caching mechanism

Batch intermediates have the same identity (canonical hash; slicing lives in the leaf evaluator, nodes are untouched) and the same consumer structure as their unbatched counterparts — so per-batch evaluation can use the same caching mechanism, with finals accumulated across batches instead of assigned:

- **`CacheManager::for_each_key`** — minimal key-enumeration API (keys are the canonical TreeNodes, so the evaluator recovers full subtrees from the cache it is handed).
- **`detail::make_batched_scratch`** — per-pass scratch registration: the same pruned counting walk as `cache_manager()` over the member subtrees (in-pass use counts), plus a **slicing-signature guard**: a subnode is registered only if the position of the containing member's batch axis in its `canon_indices()` (or its absence) is consistent across all occurrences. Canonical equality maps position-p to position-p, so equal signatures + equal element ranges imply identical slices; inconsistently-sliced subnodes are evaluated per occurrence, unshared. The walk prunes a re-encounter of a canonically-equal node only when its signature matches the first visit's, and descends otherwise, so descendants' signatures under an inconsistently-sliced occurrence are audited rather than hidden by the prune. Count inexactness from the pruned walk is benign (undercount ⇒ recompute, overcount ⇒ linger until the per-batch `reset()`).
- **Group replay in `make_batched_custom_evaluator`** — on interception, the group = trigger + every registered persistent, not-yet-alive key batchable over an identically-realized partition. Members nested inside other members evaluate in earlier passes and are then pre-seeded into the outer pass (when slice-free w.r.t. the outer axis; registered persistent in the scratch so they survive the per-batch `reset()`) or re-derived sliced (correct, unshared) otherwise. Completed members are stored into the real cache under the canonical-phase convention; the trigger's result is returned for `evaluate()` to cache as usual. With an unregistered (empty) cache the group degenerates to the trigger alone, which still fixes the within-batch sibling duplication.

## Validation

- New unit tests: scratch registration + signature-guard exclusion, including descent through signature-inconsistent re-encounters (a descendant sliced differently only under a pruned occurrence must not be shared); within-batch sibling dedup (leaf-eval counting: shared child evaluated once per batch, not once per occurrence); cross-final group sharing (second final prebuilt and alive after the first trigger; shared sub-intermediate evaluated n_batches times total across 3 consumers); nested finals (inner built in an earlier layer, seeded into the outer pass — exact leaf counts). Full suite passes (68 cases, 311k assertions).
- mpqc c6h14/cc-pVDZ PNO-CCSD (3 aux batches): `g·C` evaluations ×9 → **×3** (= n_batches, work parity with unbatched); iteration-1 wall time 40.4 s → **20.9 s** (now faster than unbatched 25.7 s, at half the peak intermediate size: 2.9 GB vs 6.2 GB sliced vs full); total CCSD solve 115.3 s → **93.5 s**. Energies agree with the pre-fix batched run to 3e-11; the unbatched path is untouched. he10 PAO-CSV-CCSD batched validation test reproduces its reference to 8e-9 (≪ its 1e-7 precision).
