### PR TITLE
optimize: rename OptimizeOptions terminology (objective_function / volatile_weight / CSE)

### DIFF
--- a/SeQuant/core/optimize/optimize.cpp
+++ b/SeQuant/core/optimize/optimize.cpp
@@ -33,15 +33,15 @@ index_to_extent_t default_idx_to_size() {
 
 /// Optimize a Product that contains only Tensor and scalar factors.
 ExprPtr opt_pure_product(Product const& prod, OptimizeOptions const& opts) {
-  bool const subnet_cse = opts.subnet_cse == SubnetCSE::Enable;
-  if (opts.opt_for == OptFor::Flops)
-    return opt::single_term_opt<OptFor::Flops>(
+  bool const subnet_cse = opts.CSE.subnet;
+  if (opts.objective_function == ObjectiveFunction::DenseFLOPs)
+    return opt::single_term_opt<ObjectiveFunction::DenseFLOPs>(
         prod, opts.idx_to_extent, subnet_cse, opts.is_volatile_leaf,
-        opts.n_replay, opts.footprint_weight);
-  SEQUANT_ASSERT(opts.opt_for == OptFor::Memsize);
-  return opt::single_term_opt<OptFor::Memsize>(
+        opts.volatile_weight, opts.footprint_weight);
+  SEQUANT_ASSERT(opts.objective_function == ObjectiveFunction::DenseSize);
+  return opt::single_term_opt<ObjectiveFunction::DenseSize>(
       prod, opts.idx_to_extent, subnet_cse, opts.is_volatile_leaf,
-      opts.n_replay, opts.footprint_weight);
+      opts.volatile_weight, opts.footprint_weight);
 }
 
 /// Deliberately non-identifier label prefix used to stand in for non-Tensor,

--- a/SeQuant/core/optimize/options.hpp
+++ b/SeQuant/core/optimize/options.hpp
@@ -46,7 +46,7 @@ struct OptimizeOptions {
 
   /// Common-subexpression-elimination options. All disabled by default;
   /// enabling can reduce op counts at the cost of additional optimization time.
-  CSEOptions CSE;
+  CSEOptions CSE = {};
 
   /// Caller-supplied Index to extent provider. If empty, defaults to
   /// \c IndexSpace::approximate_size().

--- a/SeQuant/core/optimize/options.hpp
+++ b/SeQuant/core/optimize/options.hpp
@@ -65,7 +65,7 @@ struct OptimizeOptions {
   /// on every replay of the network), while persistent (volatile-independent)
   /// contractions are counted once. Conceptually the expected number of
   /// replays. Default 1.0 (no change). Only consulted when is_volatile_leaf is
-  /// non-empty and objective_function == DenseFLOPs.
+  /// non-empty and objective_function == ObjectiveFunction::DenseFLOPs.
   double volatile_weight = 1.0;
 
   /// Per-intermediate memory-footprint penalty added to the single-term
@@ -87,7 +87,8 @@ struct OptimizeOptions {
   /// or avoid materializing such large intermediates (e.g. transforming both
   /// large legs before exposing a shared subtree), trading a controlled amount
   /// of extra FLOPs for a lower peak footprint. Only consulted when
-  /// objective_function == DenseFLOPs; the units are FLOPs-per-element, so a
+  /// objective_function == ObjectiveFunction::DenseFLOPs; the units are
+  /// FLOPs-per-element, so a
   /// useful magnitude is on the order of the contracted-index extent that the
   /// offending intermediate would otherwise leave free.
   double footprint_weight = 0.0;

--- a/SeQuant/core/optimize/options.hpp
+++ b/SeQuant/core/optimize/options.hpp
@@ -9,17 +9,24 @@ namespace sequant {
 class Index;
 class Tensor;
 
-/// Cost metric to optimize for in single-term and top-level optimize routines.
-enum class OptFor { Flops, Memsize };
+/// Objective function to minimize in single-term and top-level optimize
+/// routines. The `Dense*` models are the current cost estimates, which assume
+/// dense tensors; "Size" (not "Memsize") because operands need not live in
+/// memory (disk, distributed, ...). Leaves room for `Sparse*` models later.
+enum class ObjectiveFunction { DenseFLOPs, DenseSize };
 
 /// Whether to reorder summands so terms with shared intermediates appear
 /// closer to each other.
 enum class ReorderSum { Reorder, NoReorder };
 
-/// Whether single-term optimization should recognize equivalent subnetworks
-/// while searching for an evaluation order, trading extra search time for
-/// potentially lower op counts.
-enum class SubnetCSE { Enable, Disable };
+/// Common-subexpression-elimination (CSE) options for single-term
+/// optimization. `subnet` recognizes equivalent subnetworks while searching for
+/// an evaluation order, trading extra search time for potentially lower op
+/// counts. (Room to grow, e.g. a maximum subnet size to consider.) `CSE` is an
+/// initialism.
+struct CSEOptions {
+  bool subnet = false;
+};
 
 /// A type-erased provider mapping an Index to its extent. Used by the public
 /// optimize() API. Callers reaching for the templated opt::single_term_opt
@@ -31,17 +38,16 @@ using index_to_extent_t = std::function<std::size_t(Index const&)>;
 
 /// Options that control behavior of \ref sequant::optimize.
 struct OptimizeOptions {
-  /// Cost metric to minimize.
-  OptFor opt_for = OptFor::Flops;
+  /// Objective function to minimize.
+  ObjectiveFunction objective_function = ObjectiveFunction::DenseFLOPs;
 
   /// Whether to reorder summands so terms with shared intermediates appear
   /// closer to each other.
   ReorderSum reorder = ReorderSum::Reorder;
 
-  /// Whether single-term optimization should perform subnetwork
-  /// common-subexpression recognition. Disabled by default; enabling can
-  /// reduce op counts at the cost of additional optimization time.
-  SubnetCSE subnet_cse = SubnetCSE::Disable;
+  /// Common-subexpression-elimination options. All disabled by default;
+  /// enabling can reduce op counts at the cost of additional optimization time.
+  CSEOptions CSE;
 
   /// Caller-supplied Index to extent provider. If empty, defaults to
   /// \c IndexSpace::approximate_size().
@@ -50,27 +56,27 @@ struct OptimizeOptions {
   /// Marks a LEAF tensor as volatile: its value changes between replays of the
   /// network, so any contraction depending on it is re-evaluated on every
   /// replay. Empty (default) ⇒ no tensor is volatile ⇒ cost weighting is
-  /// disabled and n_replay is ignored (behavior identical to before this
+  /// disabled and volatile_weight is ignored (behavior identical to before this
   /// feature). CC callers pass label==volatile_label, the same classification
   /// the runtime eval cache uses, so the optimizer's cost model and the cache
   /// agree.
   std::function<bool(Tensor const&)> is_volatile_leaf = {};
 
-  /// Expected number of times the network is replayed with the volatile inputs
-  /// mutated; the cost of each volatile contraction is multiplied by this,
-  /// while persistent (volatile-independent) contractions are counted once.
-  /// Default 1 (no change). Only consulted when is_volatile_leaf is non-empty
-  /// and opt_for == Flops.
-  unsigned n_replay = 1;
+  /// Real-valued weight on the cost of each volatile contraction (re-evaluated
+  /// on every replay of the network), while persistent (volatile-independent)
+  /// contractions are counted once. Conceptually the expected number of
+  /// replays. Default 1.0 (no change). Only consulted when is_volatile_leaf is
+  /// non-empty and objective_function == DenseFLOPs.
+  double volatile_weight = 1.0;
 
   /// Per-intermediate memory-footprint penalty added to the single-term
   /// optimization cost. For every binary contraction, the storage footprint of
   /// its RESULT intermediate (the product of the extents of the result's
   /// indices, i.e. its element count) is multiplied by this weight and added to
   /// the contraction cost. Unlike the FLOPs cost, this penalty is NOT scaled by
-  /// \ref n_replay (peak footprint is a one-time materialization cost, not a
-  /// per-replay one). 0 (default) disables the penalty, recovering the pure
-  /// FLOPs/Memsize behavior.
+  /// \ref volatile_weight (peak footprint is a one-time materialization cost,
+  /// not a per-replay one). 0 (default) disables the penalty, recovering the
+  /// pure FLOPs/Size behavior.
   ///
   /// Rationale: the FLOPs cost is blind to the storage size of the
   /// intermediates it materializes, so it will happily pick an order (and thus
@@ -82,9 +88,9 @@ struct OptimizeOptions {
   /// or avoid materializing such large intermediates (e.g. transforming both
   /// large legs before exposing a shared subtree), trading a controlled amount
   /// of extra FLOPs for a lower peak footprint. Only consulted when
-  /// opt_for == Flops; the units are FLOPs-per-element, so a useful magnitude
-  /// is on the order of the contracted-index extent that the offending
-  /// intermediate would otherwise leave free.
+  /// objective_function == DenseFLOPs; the units are FLOPs-per-element, so a
+  /// useful magnitude is on the order of the contracted-index extent that the
+  /// offending intermediate would otherwise leave free.
   double footprint_weight = 0.0;
 };
 

--- a/SeQuant/core/optimize/options.hpp
+++ b/SeQuant/core/optimize/options.hpp
@@ -10,9 +10,9 @@ class Index;
 class Tensor;
 
 /// Objective function to minimize in single-term and top-level optimize
-/// routines. The `Dense*` models are the current cost estimates, which assume
-/// dense tensors; "Size" (not "Memsize") because operands need not live in
-/// memory (disk, distributed, ...). Leaves room for `Sparse*` models later.
+/// routines. The `Dense*` models assume dense tensors: `DenseFLOPs` counts
+/// floating-point operations, `DenseSize` counts result-tensor storage elements
+/// (summed over intermediates). Leaves room for `Sparse*` models later.
 enum class ObjectiveFunction { DenseFLOPs, DenseSize };
 
 /// Whether to reorder summands so terms with shared intermediates appear
@@ -22,8 +22,7 @@ enum class ReorderSum { Reorder, NoReorder };
 /// Common-subexpression-elimination (CSE) options for single-term
 /// optimization. `subnet` recognizes equivalent subnetworks while searching for
 /// an evaluation order, trading extra search time for potentially lower op
-/// counts. (Room to grow, e.g. a maximum subnet size to consider.) `CSE` is an
-/// initialism.
+/// counts. (Room to grow, e.g. a maximum subnet size to consider.)
 struct CSEOptions {
   bool subnet = false;
 };

--- a/SeQuant/core/optimize/single_term.hpp
+++ b/SeQuant/core/optimize/single_term.hpp
@@ -384,20 +384,26 @@ EvalSequence single_term_opt_impl(TensorNetwork const& network,
 
 ///
 /// \tparam Metric Objective function (ObjectiveFunction::DenseFLOPs or
-/// ::DenseSize). \tparam IdxToSz \param network A TensorNetwork object. \param
-/// idxsz An invocable on Index, that maps Index to its dimension. \param
-/// subnet_cse Whether to recognize equivalent subnetworks to try minimizing the
-/// ops counts. \param is_volatile_leaf Predicate marking a leaf tensor as
-/// volatile (its value changes on every replay); empty disables weighting. The
-/// predicate MUST be invariant under slot/index canonicalization — key on
-/// tensor label or structure, NOT on anonymous index identity — so that two
-/// subnetworks deemed equivalent by the subnet-CSE canonicalization also agree
-/// on volatility (the CSE path stores one cost per canonical subnet). Flops
-/// metric only. \param volatile_weight Multiplier applied to the cost of each
-/// volatile-result contraction (volatile contractions are re-evaluated on every
-/// replay); persistent contractions are counted once. 1 (default) disables
-/// weighting. \return Optimal evaluation sequence under the chosen cost metric.
-/// If there
+///         ObjectiveFunction::DenseSize).
+/// \tparam IdxToSz Invocable type mapping an Index to its extent.
+/// \param network A TensorNetwork object.
+/// \param idxsz An invocable on Index, that maps Index to its dimension.
+/// \param subnet_cse Whether to recognize equivalent subnetworks to try
+///        minimizing the ops counts.
+/// \param is_volatile_leaf Predicate marking a leaf tensor as volatile (its
+///        value changes on every replay); empty disables weighting. The
+///        predicate MUST be invariant under slot/index canonicalization — key
+///        on tensor label or structure, NOT on anonymous index identity — so
+///        that two subnetworks deemed equivalent by the subnet-CSE
+///        canonicalization also agree on volatility (the CSE path stores one
+///        cost per canonical subnet). ObjectiveFunction::DenseFLOPs only.
+/// \param volatile_weight Multiplier applied to the cost of each
+///        volatile-result contraction (volatile contractions are re-evaluated
+///        on every replay); persistent contractions are counted once. 1
+///        (default) disables weighting.
+/// \param footprint_weight Per-intermediate storage-footprint penalty added to
+///        the cost (ObjectiveFunction::DenseFLOPs only); 0 (default) disables.
+/// \return Optimal evaluation sequence under the chosen cost metric. If there
 ///         are equivalent optimal sequences then the result is the one that
 ///         keeps the order of tensors in the network as original as possible.
 ///
@@ -412,8 +418,8 @@ EvalSequence single_term_opt(
   // footprint counter alongside the cost function (idxsz is copied into each).
   auto footprint_fn = footprint_counter(idxsz);
 
-  // Volatility weighting is a Flops-only notion (persistent intermediates cost
-  // MORE memory, not less, so it is wrong-signed for Memsize). Build the
+  // Volatility weighting is a DenseFLOPs-only notion (persistent intermediates
+  // cost MORE memory, not less, so it is wrong-signed for DenseSize). Build the
   // volatile-leaf bitmask in network.tensors() bit order so it aligns with the
   // DP's subset bits.
   size_t volatile_mask = 0;

--- a/SeQuant/core/optimize/single_term.hpp
+++ b/SeQuant/core/optimize/single_term.hpp
@@ -278,7 +278,7 @@ template <typename CostFn, typename FootprintFn>
 EvalSequence single_term_opt_impl(TensorNetwork const& network,
                                   meta::range_of<Index> auto const& tidxs,
                                   CostFn&& cost_fn, bool subnet_cse,
-                                  size_t volatile_mask, double n_replay,
+                                  size_t volatile_mask, double volatile_weight,
                                   FootprintFn&& footprint_fn,
                                   double footprint_weight) {
   using ranges::views::concat;
@@ -305,8 +305,8 @@ EvalSequence single_term_opt_impl(TensorNetwork const& network,
     if (std::popcount(n) < 2) continue;
     // A subset is volatile iff it contains any volatile leaf; the contraction
     // that forms it is then re-executed on every replay. volatile_mask == 0
-    // (no predicate / Memsize / n_replay<=1) makes w == 1 everywhere.
-    double const w = (volatile_mask & n) ? n_replay : 1.0;
+    // (no predicate / DenseSize / volatile_weight<=1) makes w == 1 everywhere.
+    double const w = (volatile_mask & n) ? volatile_weight : 1.0;
     for (auto& curr_cost = results[n].ops;
          auto&& [lp, rp] : bits::bipartitions(n)) {
       // do nothing with the trivial bipartition
@@ -383,30 +383,29 @@ EvalSequence single_term_opt_impl(TensorNetwork const& network,
 }
 
 ///
-/// \tparam OptFor Cost metric to optimize for (Flops or Memsize).
-/// \tparam IdxToSz
-/// \param network A TensorNetwork object.
-/// \param idxsz An invocable on Index, that maps Index to its dimension.
-/// \param subnet_cse Whether to recognize equivalent subnetworks to try
-/// minimizing the ops counts.
-/// \param is_volatile_leaf Predicate marking a leaf tensor as volatile (its
-/// value changes on every replay); empty disables weighting. The predicate MUST
-/// be invariant under slot/index canonicalization — key on tensor label or
-/// structure, NOT on anonymous index identity — so that two subnetworks deemed
-/// equivalent by the subnet-CSE canonicalization also agree on volatility (the
-/// CSE path stores one cost per canonical subnet). Flops metric only.
-/// \param n_replay Multiplier applied to the cost of each volatile-result
-/// contraction (volatile contractions are re-evaluated on every replay);
-/// persistent contractions are counted once. 1 (default) disables weighting.
-/// \return Optimal evaluation sequence under the chosen cost metric. If there
+/// \tparam Metric Objective function (ObjectiveFunction::DenseFLOPs or
+/// ::DenseSize). \tparam IdxToSz \param network A TensorNetwork object. \param
+/// idxsz An invocable on Index, that maps Index to its dimension. \param
+/// subnet_cse Whether to recognize equivalent subnetworks to try minimizing the
+/// ops counts. \param is_volatile_leaf Predicate marking a leaf tensor as
+/// volatile (its value changes on every replay); empty disables weighting. The
+/// predicate MUST be invariant under slot/index canonicalization — key on
+/// tensor label or structure, NOT on anonymous index identity — so that two
+/// subnetworks deemed equivalent by the subnet-CSE canonicalization also agree
+/// on volatility (the CSE path stores one cost per canonical subnet). Flops
+/// metric only. \param volatile_weight Multiplier applied to the cost of each
+/// volatile-result contraction (volatile contractions are re-evaluated on every
+/// replay); persistent contractions are counted once. 1 (default) disables
+/// weighting. \return Optimal evaluation sequence under the chosen cost metric.
+/// If there
 ///         are equivalent optimal sequences then the result is the one that
 ///         keeps the order of tensors in the network as original as possible.
 ///
-template <OptFor Metric, has_index_extent IdxToSz>
+template <ObjectiveFunction Metric, has_index_extent IdxToSz>
 EvalSequence single_term_opt(
     TensorNetwork const& network, IdxToSz&& idxsz, bool subnet_cse,
     std::function<bool(Tensor const&)> const& is_volatile_leaf = {},
-    unsigned n_replay = 1, double footprint_weight = 0.0) {
+    double volatile_weight = 1.0, double footprint_weight = 0.0) {
   decltype(OptRes::indices) tidxs{};
 
   // The per-intermediate footprint penalty needs idxsz too, so build a
@@ -419,23 +418,23 @@ EvalSequence single_term_opt(
   // DP's subset bits.
   size_t volatile_mask = 0;
   double nr = 1.0;
-  if constexpr (Metric == OptFor::Flops) {
-    if (is_volatile_leaf && n_replay > 1) {
+  if constexpr (Metric == ObjectiveFunction::DenseFLOPs) {
+    if (is_volatile_leaf && volatile_weight > 1.0) {
       size_t i = 0;
       for (auto&& t : network.tensors()) {
         auto tp = std::dynamic_pointer_cast<Tensor>(t);
         if (tp && is_volatile_leaf(*tp)) volatile_mask |= (size_t{1} << i);
         ++i;
       }
-      nr = static_cast<double>(n_replay);
+      nr = volatile_weight;
     }
     auto cost_fn = flops_counter(idxsz);
     return single_term_opt_impl(network, tidxs, cost_fn, subnet_cse,
                                 volatile_mask, nr, footprint_fn,
                                 footprint_weight);
   } else {
-    static_assert(Metric == OptFor::Memsize,
-                  "Only Flops and Memsize OptFor supported.");
+    static_assert(Metric == ObjectiveFunction::DenseSize,
+                  "Only DenseFLOPs and DenseSize ObjectiveFunction supported.");
     auto cost_fn = memsize_counter(idxsz);
     return single_term_opt_impl(network, tidxs, cost_fn, subnet_cse,
                                 volatile_mask, nr, footprint_fn,
@@ -446,19 +445,20 @@ EvalSequence single_term_opt(
 }  // namespace detail
 
 ///
-/// \tparam Metric Cost metric to optimize for (Flops by default; Memsize
-///         minimizes total operand memory rather than flops).
+/// \tparam Metric Objective function (DenseFLOPs by default; DenseSize
+///         minimizes total operand storage rather than flops).
 /// \param prod  Product to be optimized.
 /// \param idxsz An invocable object that maps an Index object to size.
 /// \return Parenthesized product expression.
 ///
 /// @note @c prod is assumed to consist of only Tensor expressions
 ///
-template <OptFor Metric = OptFor::Flops, has_index_extent IdxToSz>
+template <ObjectiveFunction Metric = ObjectiveFunction::DenseFLOPs,
+          has_index_extent IdxToSz>
 ExprPtr single_term_opt(
     Product const& prod, IdxToSz&& idxsz, bool subnet_cse = false,
     std::function<bool(Tensor const&)> const& is_volatile_leaf = {},
-    unsigned n_replay = 1, double footprint_weight = 0.0) {
+    double volatile_weight = 1.0, double footprint_weight = 0.0) {
   using ranges::views::filter;
   using ranges::views::reverse;
 
@@ -469,7 +469,7 @@ ExprPtr single_term_opt(
       prod | filter(&ExprPtr::template is<Tensor>) | ranges::to_vector;
   auto seq = detail::single_term_opt<Metric>(
       TensorNetwork{tensors}, std::forward<IdxToSz>(idxsz), subnet_cse,
-      is_volatile_leaf, n_replay, footprint_weight);
+      is_volatile_leaf, volatile_weight, footprint_weight);
   auto result = container::svector<ExprPtr>{};
   for (auto i : seq)
     if (i == -1) {

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -240,12 +240,12 @@ TEST_CASE("optimize", "[optimize]") {
       // separately via opts_off below.)
       auto opts1 = base;
       opts1.is_volatile_leaf = is_t;
-      opts1.n_replay = 1;
+      opts1.volatile_weight = 1;
       auto res1 = optimize(ex<Product>(prod), opts1);
 
       auto opts10 = base;
       opts10.is_volatile_leaf = is_t;
-      opts10.n_replay = 10;
+      opts10.volatile_weight = 10;
       auto res10 = optimize(ex<Product>(prod), opts10);
 
       // a bare top-level t leaf means t was contracted last (persistent-first)
@@ -266,7 +266,7 @@ TEST_CASE("optimize", "[optimize]") {
 
       // empty predicate => weighting off => identical to n_replay=1 regardless
       auto opts_off = base;
-      opts_off.n_replay = 10;  // ignored: predicate empty
+      opts_off.volatile_weight = 10;  // ignored: predicate empty
       auto res_off = optimize(ex<Product>(prod), opts_off);
       REQUIRE(res_off == res1);
     }
@@ -358,9 +358,11 @@ TEST_CASE("optimize", "[optimize]") {
 
       // both metrics must binarize the 3-tensor product into a binary tree:
       // a 2-factor top product whose leaves are the 3 original tensors
-      for (auto opt_for : {OptFor::Flops, OptFor::Memsize}) {
-        CAPTURE(static_cast<int>(opt_for));
-        auto res = optimize(prod, OptimizeOptions{.opt_for = opt_for});
+      for (auto objective_function :
+           {ObjectiveFunction::DenseFLOPs, ObjectiveFunction::DenseSize}) {
+        CAPTURE(static_cast<int>(objective_function));
+        auto res = optimize(
+            prod, OptimizeOptions{.objective_function = objective_function});
         REQUIRE(res->is<Product>());
         REQUIRE(res->as<Product>().factors().size() == 2);
         REQUIRE(count_tensor_leaves(res) == 3);
@@ -634,10 +636,10 @@ TEST_CASE("optimize", "[optimize]") {
       auto expr = ex<Product>(prod);
 
       auto res_cse =
-          optimize(expr, OptimizeOptions{.subnet_cse = SubnetCSE::Enable,
+          optimize(expr, OptimizeOptions{.CSE = {.subnet = true},
                                          .idx_to_extent = idx_to_extent});
       auto res_no_cse =
-          optimize(expr, OptimizeOptions{.subnet_cse = SubnetCSE::Disable,
+          optimize(expr, OptimizeOptions{.CSE = {.subnet = false},
                                          .idx_to_extent = idx_to_extent});
 
       // With CSE: balanced tree -- both children are Products.

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -258,13 +258,14 @@ TEST_CASE("optimize", "[optimize]") {
 
       // weighting flips the chosen factorization
       REQUIRE(res1 != res10);
-      // n_replay=1 reproduces today's behavior: t buried in an inner
+      // volatile_weight=1 reproduces today's behavior: t buried in an inner
       // intermediate
       REQUIRE_FALSE(top_has_bare_t(res1));
-      // n_replay=10: persistent g*g built first, t contracted last
+      // volatile_weight=10: persistent g*g built first, t contracted last
       REQUIRE(top_has_bare_t(res10));
 
-      // empty predicate => weighting off => identical to n_replay=1 regardless
+      // empty predicate => weighting off => identical to volatile_weight=1
+      // regardless
       auto opts_off = base;
       opts_off.volatile_weight = 10;  // ignored: predicate empty
       auto res_off = optimize(ex<Product>(prod), opts_off);


### PR DESCRIPTION
Renames `OptimizeOptions` terminology to match how the values are used (prerequisite for the MPQC `SeQuantEngine` keyword cleanup):

- `OptFor{Flops,Memsize}` → `ObjectiveFunction{DenseFLOPs,DenseSize}` (current cost models are dense; "Size" because operands need not live in memory — disk/distributed; room for `Sparse*` later)
- `opt_for` → `objective_function`
- `n_replay` (`unsigned`) → `volatile_weight` (`double`, beside `footprint_weight`)
- `subnet_cse`/`SubnetCSE{Enable,Disable}` → `CSEOptions CSE` (`CSE.subnet`; room to grow)

Hard rename, no aliases. Behavior unchanged — `test_optimize` passes (204 assertions / 3 cases). The free-function `bool subnet_cse` parameter is intentionally kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)