### PR TITLE
eval/TA: fix stack-use-after-scope in tot_inner_rank

### DIFF
--- a/SeQuant/core/eval/backends/tiledarray/result.hpp
+++ b/SeQuant/core/eval/backends/tiledarray/result.hpp
@@ -39,7 +39,13 @@ template <typename ArrayT>
     // views (e.g. a screened pair), so skip those -- calling range() on an
     // empty view asserts (ArenaTensor) or is UB (TA::Tensor).
     for (auto it = arr.begin(); it != arr.end() && r == 0; ++it) {
-      auto const& outer_tile = it->get();
+      // NOTE: own the tile by value. it->get() (TileReference::get) returns the
+      // tile by value; binding it to a reference does not lifetime-extend the
+      // temporary through this proxy chain, so a reference would dangle and the
+      // inner loop below would read freed stack (ASan: stack-use-after-scope).
+      // The copy is shallow over ArenaTensor's Cell pointers, which alias the
+      // arena owned by the DistArray-resident tile (valid for arr's lifetime).
+      auto const outer_tile = it->get();
       for (auto const& inner : outer_tile) {
         if (inner.empty()) continue;
         if (inner.range().rank() > 0) {


### PR DESCRIPTION
`tot_inner_rank` bound a reference to `it->get()`, whose `TileReference::get()` returns the tile **by value**. Through the iterator `operator->` proxy chain the returned temporary is not lifetime-extended, so the reference dangles and the inner loop reads freed stack.

ASan (RelWithDebInfo, PaRSEC backend) reports `stack-use-after-scope` here, reached via `ResultTensorOfTensorTA::add_inplace` during CCk CSV residual evaluation. It is usually benign (the stale slot still holds valid bytes), but fatal under a task backend that runs other work on the same thread stack while `it->get()`'s internals block (e.g. PaRSEC): the slot is clobbered, yielding a garbage inner-tile pointer and a crash.

Fix: own the tile by value. The copy is shallow over `ArenaTensor`'s Cell pointers, which alias the arena owned by the DistArray-resident tile and stay valid for the array's lifetime.

Verified: PaRSEC + ASan, he10 CSV-CCk, 8/8 runs clean (was: ASan fired on run 1).