### PR TITLE
Batched eval: preserve operand lobounds on slice (fixes ToT einsum SIGABRT); + memory-aware factorization/cache knobs

### DIFF
--- a/SeQuant/core/eval/backends/tiledarray/result.hpp
+++ b/SeQuant/core/eval/backends/tiledarray/result.hpp
@@ -682,9 +682,13 @@ class ResultTensorOfTensorTA final : public Result {
 /// \brief Restrict a TA::DistArray to a contiguous tile range of one mode.
 ///
 /// Keeps tiles `[tile_lo, tile_hi)` of mode \p mode and all tiles of every
-/// other mode; the result's `mode`-th TiledRange1 covers only those tiles
-/// (its element range is shifted to start at 0). Implemented with TA's
-/// `block()`, so block-sparse shape is preserved. Used to evaluate a tensor
+/// other mode; the result's `mode`-th TiledRange1 covers only those tiles.
+/// Every mode's original element lobound is preserved (via TA's
+/// `preserve_lobound` block), so a spectator index that carries a nonzero
+/// lobound (e.g. an active-occupied index with a frozen-core offset) keeps it
+/// and still matches the unsliced operand it is contracted against. Implemented
+/// with TA's `block()`, so block-sparse shape is preserved. Used to evaluate a
+/// tensor
 /// network in batches over a contracted index (see
 /// make_batched_custom_evaluator): slicing every leaf that carries the index
 /// to a tile range, evaluating, and summing reproduces the full contraction
@@ -714,17 +718,17 @@ template <typename... Args>
       // All-empty-inner ToT: tot_inner_rank() is 0, so there's no inner rank to
       // build the ToT annotation block() needs. The slice of zero is zero, so
       // build the sliced outer trange by hand (mode cut to [tile_lo,tile_hi),
-      // each dim rebased to 0, matching block()) and return a zero ToT over it.
-      // The result is dense even if ArrayT's policy is sparse -- harmless, the
+      // every dim's original element lobound preserved, matching the
+      // preserve_lobound block() below) and return a zero ToT over it. The
+      // result is dense even if ArrayT's policy is sparse -- harmless, the
       // array is identically zero.
       std::vector<TA::TiledRange1> tr1s;
       tr1s.reserve(rank);
       for (std::size_t d = 0; d < rank; ++d) {
         auto const& dim = arr.trange().dim(d);
-        std::size_t const base = dim.tile(lo[d]).first;
-        std::vector<std::size_t> bounds{0};
+        std::vector<std::size_t> bounds{dim.tile(lo[d]).first};
         for (std::size_t t = lo[d]; t < hi[d]; ++t)
-          bounds.push_back(dim.tile(t).second - base);
+          bounds.push_back(dim.tile(t).second);
         tr1s.emplace_back(bounds.begin(), bounds.end());
       }
       TA::DistArray<Args...> out{arr.world(),
@@ -740,7 +744,16 @@ template <typename... Args>
     annot = detail::ords_to_annot(iota(std::size_t{0}, rank));
   }
   TA::DistArray<Args...> out;
-  out(annot) = arr(annot).block(lo, hi);
+  // preserve_lobound: keep every mode's original element lobound instead of
+  // rebasing the block to 0. We only sub-range the batch mode; the other modes
+  // are taken in full, but plain block() would still rebase them to 0 -- giving
+  // a spectator index like the active-occupied i (whose DistArray carries an
+  // ncore lobound) a 0 lobound in this sliced operand, which then mismatches
+  // the unsliced operand's TiledRange1 for the same index when the two are
+  // combined by einsum's general product (Einsum::index::operator| asserts that
+  // a shared index has the same TiledRange1 in both operands). The batch mode
+  // keeps its real element offset too, consistently across all sliced operands.
+  out(annot) = arr(annot).block(lo, hi, TA::preserve_lobound);
   TA::DistArray<Args...>::wait_for_lazy_cleanup(arr.world());
   return out;
 }

