### PR TITLE
Tensor::adjoint(): keep net ranks consistent via _swap_bra_ket()

### DIFF
--- a/SeQuant/core/expressions/tensor.cpp
+++ b/SeQuant/core/expressions/tensor.cpp
@@ -23,7 +23,11 @@ void Tensor::assert_nonreserved_label(
 }
 
 void Tensor::adjoint() {
-  std::swap(bra_.value(), ket_.value());
+  // _swap_bra_ket() swaps bra<->ket *and* the derived net ranks, then
+  // re-canonicalizes slots (needed when empty slots are present) and resets the
+  // hash; a bare std::swap of the index containers would leave the net ranks
+  // and slot order inconsistent
+  _swap_bra_ket();
 
   // adjointness is tracked solely by the label marker, for Nonsymm braket
   if (braket_symmetry() == BraKetSymmetry::Nonsymm) {


### PR DESCRIPTION
Follow-up to #551 addressing a [Copilot review comment](https://github.com/ValeevGroup/SeQuant/pull/551#discussion_r3410760487).

### Problem
`Tensor::adjoint()` swapped the `bra_`/`ket_` index containers with a bare `std::swap` but left the derived net ranks (`bra_net_rank_`/`ket_net_rank_`) unswapped and skipped slot re-canonicalization. For tensors with empty index slots (where `*_net_rank() != *_rank()`) this left the object internally inconsistent, which can mislead downstream logic that reads `bra_net_rank()`/`ket_net_rank()`.

### Fix
Delegate the bra↔ket swap to the existing `_swap_bra_ket()` primitive, which swaps the containers, swaps the net ranks, re-validates, and re-canonicalizes slots. Equivalent to the old code in the common no-empty-slot case; correct when empty slots are present. The label-marker adjointness toggle introduced in #551 is unchanged.

### Testing
Full unit test suite passes (7058 assertions in 70 test cases), including the #551 regressions (`test_eval_expr` `g·t⁺·t` binarize, `test_mbpt_cc`).