### PR TITLE
CC/UCC Related Improvements

### DIFF
--- a/SeQuant/core/expressions/tensor.cpp
+++ b/SeQuant/core/expressions/tensor.cpp
@@ -25,16 +25,12 @@ void Tensor::assert_nonreserved_label(
 void Tensor::adjoint() {
   std::swap(bra_.value(), ket_.value());
 
-  // only track adjointness for BraKetSymmetry::Nonsymm cases
+  // adjointness is tracked solely by the label marker, for Nonsymm braket
   if (braket_symmetry() == BraKetSymmetry::Nonsymm) {
-    if (label_.back() == sequant::adjoint_label) {
-      SEQUANT_ASSERT(is_adjoint_);
+    if (!label_.empty() && label_.back() == sequant::adjoint_label)
       label_.pop_back();
-    } else {
-      SEQUANT_ASSERT(!is_adjoint_);
+    else
       label_.push_back(sequant::adjoint_label);
-    }
-    is_adjoint_ = !is_adjoint_;
   }
 
   reset_hash_value();

--- a/SeQuant/core/expressions/tensor.hpp
+++ b/SeQuant/core/expressions/tensor.hpp
@@ -795,7 +795,6 @@ class Tensor : public Expr, public AbstractTensor, public MutatableLabeled {
   ColumnSymmetry column_symmetry_ = ColumnSymmetry::Nonsymm;
   mutable std::optional<hash_type>
       bra_hash_value_;  // memoized byproduct of memoizing_hash()
-  bool is_adjoint_ = false;
   std::size_t bra_net_rank_;
   std::size_t ket_net_rank_;
 

--- a/SeQuant/domain/mbpt/models/cc.cpp
+++ b/SeQuant/domain/mbpt/models/cc.cpp
@@ -57,6 +57,8 @@ bool CC::unitary() const {
   return ansatz_ == Ansatz::U || ansatz_ == Ansatz::oU;
 }
 
+std::optional<size_t> CC::hbar_comm_rank() const { return hbar_comm_rank_; }
+
 bool CC::skip_singles() const { return skip_singles_; }
 
 bool CC::screen() const { return screen_; }
@@ -67,6 +69,15 @@ ExprPtr CC::hbar(std::optional<size_t> truncation_rank) const {
   const auto truncation = truncation_rank.value_or(hbar_comm_rank_.value_or(4));
   return mbpt::lst(H(), T(N, skip_singles()), truncation,
                    {.unitary = unitary()});
+}
+
+ExprPtr CC::energy(std::optional<size_t> comm_rank) const {
+  // <0|H̄|0>: reference expectation value of H̄ at the requested commutator
+  // truncation. No projector ⇒ this is the energy. ref_av applies the
+  // connectivity (empty for unitary, default otherwise).
+  return this->unitary() ? this->ref_av(this->hbar(comm_rank),
+                                        mbpt::OpConnections<std::wstring>{})
+                         : this->ref_av(this->hbar(comm_rank));
 }
 
 std::vector<ExprPtr> CC::t(size_t pmax, size_t pmin) const {

--- a/SeQuant/domain/mbpt/models/cc.cpp
+++ b/SeQuant/domain/mbpt/models/cc.cpp
@@ -69,7 +69,7 @@ ExprPtr CC::hbar(std::optional<size_t> truncation_rank) const {
                    {.unitary = unitary()});
 }
 
-std::vector<ExprPtr> CC::t(size_t pmax, size_t pmin) {
+std::vector<ExprPtr> CC::t(size_t pmax, size_t pmin) const {
   pmax = (pmax == std::numeric_limits<size_t>::max() ? N : pmax);
   SEQUANT_ASSERT(pmax >= pmin && "pmax should be >= pmin");
 
@@ -121,7 +121,7 @@ std::vector<ExprPtr> CC::t(size_t pmax, size_t pmin) {
   return result;
 }
 
-std::vector<ExprPtr> CC::λ() {
+std::vector<ExprPtr> CC::λ() const {
   SEQUANT_ASSERT(!unitary() && "there is no need for CC::λ for unitary ansatz");
 
   // construct hbar
@@ -188,7 +188,7 @@ std::vector<ExprPtr> CC::λ() {
 }
 
 std::vector<ExprPtr> CC::tʼ(size_t rank, size_t order,
-                            std::optional<size_t> nbatch) {
+                            std::optional<size_t> nbatch) const {
   SEQUANT_ASSERT(order == 1 &&
                  "sequant::mbpt::CC::tʼ(): only first-order perturbation is "
                  "supported now");
@@ -252,7 +252,7 @@ std::vector<ExprPtr> CC::tʼ(size_t rank, size_t order,
 }
 
 std::vector<ExprPtr> CC::λʼ(size_t rank, size_t order,
-                            std::optional<size_t> nbatch) {
+                            std::optional<size_t> nbatch) const {
   SEQUANT_ASSERT(order == 1 &&
                  "sequant::mbpt::CC::λʼ(): only first-order perturbation is "
                  "supported now");
@@ -311,7 +311,7 @@ std::vector<ExprPtr> CC::λʼ(size_t rank, size_t order,
   return result;
 }
 
-std::vector<ExprPtr> CC::eom_r(nₚ np, nₕ nh) {
+std::vector<ExprPtr> CC::eom_r(nₚ np, nₕ nh) const {
   SEQUANT_ASSERT((np > 0 || nh > 0) && "Unsupported excitation order");
   if (np != nh)
     SEQUANT_ASSERT(
@@ -361,7 +361,7 @@ std::vector<ExprPtr> CC::eom_r(nₚ np, nₕ nh) {
   return result;
 }
 
-std::vector<ExprPtr> CC::eom_l(nₚ np, nₕ nh) {
+std::vector<ExprPtr> CC::eom_l(nₚ np, nₕ nh) const {
   SEQUANT_ASSERT(!unitary() &&
                  "there is no need for CC::eom_l for unitary ansatz");
   SEQUANT_ASSERT((np > 0 || nh > 0) && "Unsupported excitation order");

--- a/SeQuant/domain/mbpt/models/cc.hpp
+++ b/SeQuant/domain/mbpt/models/cc.hpp
@@ -101,7 +101,7 @@ class CC {
   ///   \f$ \langle k |\bar{H}|0 \rangle = 0 \f$ for `k` in the [\p pmin,\p
   ///   pmax] range, and null value otherwise
   [[nodiscard]] std::vector<ExprPtr> t(
-      size_t pmax = std::numeric_limits<size_t>::max(), size_t pmin = 0);
+      size_t pmax = std::numeric_limits<size_t>::max(), size_t pmin = 0) const;
 
   /// @brief derives λ amplitude equations,
   /// \f$ \langle 0| (1 + \hat{\Lambda}) \frac{d \bar{H}}{d \hat{T}_P} |0
@@ -112,7 +112,7 @@ class CC {
   ///   \rangle = 0 \f$ for `k` in
   /// the [1,N] range; element 0 contains the λ pseudoenergy, computed as the
   /// CC energy with \f$ \hat{T} \f$ replaced by \f$ \hat{\Lambda}^{\dagger} \f$
-  [[nodiscard]] std::vector<ExprPtr> λ();
+  [[nodiscard]] std::vector<ExprPtr> λ() const;
 
   // clang-format off
   /// @brief derives perturbed t amplitude equations
@@ -124,7 +124,7 @@ class CC {
   // clang-format on
   [[nodiscard]] std::vector<ExprPtr> tʼ(
       size_t rank = 1, size_t order = 1,
-      std::optional<size_t> nbatch = std::nullopt);
+      std::optional<size_t> nbatch = std::nullopt) const;
 
   // clang-format off
   /// @brief derives perturbed λ amplitude equations
@@ -136,19 +136,19 @@ class CC {
   // clang-format on
   [[nodiscard]] std::vector<ExprPtr> λʼ(
       size_t rank = 1, size_t order = 1,
-      std::optional<size_t> nbatch = std::nullopt);
+      std::optional<size_t> nbatch = std::nullopt) const;
 
   /// @brief derives right-side sigma equations for EOM-CC
   /// @param np number of particle creators in R operator
   /// @param nh number of hole creators in R operator
   /// @return vector of right side sigma equations, element 0 is always null
-  [[nodiscard]] std::vector<ExprPtr> eom_r(nₚ np, nₕ nh);
+  [[nodiscard]] std::vector<ExprPtr> eom_r(nₚ np, nₕ nh) const;
 
   /// @brief derives left-side sigma equations for EOM-CC
   /// @param np number of particle annihilators in L operator
   /// @param nh number of hole annihilators in L operator
   /// @return vector of left side sigma equations, element 0 is always null
-  [[nodiscard]] std::vector<ExprPtr> eom_l(nₚ np, nₕ nh);
+  [[nodiscard]] std::vector<ExprPtr> eom_l(nₚ np, nₕ nh) const;
 
  private:
   size_t N;

--- a/SeQuant/domain/mbpt/models/cc.hpp
+++ b/SeQuant/domain/mbpt/models/cc.hpp
@@ -95,7 +95,8 @@ class CC {
 
   /// @brief derives the CC energy expression \f$ \langle 0|\bar{H}|0 \rangle
   /// \f$ at the requested commutator truncation, WITHOUT deriving the
-  /// projected amplitude equations (cheaper than `t().at(0)`).
+  /// projected amplitude equations (avoids deriving the full `t()` manifold
+  /// just to read `t().at(0)`).
   /// @param comm_rank optional H̄ commutator-truncation override, forwarded to
   ///   @ref hbar (defaults to the engine's `hbar_comm_rank`, else 4).
   /// @return the energy expression \f$ \langle 0|\bar{H}|0 \rangle \f$

--- a/SeQuant/domain/mbpt/models/cc.hpp
+++ b/SeQuant/domain/mbpt/models/cc.hpp
@@ -69,6 +69,10 @@ class CC {
   /// @return true if the ansatz is unitary
   [[nodiscard]] bool unitary() const;
 
+  /// @return the maximum of nested commutators in H̄; returns std::nullopt if
+  /// not set
+  [[nodiscard]] std::optional<size_t> hbar_comm_rank() const;
+
   /// @return true if singles amplitudes are excluded from \f$ \hat{T} \f$ and
   /// \f$ \hat{\Lambda} \f$
   [[nodiscard]] bool skip_singles() const;
@@ -88,6 +92,15 @@ class CC {
   /// value. If provided, will override all defaults.
   [[nodiscard]] ExprPtr hbar(
       std::optional<size_t> truncation_rank = std::nullopt) const;
+
+  /// @brief derives the CC energy expression \f$ \langle 0|\bar{H}|0 \rangle
+  /// \f$ at the requested commutator truncation, WITHOUT deriving the
+  /// projected amplitude equations (cheaper than `t().at(0)`).
+  /// @param comm_rank optional H̄ commutator-truncation override, forwarded to
+  ///   @ref hbar (defaults to the engine's `hbar_comm_rank`, else 4).
+  /// @return the energy expression \f$ \langle 0|\bar{H}|0 \rangle \f$
+  [[nodiscard]] ExprPtr energy(
+      std::optional<size_t> comm_rank = std::nullopt) const;
 
   /// @brief derives t amplitude equations, \f$ \langle P|\bar{H}|0 \rangle = 0
   /// \f$

--- a/tests/unit/test_eval_expr.cpp
+++ b/tests/unit/test_eval_expr.cpp
@@ -276,16 +276,14 @@ TEST_CASE("eval_expr", "[EvalExpr]") {
 
   SECTION("Adjoint op in a binarized term") {
     // Regression: a tensor leaf can carry the adjoint marker U+207A '⁺' in its
-    // label while NOT being internally flagged adjoint (is_adjoint_). The flag
-    // is only ever set by Tensor::adjoint(); a tensor built directly from a
-    // label string that already ends in '⁺' keeps the marker but leaves the
-    // flag default-false.
+    // label without having been produced by Tensor::adjoint() — e.g. when built
+    // directly from a label string that already ends in '⁺'. Adjointness is
+    // tracked solely by this label marker, so such a leaf is a valid adjoint.
     //
     // binarize() keys off the '⁺' label to surface the marker-bearing leaf as
     // EvalOp::Adjoint (see the "Adjoint op" section above), stripping the
-    // marker via Tensor::adjoint(). That path should tolerate a leaf whose flag
-    // was never set; instead it trips Tensor::adjoint()'s is_adjoint_
-    // consistency assertion.
+    // marker via Tensor::adjoint(). That path must tolerate a leaf that never
+    // went through Tensor::adjoint().
     auto expr = deserialize(L"1/2 g{i_1,i_2;a_1,a_2} t⁺{a_1;i_1} t{a_2;i_2}",
                             {.def_braket_symm = BraKetSymmetry::Nonsymm});
     REQUIRE(expr->is<Product>());

--- a/tests/unit/test_eval_expr.cpp
+++ b/tests/unit/test_eval_expr.cpp
@@ -274,6 +274,34 @@ TEST_CASE("eval_expr", "[EvalExpr]") {
     REQUIRE(g_tree.leaf());  // no Adjoint wrapper
   }
 
+  SECTION("Adjoint op in a binarized term") {
+    // Regression: a tensor leaf can carry the adjoint marker U+207A '⁺' in its
+    // label while NOT being internally flagged adjoint (is_adjoint_). The flag
+    // is only ever set by Tensor::adjoint(); a tensor built directly from a
+    // label string that already ends in '⁺' keeps the marker but leaves the
+    // flag default-false.
+    //
+    // binarize() keys off the '⁺' label to surface the marker-bearing leaf as
+    // EvalOp::Adjoint (see the "Adjoint op" section above), stripping the
+    // marker via Tensor::adjoint(). That path should tolerate a leaf whose flag
+    // was never set; instead it trips Tensor::adjoint()'s is_adjoint_
+    // consistency assertion.
+    auto expr = deserialize(L"1/2 g{i_1,i_2;a_1,a_2} t⁺{a_1;i_1} t{a_2;i_2}",
+                            {.def_braket_symm = BraKetSymmetry::Nonsymm});
+    REQUIRE(expr->is<Product>());
+
+    bool has_marker_leaf = false;
+    for (auto const& factor : expr->as<Product>().factors())
+      has_marker_leaf |=
+          factor->is<Tensor>() && factor->as<Tensor>().label() == L"t⁺";
+    REQUIRE(has_marker_leaf);
+
+    // binarize() must not throw on this term:
+    SEQUANT_PRAGMA_IGNORE_DEPRECATED_BEGIN
+    REQUIRE_NOTHROW(binarize(expr));
+    SEQUANT_PRAGMA_IGNORE_DEPRECATED_END
+  }
+
   SECTION("external hyperindices") {
     // t{i1,i2;a1,a3} T2{a2,a3;i1,i2}: i1,i2 appear in bra of t and ket of
     // T2 (multiply-appearing), a3 also multiply-appearing

--- a/tests/unit/test_mbpt_cc.cpp
+++ b/tests/unit/test_mbpt_cc.cpp
@@ -50,6 +50,23 @@ TEST_CASE("mbpt_cc", "[mbpt/cc][valgrind_skip]") {
     }  // SECTION("λ")
   }
 
+  SECTION("energy") {
+    // CC::energy() must equal the p==0 element of CC::t() for both ansätze.
+    const auto N = 2;
+    SECTION("TCC energy == t()[0]") {
+      REQUIRE_THAT(CC{N}.energy(), EquivalentTo(CC{N}.t().at(0)));
+    }
+    SECTION("UCC energy == t()[0]") {
+      const CC::Options opts{.ansatz = CC::Ansatz::U, .hbar_comm_rank = 2};
+      REQUIRE_THAT(CC(N, opts).energy(), EquivalentTo(CC(N, opts).t().at(0)));
+      // explicit rank override matches an engine built at that rank
+      REQUIRE_THAT(
+          CC(N, opts).energy(3),
+          EquivalentTo(
+              CC(N, {.ansatz = CC::Ansatz::U, .hbar_comm_rank = 3}).t().at(0)));
+    }
+  }  // SECTION("energy")
+
   SECTION("eom_cc"){SECTION("EOM-CCSD"){const auto N = 2;
   auto cc = CC{N};
   SECTION("EE-EOM-CCSD R") {


### PR DESCRIPTION
This PR is a collection of changes to facilitate UCC integration in MPQC4 (see https://github.com/ValeevGroup/mpqc4/pull/774).

### Changelist

**`mbpt::CC`*
- **const-qualify the derivation methods.** `t`, `λ`, `tʼ`, `λʼ`, `eom_r`, `eom_l` don't mutate engine state, so they're now `const` and callable through a `const CC&`.
- **Add `energy()` and `hbar_comm_rank()`.** `energy(comm_rank)` derives the CC energy expression without deriving the projected amplitude equations.

**`Tensor` adjointness**
- **Make adjointness label-driven; drop the `is_adjoint_` flag.**
- Tensor tracked adjointness redundantly the `⁺` label marker plus a separate `is_adjoint_` bool, synced only inside `Tensor::adjoint()`. 
- A tensor built from a label string already ending in `⁺` carried the marker but left `is_adjoint_` at `false`, tripping `SEQUANT_ASSERT` while binarizing closed-shell UCC residuals in MPQC. 
- The label marker is already the single source of truth, so `is_adjoint_` is removed and `adjoint()` toggles the marker alone. 

**Tests**
- `test_mbpt_cc`: `energy() == t().at(0)` for the T and U ansätze, including rank override.
- `test_eval_expr`: `binarize()` of a `g·t⁺·t` term carrying a `Nonsymm` `t⁺` leaf must not throw (regression for the case above).