--- a/SeQuant/core/eval/backends/tiledarray/result.hpp
+++ b/SeQuant/core/eval/backends/tiledarray/result.hpp
@@ -726,9 +726,10 @@ template <typename... Args>
       tr1s.reserve(rank);
       for (std::size_t d = 0; d < rank; ++d) {
         auto const& dim = arr.trange().dim(d);
-        std::vector<std::size_t> bounds{dim.tile(lo[d]).first};
+        std::vector<std::size_t> bounds{
+            static_cast<std::size_t>(dim.tile(lo[d]).first)};
         for (std::size_t t = lo[d]; t < hi[d]; ++t)
-          bounds.push_back(dim.tile(t).second);
+          bounds.push_back(static_cast<std::size_t>(dim.tile(t).second));
         tr1s.emplace_back(bounds.begin(), bounds.end());
       }
       TA::DistArray<Args...> out{arr.world(),

--- a/SeQuant/core/eval/cache_manager.hpp
+++ b/SeQuant/core/eval/cache_manager.hpp
@@ -396,19 +396,38 @@ auto cache_manager(meta::eval_node_range auto const& nodes,
 /// \p min_repeats times (the usual CSE rule), plus *all* P nodes regardless of
 /// repeat count (a P node is reused across evaluations even if used once each).
 ///
+/// Default footprint accessor for cache_manager: reports zero footprint for
+/// every node, so the footprint gate is inert (combined with max_footprint==0).
+struct zero_footprint {
+  double operator()(auto const&) const noexcept { return 0.; }
+};
+
 /// \param nodes the evaluation forest.
 /// \param is_volatile `bool(TreeNode const&)`: true if the node is
 ///        intrinsically volatile. Only its value on leaves matters in practice
 ///        (volatility propagates up), but it is consulted on every node.
 /// \param min_repeats minimum NP repeats to cache (default 2).
+/// \param footprint_of `double(TreeNode const&)`: the materialized storage
+///        footprint of a node's result (e.g. its element count or byte size).
+///        Consulted only when \p max_footprint > 0.
+/// \param max_footprint footprint gate: any node whose \p footprint_of exceeds
+///        this is NOT cached (neither as an NP repeat nor as a P frontier
+///        node), so it is recomputed by each consumer instead of being
+///        materialized whole and held. This bounds the peak/sustained footprint
+///        of huge intermediates that carry a free large-space index (e.g. a
+///        half-transformed DF integral with a free projected-AO index), at the
+///        cost of recomputation. 0 (default) disables the gate.
 /// \see CacheManager, cache_manager
-template <bool force_hash_collisions = false>
+template <bool force_hash_collisions = false,
+          typename FootprintOf = zero_footprint>
 auto cache_manager(meta::eval_node_range auto const& nodes, auto&& is_volatile,
-                   size_t min_repeats = 2)
+                   size_t min_repeats = 2, FootprintOf footprint_of = {},
+                   double max_footprint = 0.)
   requires requires(
       std::ranges::range_value_t<std::remove_cvref_t<decltype(nodes)>> const&
           n) {
     { is_volatile(n) } -> std::convertible_to<bool>;
+    { footprint_of(n) } -> std::convertible_to<double>;
   }
 {
   using TreeNode =
@@ -446,9 +465,18 @@ auto cache_manager(meta::eval_node_range auto const& nodes, auto&& is_volatile,
   for (auto&& tree : nodes) visit(visit, tree);
 
   // Cache NP repeats + every P node; persistence = membership in `persistent`.
+  // Footprint gate: a node whose result is larger than max_footprint is never
+  // cached (so it is recomputed by each consumer rather than materialized whole
+  // and held), bounding the footprint of huge free-large-index intermediates.
   std::unordered_map<TreeNode, size_t, Hasher, Comp> filtered;
-  for (auto&& [n, c] : counts)
-    if (c >= min_repeats || persistent.contains(n)) filtered.emplace(n, c);
+  for (auto&& [n, c] : counts) {
+    if (!(c >= min_repeats || persistent.contains(n))) continue;
+    if (max_footprint > 0. && footprint_of(n) > max_footprint) {
+      persistent.erase(n);  // keep is_persistent consistent with what is cached
+      continue;
+    }
+    filtered.emplace(n, c);
+  }
 
   auto is_persistent = [persistent = std::move(persistent)](TreeNode const& n) {
     return persistent.contains(n);

--- a/SeQuant/core/optimize/optimize.cpp
+++ b/SeQuant/core/optimize/optimize.cpp
@@ -37,11 +37,11 @@ ExprPtr opt_pure_product(Product const& prod, OptimizeOptions const& opts) {
   if (opts.opt_for == OptFor::Flops)
     return opt::single_term_opt<OptFor::Flops>(
         prod, opts.idx_to_extent, subnet_cse, opts.is_volatile_leaf,
-        opts.n_replay);
+        opts.n_replay, opts.footprint_weight);
   SEQUANT_ASSERT(opts.opt_for == OptFor::Memsize);
   return opt::single_term_opt<OptFor::Memsize>(
       prod, opts.idx_to_extent, subnet_cse, opts.is_volatile_leaf,
-      opts.n_replay);
+      opts.n_replay, opts.footprint_weight);
 }
 
 /// Deliberately non-identifier label prefix used to stand in for non-Tensor,

--- a/SeQuant/core/optimize/options.hpp
+++ b/SeQuant/core/optimize/options.hpp
@@ -62,6 +62,30 @@ struct OptimizeOptions {
   /// Default 1 (no change). Only consulted when is_volatile_leaf is non-empty
   /// and opt_for == Flops.
   unsigned n_replay = 1;
+
+  /// Per-intermediate memory-footprint penalty added to the single-term
+  /// optimization cost. For every binary contraction, the storage footprint of
+  /// its RESULT intermediate (the product of the extents of the result's
+  /// indices, i.e. its element count) is multiplied by this weight and added to
+  /// the contraction cost. Unlike the FLOPs cost, this penalty is NOT scaled by
+  /// \ref n_replay (peak footprint is a one-time materialization cost, not a
+  /// per-replay one). 0 (default) disables the penalty, recovering the pure
+  /// FLOPs/Memsize behavior.
+  ///
+  /// Rationale: the FLOPs cost is blind to the storage size of the
+  /// intermediates it materializes, so it will happily pick an order (and thus
+  /// expose, as a shareable subtree, a common subexpression) that carries a
+  /// free large-space index — e.g. a half-transformed DF integral that still
+  /// carries a free projected-AO (PAO) index — because forming it once is
+  /// FLOPs-cheap. Such an intermediate can be enormous. A nonzero
+  /// footprint_weight biases single-term optimization toward orders that defer
+  /// or avoid materializing such large intermediates (e.g. transforming both
+  /// large legs before exposing a shared subtree), trading a controlled amount
+  /// of extra FLOPs for a lower peak footprint. Only consulted when
+  /// opt_for == Flops; the units are FLOPs-per-element, so a useful magnitude
+  /// is on the order of the contracted-index extent that the offending
+  /// intermediate would otherwise leave free.
+  double footprint_weight = 0.0;
 };
 
 }  // namespace sequant

--- a/SeQuant/core/optimize/single_term.hpp
+++ b/SeQuant/core/optimize/single_term.hpp
@@ -94,6 +94,27 @@ auto memsize_counter(has_index_extent auto&& ixex) {
   };
 }
 
