### PR TITLE
`mbpt`: handle bare-Tensor summands in `ref_av`

### DIFF
--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -1496,9 +1496,15 @@ ExprPtr expectation_value_impl(ExprPtr expr, OpConnections<int> connect,
         SEQUANT_ASSERT(exptr.template is<Sum>());
         auto result = std::make_shared<Sum>();
         for (auto& summand : exptr.template as<Sum>().summands()) {
-          SEQUANT_ASSERT(summand.template is<Product>());
-          auto result_summand = summand.template as<Product>().clone();
-          auto product_ptr = result_summand.template as_shared_ptr<Product>();
+          // a summand may collapse to a single factor rather than a Product
+          // (e.g. a fully-contracted one-body term like h^O_O with unit
+          // coefficient); wrap it so it can be processed uniformly
+          auto product_ptr =
+              summand.template is<Product>()
+                  ? summand.template as<Product>()
+                        .clone()
+                        .as_shared_ptr<Product>()
+                  : std::make_shared<Product>(ExprPtrList{summand->clone()});
           impl_for_single_tn(product_ptr);
           result->append(product_ptr);
         }

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -1108,6 +1108,20 @@ SECTION("MRSO") {
     REQUIRE(simplify(result - result_top) == ex<Constant>(0));
   }
 
+  // non-normal-ordered one-body operator in product form: h * a†_p * a_q
+  SECTION("ref_av of non-normal-ordered one-body product") {
+    const Index p{L"p_1"};  // complete space (spans core + active + virtual)
+    const Index q{L"p_2"};
+    // creator index (p) -> tensor bra, annihilator index (q) -> tensor ket
+    auto H1 = ex<Tensor>(L"h", bra{p}, ket{q}, Symmetry::Nonsymm,
+                         BraKetSymmetry::Conjugate) *
+              fcrex(p) * fannx(q);
+    ExprPtr result;
+    REQUIRE_NOTHROW(result = t::ref_av(H1));
+    REQUIRE_THAT(result, SimplifiesTo(L"h{O_1;O_1}:N-C-S + "
+                                      L"h{u_2;u_1}:N-C-S * γ{u_1;u_2}:N-C-S"));
+  }
+
 #if 0
     // H**T12 -> R2
     SECTION("wick(H**T2 -> R2)") {


### PR DESCRIPTION
- `tensor::ref_av` asserted every post-Wick summand is a `Product`. 
- A one-body operator in product form (`h * a†_p * a_q`) produces a fully-contracted core-trace term `h^O_O` that `simplify()` folds into a bare `Tensor`, tripping the assert.
- See the new unit test to reproduce. 

/cc @shivupa