### PR TITLE
`eval`: scalar x tensor product inherits canon_phase from tensor

### DIFF
--- a/SeQuant/core/eval/eval_expr.cpp
+++ b/SeQuant/core/eval/eval_expr.cpp
@@ -531,7 +531,7 @@ EvalExprNode binarize(Product const& prod, IndexSet const& uncontract,
           detail::make_tensor_wo_symmetries(opts, bra(t.bra()), ket(t.ket()),
                                             aux(t.aux())),  //
           tl->canon_indices(),                              //
-          1,                                                //
+          tl->canon_phase(),                                //
           h,
           nullptr};
     } else {
@@ -607,7 +607,7 @@ EvalExprNode binarize(Product const& prod, IndexSet const& uncontract,
                            type,                   //
                            expr,                   //
                            left->canon_indices(),  //
-                           1,                      //
+                           left->canon_phase(),    //
                            h,                      //
                            nullptr};
 

--- a/tests/unit/test_eval_expr.cpp
+++ b/tests/unit/test_eval_expr.cpp
@@ -197,6 +197,30 @@ TEST_CASE("eval_expr", "[EvalExpr]") {
                                              ket(IndexList{L"a_1"})));
   }
 
+  SECTION(
+      "scalar * tensor product node inherits the tensor operand canon_phase") {
+    // Regression: binarize(Product) hardcoded canon_phase=1 for scalar*tensor
+    // nodes instead of inheriting the tensor operand's real phase.
+    // Subexpression reuse relies on that phase to reconcile sign-differing
+    // duplicates, so the wrong phase silently produced a wrong result.
+    auto check_phase_inheritance = [](std::wstring_view expr_str) {
+      auto res = deserialize<ResultExpr>(
+          std::wstring{L"Result{a3;i1,i2} = "} + std::wstring{expr_str},
+          {.def_perm_symm = Symmetry::Antisymm});
+      auto root = binarize(res);
+      auto const& tensor_operand =
+          root.left()->is_tensor() ? root.left() : root.right();
+      // Sanity: this contraction must exercise phase=-1, else the CHECK
+      // below would pass trivially even with the bug reintroduced.
+      REQUIRE((int)tensor_operand->canon_phase() == -1);
+      CHECK((int)root->canon_phase() == (int)tensor_operand->canon_phase());
+    };
+    check_phase_inheritance(
+        L"1/2 R{a2;i1,i3} g{i3,a3;i2,a2}");  // numeric scalar
+    check_phase_inheritance(
+        L"R{a2;i1,i3} g{i3,a3;i2,a2} λ");  // Variable scalar
+  }
+
   SECTION("Adjoint op") {
     // A Nonsymm-braket tensor's adjoint() relabels its label with U+207A '⁺'
     // (Tensor::adjoint() at expressions/tensor.cpp:25-41). When that leaf


### PR DESCRIPTION
### Summary
Fixes a sign bug in the eval-tree binarization of "scalar × tensor" product nodes (e.g. a numeric prefactor like 1/2 times a tensor, or a symbolic scalar like λ times a tensor).

### Problem
`binarize(Product)` built scalar × tensor nodes (e.g. 1/2 R g, R g λ) with `canon_phase` hardcoded to +1 at two sites, discarding whatever phase the tensor operand actually had from its own antisymmetric canonicalization. This broke a UCC-EOM validation test and produced a non-Hermitian subspace in 2h1p manifold (~3e-4 deviation). 

### Fix
Both construction sites in `binarize(Product)` now inherit `canon_phase()` from the tensor operand instead of assuming +1.

### Testing
- New unit test asserts a scalar × tensor node's `canon_phase` matches its tensor child's, for a numeric-scalar contraction and a Variable-scalar one, covering both patched sites.
- MPQC validation tests now pass and subspace remains Hermitian. 
- Tested in MPQC CI: https://github.com/ValeevGroup/mpqc4/pull/774, all tests pass. 