+/// \brief Cost function returning the storage footprint (element count) of a
+/// single tensor: the product of the extents of its indices.
+///
+/// Used to apply a per-intermediate memory-footprint penalty in single-term
+/// optimization (see OptimizeOptions::footprint_weight). A scalar (no indices)
+/// contributes zero.
+///
+/// \param ixex Invocable mapping an Index to its extent.
+/// \return A callable <tt>(result) -> double</tt> yielding the element count of
+/// the result tensor.
+auto footprint_counter(has_index_extent auto&& ixex) {
+  return [ixex = std::forward<decltype(ixex)>(ixex)](
+             meta::range_of<Index> auto const& result) -> double {
+    using ranges::views::concat;
+    auto tot_idxs = tot_indices(result);
+    double mem = ranges::accumulate(concat(tot_idxs.outer, tot_idxs.inner), 1.,
+                                    std::multiplies{}, ixex);
+    return mem == 1. ? 0. : mem;
+  };
+}
+
 ///
 /// Represents a result of optimization on a range of expressions
 /// for a binary evaluation
@@ -248,14 +269,18 @@ inline SubnetMetadata build_subnet_metadata(
 ///  intermediate results, which is particularly effective for
 ///  expressions with repeating tensor patterns.
 ///
-template <typename CostFn>
-  requires requires(CostFn&& fn, decltype(OptRes::indices) const& ixs) {
+template <typename CostFn, typename FootprintFn>
+  requires requires(CostFn&& fn, FootprintFn&& ffn,
+                    decltype(OptRes::indices) const& ixs) {
     { fn(ixs, ixs, ixs) } -> std::floating_point;
+    { ffn(ixs) } -> std::floating_point;
   }
 EvalSequence single_term_opt_impl(TensorNetwork const& network,
                                   meta::range_of<Index> auto const& tidxs,
                                   CostFn&& cost_fn, bool subnet_cse,
-                                  size_t volatile_mask, double n_replay) {
+                                  size_t volatile_mask, double n_replay,
+                                  FootprintFn&& footprint_fn,
+                                  double footprint_weight) {
   using ranges::views::concat;
   auto const nt = network.tensors().size();
   if (nt == 1) return EvalSequence{0};
@@ -288,6 +313,14 @@ EvalSequence single_term_opt_impl(TensorNetwork const& network,
       // i.e. one subset is the empty set and the other full
       if (lp == 0 || rp == 0) continue;
 
+      // Per-intermediate memory-footprint penalty (storage of THIS result),
+      // added once and NOT scaled by the replay weight w (peak footprint is a
+      // one-time materialization cost). Zero when footprint_weight == 0.
+      double const fp =
+          footprint_weight != 0.0
+              ? footprint_weight * footprint_fn(results[n].indices)
+              : 0.0;
+
       double new_cost = 0;
       container::vector<size_t> combined_subnets;
       if (subnet_cse) {
@@ -298,7 +331,8 @@ EvalSequence single_term_opt_impl(TensorNetwork const& network,
                        std::back_inserter(combined_subnets));
         new_cost = w * cost_fn(results[lp].indices,  //
                                results[rp].indices,  //
-                               results[n].indices);
+                               results[n].indices)   //
+                   + fp;
         for (auto id : combined_subnets) {
           new_cost += unique_meta_costs[id];
         }
@@ -306,7 +340,7 @@ EvalSequence single_term_opt_impl(TensorNetwork const& network,
         new_cost = w * cost_fn(results[lp].indices,  //
                                results[rp].indices,  //
                                results[n].indices)   //
-                   + results[lp].ops + results[rp].ops;
+                   + fp + results[lp].ops + results[rp].ops;
       }
 
       if (new_cost <= curr_cost) {
@@ -326,7 +360,10 @@ EvalSequence single_term_opt_impl(TensorNetwork const& network,
       // cost is intentional and benign.
       unique_meta_costs[mid] =
           w * cost_fn(results[results[n].lp].indices,
-                      results[results[n].rp].indices, results[n].indices);
+                      results[results[n].rp].indices, results[n].indices) +
+          (footprint_weight != 0.0
+               ? footprint_weight * footprint_fn(results[n].indices)
+               : 0.0);
       auto it = std::lower_bound(results[n].subnets.begin(),
                                  results[n].subnets.end(), mid);
       if (it == results[n].subnets.end() || *it != mid) {
@@ -369,8 +406,12 @@ template <OptFor Metric, has_index_extent IdxToSz>
 EvalSequence single_term_opt(
     TensorNetwork const& network, IdxToSz&& idxsz, bool subnet_cse,
     std::function<bool(Tensor const&)> const& is_volatile_leaf = {},
-    unsigned n_replay = 1) {
+    unsigned n_replay = 1, double footprint_weight = 0.0) {
   decltype(OptRes::indices) tidxs{};
+
+  // The per-intermediate footprint penalty needs idxsz too, so build a
+  // footprint counter alongside the cost function (idxsz is copied into each).
+  auto footprint_fn = footprint_counter(idxsz);
 
   // Volatility weighting is a Flops-only notion (persistent intermediates cost
   // MORE memory, not less, so it is wrong-signed for Memsize). Build the
@@ -388,15 +429,17 @@ EvalSequence single_term_opt(
       }
       nr = static_cast<double>(n_replay);
     }
-    auto cost_fn = flops_counter(std::forward<IdxToSz>(idxsz));
+    auto cost_fn = flops_counter(idxsz);
     return single_term_opt_impl(network, tidxs, cost_fn, subnet_cse,
-                                volatile_mask, nr);
+                                volatile_mask, nr, footprint_fn,
+                                footprint_weight);
   } else {
     static_assert(Metric == OptFor::Memsize,
                   "Only Flops and Memsize OptFor supported.");
-    auto cost_fn = memsize_counter(std::forward<IdxToSz>(idxsz));
+    auto cost_fn = memsize_counter(idxsz);
     return single_term_opt_impl(network, tidxs, cost_fn, subnet_cse,
-                                volatile_mask, nr);
+                                volatile_mask, nr, footprint_fn,
+                                footprint_weight);
   }
 }
 
@@ -415,7 +458,7 @@ template <OptFor Metric = OptFor::Flops, has_index_extent IdxToSz>
 ExprPtr single_term_opt(
     Product const& prod, IdxToSz&& idxsz, bool subnet_cse = false,
     std::function<bool(Tensor const&)> const& is_volatile_leaf = {},
-    unsigned n_replay = 1) {
+    unsigned n_replay = 1, double footprint_weight = 0.0) {
   using ranges::views::filter;
   using ranges::views::reverse;
 
@@ -426,7 +469,7 @@ ExprPtr single_term_opt(
       prod | filter(&ExprPtr::template is<Tensor>) | ranges::to_vector;
   auto seq = detail::single_term_opt<Metric>(
       TensorNetwork{tensors}, std::forward<IdxToSz>(idxsz), subnet_cse,
-      is_volatile_leaf, n_replay);
+      is_volatile_leaf, n_replay, footprint_weight);
   auto result = container::svector<ExprPtr>{};
   for (auto i : seq)
     if (i == -1) {

--- a/tests/unit/test_cache_manager.cpp
+++ b/tests/unit/test_cache_manager.cpp
@@ -289,3 +289,38 @@ TEST_CASE("cache_manager_volatility_frontier", "[cache_manager]") {
   check(node, /*parent_volatile=*/false);  // root has no (volatile) consumer
   REQUIRE(saw_persistent);  // the NV product feeding the volatile root is P
 }
+
+TEST_CASE("cache_manager_footprint_gate", "[cache_manager]") {
+  // R = f * g * t : the NV product (f*g) feeds the volatile root, so without a
+  // footprint gate it is cached as a persistent (cross-iteration) entry.
+  auto const node = make_node(L"R{a1;i1} = f{a1;a2} * g{a2;a3} * t{a3;i1}");
+  auto is_volatile = [](node_type const& n) {
+    return n.leaf() && n->is_tensor() && n->as_tensor().label() == L"t";
+  };
+  // footprint proxy: number of result indices (the NV frontier I{a1;a3} has 2).
+  auto footprint_of = [](node_type const& n) -> double {
+    return n.leaf() ? 0. : static_cast<double>(n->canon_indices().size());
+  };
+
+  std::function<int(node_type const&, manager_type const&)> count_persistent =
+      [&](node_type const& n, manager_type const& m) -> int {
+    if (n.leaf()) return 0;
+    return (m.persistent(n) ? 1 : 0) + count_persistent(n.left(), m) +
+           count_persistent(n.right(), m);
+  };
+
+  // no gate (max_footprint == 0): the NV/V frontier is cached and persistent.
+  auto man0 = sequant::cache_manager(std::array{node}, is_volatile);
+  REQUIRE(count_persistent(node, man0) >= 1);
+
+  // a threshold above the frontier footprint leaves caching unchanged.
+  auto man_hi = sequant::cache_manager(std::array{node}, is_volatile,
+                                       /*min_repeats=*/2, footprint_of, 10.);
+  REQUIRE(count_persistent(node, man_hi) == count_persistent(node, man0));
+
+  // a threshold below the 2-index frontier footprint evicts it: it is not
+  // cached at all (no persistent entry; absent from the cache map).
+  auto man_lo = sequant::cache_manager(std::array{node}, is_volatile,
+                                       /*min_repeats=*/2, footprint_of, 1.5);
+  REQUIRE(count_persistent(node, man_lo) == 0);
+}

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -271,6 +271,48 @@ TEST_CASE("optimize", "[optimize]") {
       REQUIRE(res_off == res1);
     }
 
+    SECTION("Single term optimization: footprint_weight") {
+      using namespace sequant;
+
+      // Network A{i1;x1} * B{x1;i2} * C{i2;a1}: contract x1 (between A,B) and
+      // i2 (between B,C); free indices {i1, a1}. With the aux index x LARGE and
+      // the virtual index a SMALL, the two viable orders trade FLOPs against
+      // the footprint of the single intermediate they materialize:
+      //
+      //   (A*B)*C : I{i1;i2}  (occ^2 = 100)         FLOPs i*x*i + i*i*a =
+      //   100400 A*(B*C) : I{x1;a1}  (aux*virt = 4000)     FLOPs x*i*a + i*x*a
+      //   =  80000
+      //
+      // Pure FLOPs picks A*(B*C): cheaper, but materializes the big
+      // aux-carrying intermediate I{x1;a1}. A nonzero footprint_weight
+      // penalizes that 4000-element intermediate (vs the 100-element one) and
+      // flips the choice to (A*B)*C. Flip threshold here is footprint_weight >
+      // ~5.2.
+      auto uocc = reg->retrieve_ptr(L"a");
+      auto aux = reg->retrieve_ptr(L"x");
+      auto const uocc_sz = uocc->approximate_size();
+      auto const aux_sz = aux->approximate_size();
+      uocc->approximate_size(4);    // virtual: deliberately SMALL
+      aux->approximate_size(1000);  // aux: deliberately LARGE
+
+      auto const prod =
+          deserialize(L"A{i1;x1} B{x1;i2} C{i2;a1}")->as<Product>();
+
+      // footprint_weight == 0 reproduces the pure-FLOPs choice ...
+      auto res0 = optimize(ex<Product>(prod), OptimizeOptions{});
+      auto res0_explicit =
+          optimize(ex<Product>(prod), OptimizeOptions{.footprint_weight = 0.0});
+      REQUIRE(res0 == res0_explicit);  // weight 0 is a no-op
+
+      // ... a large footprint_weight changes the chosen factorization.
+      auto resF = optimize(ex<Product>(prod),
+                           OptimizeOptions{.footprint_weight = 100.});
+      REQUIRE(res0 != resF);
+
+      uocc->approximate_size(uocc_sz);
+      aux->approximate_size(aux_sz);
+    }
+
     SECTION("Ensure single-value sums/products are not discarded") {
       auto sum = ex<Sum>();
       sum->as<Sum>().append(


### PR DESCRIPTION
Three commits supporting memory-bounded batched evaluation of CSV-CCk (PNO-CCSD) residuals. The last is a **crash fix**; the first two are opt-in, default-off knobs from a peak-memory investigation.

### 1. `eval/ta`: preserve lobounds when slicing an operand (bug fix — the important one)
The batched evaluator slices each leaf carrying the batch (DF/aux) index over a tile sub-range and replays the subtree. `slice_array_over_mode` did this with a single `block()` over all modes (sub-range for the batch mode, full range for the rest), but plain `block()` **rebases every mode's element lobound to 0**. A spectator index taken in full but carrying a nonzero lobound — e.g. an active-occupied index whose DistArray carries an `ncore` frozen-core offset — then gets a 0 lobound in the sliced operand, while the operand it is contracted against (not sliced) keeps its original lobound. Einsum's general product for tensor-of-tensors asserts a shared index has the same `TiledRange1` in both operands (`einsum/index.h:295`, `a[k]==b[k]`) → **SIGABRT**.

Fix: use `TA::preserve_lobound` on the `block()` (and the matching hand-built trange in the all-empty-inner branch). Manifested in water-cluster PNO-CCSD with frozen cores under aggressive `n_replay` factorization that forms a `g(i,i,Κ) * I(i,μ̃,Κ;a)` batched ToT contraction; frozen-core-free systems (He clusters, `ncore=0`) were unaffected, which is why it slipped through.

### 2. `cache_manager`: footprint gate (default off)
Optional `max_footprint` so a huge intermediate carrying a free large-space (PAO) index is not cached at all (recomputed per consumer instead of held whole). `max_footprint==0` (default) preserves current behavior; all existing callers unchanged.

### 3. `optimize`: per-intermediate footprint penalty (default off)
`OptimizeOptions::footprint_weight` adds a result-footprint term to the FLOPs single-term-optimization cost (not scaled by `n_replay`), biasing factorization away from materializing large free-large-index intermediates. `0` (default) is a no-op. Unit-tested.