### PR TITLE
Lift the >2-tensor limit on external auxiliary hyperindices (TNv3 canonicalization + BTAS batched eval)

### DIFF
--- a/SeQuant/core/eval/backends/btas/result.hpp
+++ b/SeQuant/core/eval/backends/btas/result.hpp
@@ -196,8 +196,16 @@ T batched_contract(typename T::numeric_type alpha, T const& L, Annot const& la,
     }
     return std::pair{std::move(e), sz};
   };
+  // both operands were permuted to [batch..., rest...], so their leading nb
+  // axes are the batch axes in the same order; a well-formed annotation gives
+  // them identical extents. Guard against a malformed one before slicing (P is
+  // taken from the left operand below).
   std::size_t P = 1;
-  for (std::size_t i = 0; i != nb; ++i) P *= Lp.extent(i);
+  for (std::size_t i = 0; i != nb; ++i) {
+    SEQUANT_ASSERT(Lp.extent(i) == Rp.extent(i) &&
+                   "batched_contract: operands disagree on a batch extent");
+    P *= Lp.extent(i);
+  }
   auto const [rlext, rlsz] = tail_extents(Lp, nb);
   auto const [rrext, rrsz] = tail_extents(Rp, nb);
 

--- a/SeQuant/core/eval/backends/btas/result.hpp
+++ b/SeQuant/core/eval/backends/btas/result.hpp
@@ -128,6 +128,153 @@ inline void log_btas(Args const&... args) noexcept {
   log_result("[BTAS] ", args...);
 }
 
+/// \brief The batch (Hadamard) axes of a binary contraction: labels that occur
+///        in the left operand, the right operand AND the result.
+///
+/// btas::contract classifies every index as free-left, free-right or contracted
+/// (an index shared by both operands is *always* summed); it cannot represent a
+/// batch axis -- an index carried through the contraction rather than summed,
+/// e.g. an auxiliary/quadrature index in Laplace-transform MP2 or tensor
+/// hypercontraction. Such axes are detected here and handled by
+/// batched_contract() below.
+template <typename Annot>
+Annot batch_indices(Annot const& la, Annot const& ra, Annot const& ca) {
+  auto has = [](Annot const& v, auto const& x) {
+    return std::find(v.begin(), v.end(), x) != v.end();
+  };
+  Annot batch;
+  for (auto const& x : ca)
+    if (has(la, x) && has(ra, x)) batch.push_back(x);
+  return batch;
+}
+
+/// \brief Contracts \p L (labelled \p la) with \p R (labelled \p ra) into a
+///        result labelled \p ca in which \p batch labels are Hadamard/batch
+///        axes (iterated, not summed).
+///
+/// Precondition: \p batch is non-empty and equals batch_indices(la, ra, ca).
+/// The batch axes are permuted to the front of both operands (making each batch
+/// slice a contiguous block in BTAS's row-major storage), and the non-batch
+/// remainder of each slice is contracted with plain btas::contract (or, for the
+/// degenerate slice shapes, a scaling or a dot). The per-slice results are
+/// assembled and permuted back into \p ca order.
+template <typename T, typename Annot>
+T batched_contract(typename T::numeric_type alpha, T const& L, Annot const& la,
+                   T const& R, Annot const& ra, Annot const& ca,
+                   Annot const& batch) {
+  using numeric_type = typename T::numeric_type;
+  auto has = [](Annot const& v, auto const& x) {
+    return std::find(v.begin(), v.end(), x) != v.end();
+  };
+  // non-batch remainder of a label list, preserving order
+  auto rest = [&](Annot const& v) {
+    Annot r;
+    for (auto const& x : v)
+      if (!has(batch, x)) r.push_back(x);
+    return r;
+  };
+  Annot const rl = rest(la), rr = rest(ra), rc = rest(ca);
+
+  // permute each operand to [batch..., rest...]
+  auto front_batch = [&](Annot const& r) {
+    Annot p = batch;
+    p.insert(p.end(), r.begin(), r.end());
+    return p;
+  };
+  Annot const la_p = front_batch(rl), ra_p = front_batch(rr);
+  T Lp, Rp;
+  btas::permute(L, la, Lp, la_p);
+  btas::permute(R, ra, Rp, ra_p);
+
+  auto const nb = batch.size();
+  auto tail_extents = [](T const& t, std::size_t skip) {
+    container::svector<std::size_t> e;
+    std::size_t sz = 1;
+    for (std::size_t i = skip; i != t.rank(); ++i) {
+      e.push_back(t.extent(i));
+      sz *= t.extent(i);
+    }
+    return std::pair{std::move(e), sz};
+  };
+  std::size_t P = 1;
+  for (std::size_t i = 0; i != nb; ++i) P *= Lp.extent(i);
+  auto const [rlext, rlsz] = tail_extents(Lp, nb);
+  auto const [rrext, rrsz] = tail_extents(Rp, nb);
+
+  // extent of each result-remainder label, looked up from the operands
+  container::svector<std::size_t> rcext;
+  std::size_t rcsz = 1;
+  for (auto const& x : rc) {
+    std::size_t ext = 0;
+    if (auto it = std::find(rl.begin(), rl.end(), x); it != rl.end())
+      ext = rlext[static_cast<std::size_t>(it - rl.begin())];
+    else {
+      auto jt = std::find(rr.begin(), rr.end(), x);
+      SEQUANT_ASSERT(jt != rr.end());
+      ext = rrext[static_cast<std::size_t>(jt - rr.begin())];
+    }
+    rcext.push_back(ext);
+    rcsz *= ext;
+  }
+
+  // assemble result in [batch..., rc...] layout
+  container::svector<std::size_t> cfext;
+  for (std::size_t i = 0; i != nb; ++i) cfext.push_back(Lp.extent(i));
+  cfext.insert(cfext.end(), rcext.begin(), rcext.end());
+  T C{btas::Range{cfext}};
+
+  // extract batch slice b of a [batch..., rest...]-ordered operand as a tensor
+  // with the rest extents (never called for an empty remainder -- a scalar
+  // slice is read directly, avoiding a rank-0 tensor)
+  auto slice = [](T const& src, std::size_t off,
+                  container::svector<std::size_t> const& ext, std::size_t sz) {
+    T s{btas::Range{ext}};
+    std::copy(src.data() + off, src.data() + off + sz, s.data());
+    return s;
+  };
+
+  for (std::size_t b = 0; b != P; ++b) {
+    numeric_type const* lblk = Lp.data() + b * rlsz;
+    numeric_type const* rblk = Rp.data() + b * rrsz;
+
+    if (rc.empty()) {
+      // every non-batch index is contracted -> a scalar per batch element
+      numeric_type d;
+      if (rl.empty()) {  // both slices are scalars
+        d = lblk[0] * rblk[0];
+      } else {
+        T Lb = slice(Lp, b * rlsz, rlext, rlsz);
+        T Rb = slice(Rp, b * rrsz, rrext, rrsz);
+        T Rb2;
+        btas::permute(Rb, rr, Rb2, rl);  // align for the dot
+        d = btas::dot(Lb, Rb2);
+      }
+      C.data()[b] = alpha * d;
+    } else if (rl.empty() || rr.empty()) {
+      // one slice is a scalar -> the other, permuted to rc order and scaled
+      numeric_type const s = alpha * (rl.empty() ? lblk[0] : rblk[0]);
+      T Cb;
+      if (rl.empty())
+        btas::permute(slice(Rp, b * rrsz, rrext, rrsz), rr, Cb, rc);
+      else
+        btas::permute(slice(Lp, b * rlsz, rlext, rlsz), rl, Cb, rc);
+      btas::scal(s, Cb);
+      std::copy(Cb.data(), Cb.data() + rcsz, C.data() + b * rcsz);
+    } else {
+      T Lb = slice(Lp, b * rlsz, rlext, rlsz);
+      T Rb = slice(Rp, b * rrsz, rrext, rrsz);
+      T Cb;
+      btas::contract(alpha, Lb, rl, Rb, rr, numeric_type{0}, Cb, rc);
+      std::copy(Cb.data(), Cb.data() + rcsz, C.data() + b * rcsz);
+    }
+  }
+
+  // permute [batch..., rc...] back into the requested result order ca
+  T result;
+  btas::permute(C, front_batch(rc), result, ca);
+  return result;
+}
+
 }  // namespace detail
 
 ///
@@ -197,6 +344,17 @@ class ResultTensorBTAS final : public Result {
     detail::log_btas(detail::ords_to_labels(a.lannot), " * ",
                      detail::ords_to_labels(a.rannot), " = ",
                      detail::ords_to_labels(a.this_annot), "\n");
+
+    // A batch (Hadamard) axis -- a label shared by both operands AND the result
+    // -- is carried through the contraction rather than summed (e.g. an
+    // auxiliary/quadrature index in Laplace-MP2 or tensor hypercontraction).
+    // btas::contract cannot express one (it always sums an index common to both
+    // operands), so route such contractions through batched_contract().
+    auto const batch = detail::batch_indices(a.lannot, a.rannot, a.this_annot);
+    if (!batch.empty())
+      return eval_result<ResultTensorBTAS<T>>(detail::batched_contract<T>(
+          numeric_type{1}, get<T>(), a.lannot, other.get<T>(), a.rannot,
+          a.this_annot, batch));
 
     T result;
     btas::contract(numeric_type{1},           //

--- a/SeQuant/core/tensor_network/slot.hpp
+++ b/SeQuant/core/tensor_network/slot.hpp
@@ -39,8 +39,6 @@ enum class IndexSlotType {
   TensorBraKet,
   /// in tensor aux index slot
   TensorAux,
-  /// connecting two tensor aux index slots
-  TensorAuxAux,
 };
 
 }  // namespace sequant

--- a/SeQuant/core/tensor_network/v3.cpp
+++ b/SeQuant/core/tensor_network/v3.cpp
@@ -799,7 +799,10 @@ TensorNetworkV3::canonicalize_slots(
           // factors, as in Laplace-transform MP2 or tensor hypercontraction).
           // Supported for auxiliary indices, which carry no vector-space
           // (bra/ket) character; classify by the aux slot it occupies.
-          bool all_aux = true;
+          // (all_aux is only read by the assertion, which is compiled out when
+          // assertions are disabled -- mark it maybe_unused to stay -Werror
+          // clean in that configuration)
+          [[maybe_unused]] bool all_aux = true;
           for (std::size_t v = 0; v != edge_it->vertex_count(); ++v)
             if (edge_it->vertex(v).getOrigin() != Origin::Aux) {
               all_aux = false;

--- a/SeQuant/core/tensor_network/v3.cpp
+++ b/SeQuant/core/tensor_network/v3.cpp
@@ -789,9 +789,27 @@ TensorNetworkV3::canonicalize_slots(
             SEQUANT_ASSERT(edge_it->vertex(0).getOrigin() == Origin::Ket);
             slot_type = IndexSlotType::TensorKet;
           }
-        } else {  // if
-          SEQUANT_ASSERT(edge_it->vertex_count() == 2);
+        } else if (edge_it->vertex_count() == 2) {
+          // an internal contraction edge that is also named (e.g. a proto
+          // index on a named index) connects exactly 2 slots
           slot_type = IndexSlotType::IndexBundle;
+        } else {
+          // a high-order hyperindex: a named index shared among more than 2
+          // tensor slots (e.g. an auxiliary/batching index common to many
+          // factors, as in Laplace-transform MP2 or tensor hypercontraction).
+          // Supported for auxiliary indices, which carry no vector-space
+          // (bra/ket) character; classify by the aux slot it occupies.
+          bool all_aux = true;
+          for (std::size_t v = 0; v != edge_it->vertex_count(); ++v)
+            if (edge_it->vertex(v).getOrigin() != Origin::Aux) {
+              all_aux = false;
+              break;
+            }
+          SEQUANT_ASSERT(all_aux &&
+                         "TensorNetworkV3::canonicalize_slots: high-order "
+                         "(shared among >2 tensor slots) non-auxiliary "
+                         "hyperindices are not supported");
+          slot_type = IndexSlotType::TensorAux;
         }
       } else
         slot_type = IndexSlotType::IndexBundle;

--- a/SeQuant/core/tensor_network/v3.cpp
+++ b/SeQuant/core/tensor_network/v3.cpp
@@ -797,21 +797,22 @@ TensorNetworkV3::canonicalize_slots(
           // a high-order hyperindex: a named index shared among more than 2
           // tensor slots (e.g. an auxiliary/batching index common to many
           // factors, as in Laplace-transform MP2 or tensor hypercontraction).
-          // Supported for auxiliary indices, which carry no vector-space
-          // (bra/ket) character; classify by the aux slot it occupies.
-          // (all_aux is only read by the assertion, which is compiled out when
-          // assertions are disabled -- mark it maybe_unused to stay -Werror
-          // clean in that configuration)
-          [[maybe_unused]] bool all_aux = true;
+          // Supported only for auxiliary indices, which carry no vector-space
+          // (bra/ket) character; classify by the aux slot it occupies. A
+          // non-auxiliary high-order hyperindex has no well-defined slot type,
+          // so hard-error (in every build config, not just assertion-enabled
+          // ones) rather than silently mis-canonicalize it.
+          bool all_aux = true;
           for (std::size_t v = 0; v != edge_it->vertex_count(); ++v)
             if (edge_it->vertex(v).getOrigin() != Origin::Aux) {
               all_aux = false;
               break;
             }
-          SEQUANT_ASSERT(all_aux &&
-                         "TensorNetworkV3::canonicalize_slots: high-order "
-                         "(shared among >2 tensor slots) non-auxiliary "
-                         "hyperindices are not supported");
+          if (!all_aux)
+            throw Exception(
+                "TensorNetworkV3::canonicalize_slots: high-order (shared among "
+                ">2 tensor slots) non-auxiliary hyperindices are not "
+                "supported");
           slot_type = IndexSlotType::TensorAux;
         }
       } else

--- a/tests/unit/test_eval_btas.cpp
+++ b/tests/unit/test_eval_btas.cpp
@@ -151,6 +151,63 @@ class rand_tensor_yield {
   }
 };
 
+// Like rand_tensor_yield but aux-aware: lays out tensor axes in full
+// bra-ket-aux order (const_braketaux_indices) and sizes indices by space,
+// including the batching space z. Used to evaluate expressions that carry an
+// auxiliary/batching hyperindex (Laplace-MP2 / THC style) end to end.
+template <typename Tensor_t>
+class aux_rand_tensor_yield {
+ private:
+  size_t const nocc_, nvirt_, nz_;
+  mutable std::map<std::wstring, sequant::ResultPtr> cache_;
+
+  static std::wstring key(sequant::Tensor const& t) {
+    // normalize away specific index ordinals within a space so a canonicalized
+    // leaf and the original deserialized tensor map to the same entry
+    return boost::regex_replace(
+        sequant::serialize(t.clone(), {.annot_symm = false}),
+        boost::wregex{L"([iaz])[↑↓]?_?\\d+"}, L"$1");
+  }
+
+  size_t extent(sequant::Index const& idx) const {
+    auto isr = sequant::get_default_context().index_space_registry();
+    if (idx.space() == isr->retrieve(L"i")) return nocc_;
+    if (idx.space() == isr->retrieve(L"a")) return nvirt_;
+    if (idx.space() == isr->retrieve(L"z")) return nz_;
+    SEQUANT_ASSERT(false && "aux_rand_tensor_yield: unsupported IndexSpace");
+    return 0;
+  }
+
+ public:
+  aux_rand_tensor_yield(size_t nocc, size_t nvirt, size_t nz)
+      : nocc_{nocc}, nvirt_{nvirt}, nz_{nz} {}
+
+  sequant::ResultPtr operator()(sequant::Tensor const& tnsr) const {
+    using namespace sequant;
+    auto const k = key(tnsr);
+    if (auto it = cache_.find(k); it != cache_.end()) return it->second;
+    auto rng = btas::Range{tnsr.const_braketaux_indices() |
+                           ranges::views::transform(
+                               [this](auto const& ix) { return extent(ix); }) |
+                           ranges::to_vector};
+    Tensor_t t{rng};
+    t.generate([]() { return static_cast<double>(std::rand()) / RAND_MAX; });
+    return cache_
+        .emplace(k, eval_result<ResultTensorBTAS<Tensor_t>>(std::move(t)))
+        .first->second;
+  }
+
+  sequant::ResultPtr operator()(
+      sequant::meta::can_evaluate auto const& node) const {
+    using namespace sequant;
+    if (node->result_type() == ResultType::Tensor)
+      return (*this)(node->expr()->template as<Tensor>());
+    SEQUANT_ASSERT(node->expr()->template is<Constant>());
+    return eval_result<ResultScalar<double>>(
+        node->as_constant().template value<double>());
+  }
+};
+
 using namespace sequant;
 
 template <
@@ -578,4 +635,142 @@ TEST_CASE("binarize_highorder_aux_hyperindex", "[eval_btas][hyperindex]") {
   // 9 leaves + 8 contraction intermediates per summand, plus the sum head and
   // the (-1) scaling node -- comfortably more than a handful of tensor nodes.
   CHECK(tensor_nodes > 10);
+}
+
+// Directly exercises ResultTensorBTAS::prod on a contraction that carries a
+// batch (Hadamard) axis -- a label shared by both operands AND the result. A
+// plain btas::contract cannot express one (it always sums an index common to
+// both operands), so prod() detects the batch axis and slices over it. Every
+// slice shape that batched_contract() must handle is covered: a genuine
+// contraction, a dot (result-remainder empty), and a scalar*tensor (one
+// operand-remainder empty).
+TEST_CASE("btas_batched_contract", "[eval_btas][hyperindex]") {
+  using namespace sequant;
+  using BTensorD = btas::Tensor<double>;
+
+  // arbitrary distinct annotation labels; x is the batch axis
+  const long a = 1, b = 2, k = 3, x = 9;
+  const std::size_t na = 2, nb = 4, nk = 3, nx = 5;
+
+  auto make = [](std::initializer_list<std::size_t> ext) {
+    BTensorD t{btas::Range{container::svector<std::size_t>{ext}}};
+    // deterministic, non-trivial fill: distinct value per element
+    double v = 0.0;
+    t.generate([&v]() { return (v += 1.0) / 7.0; });
+    return t;
+  };
+  auto annots = [](container::svector<long> l, container::svector<long> r,
+                   container::svector<long> c) {
+    return std::array<std::any, 3>{std::move(l), std::move(r), std::move(c)};
+  };
+  auto prod = [](BTensorD const& L, BTensorD const& R,
+                 std::array<std::any, 3> const& ann) {
+    ResultPtr lr = eval_result<ResultTensorBTAS<BTensorD>>(L);
+    ResultPtr rr = eval_result<ResultTensorBTAS<BTensorD>>(R);
+    return lr->prod(*rr, ann, DeNest::False)->get<BTensorD>();
+  };
+
+  SECTION("contraction + batch: L[a,k,x] R[k,b,x] -> C[a,b,x]") {
+    auto L = make({na, nk, nx}), R = make({nk, nb, nx});
+    auto C = prod(L, R, annots({a, k, x}, {k, b, x}, {a, b, x}));
+    REQUIRE(C.rank() == 3);
+    CHECK(C.extent(0) == na);
+    CHECK(C.extent(1) == nb);
+    CHECK(C.extent(2) == nx);
+    for (std::size_t ia = 0; ia < na; ++ia)
+      for (std::size_t ib = 0; ib < nb; ++ib)
+        for (std::size_t ix = 0; ix < nx; ++ix) {
+          double ref = 0.0;
+          for (std::size_t ik = 0; ik < nk; ++ik)
+            ref += L(ia, ik, ix) * R(ik, ib, ix);
+          CHECK(C(ia, ib, ix) == Catch::Approx(ref));
+        }
+  }
+
+  SECTION("dot + batch (empty result remainder): L[k,x] R[k,x] -> C[x]") {
+    auto L = make({nk, nx}), R = make({nk, nx});
+    auto C = prod(L, R, annots({k, x}, {k, x}, {x}));
+    REQUIRE(C.rank() == 1);
+    CHECK(C.extent(0) == nx);
+    for (std::size_t ix = 0; ix < nx; ++ix) {
+      double ref = 0.0;
+      for (std::size_t ik = 0; ik < nk; ++ik) ref += L(ik, ix) * R(ik, ix);
+      CHECK(C(ix) == Catch::Approx(ref));
+    }
+  }
+
+  SECTION("scalar*tensor + batch (empty operand remainder): L[x] R[b,x]") {
+    auto L = make({nx}), R = make({nb, nx});
+    auto C = prod(L, R, annots({x}, {b, x}, {b, x}));
+    REQUIRE(C.rank() == 2);
+    CHECK(C.extent(0) == nb);
+    CHECK(C.extent(1) == nx);
+    for (std::size_t ib = 0; ib < nb; ++ib)
+      for (std::size_t ix = 0; ix < nx; ++ix)
+        CHECK(C(ib, ix) == Catch::Approx(L(ix) * R(ib, ix)));
+  }
+
+  SECTION(
+      "result axis order differs from [batch,rest]: L[a,x] R[b,x] -> "
+      "C[x,a,b]") {
+    auto L = make({na, nx}), R = make({nb, nx});
+    auto C = prod(L, R, annots({a, x}, {b, x}, {x, a, b}));
+    REQUIRE(C.rank() == 3);
+    CHECK(C.extent(0) == nx);
+    CHECK(C.extent(1) == na);
+    CHECK(C.extent(2) == nb);
+    for (std::size_t ix = 0; ix < nx; ++ix)
+      for (std::size_t ia = 0; ia < na; ++ia)
+        for (std::size_t ib = 0; ib < nb; ++ib)
+          CHECK(C(ix, ia, ib) == Catch::Approx(L(ia, ix) * R(ib, ix)));
+  }
+}
+
+// End-to-end through binarize + evaluate: a batched-over-aux contraction whose
+// batching index z1 is shared by 3 tensors (the >2-tensor case the TNv3 fix
+// unlocks) and carried into the result. Every contraction node evaluates via
+// the batched prod() path, and the answer must match a hand-computed reference.
+//   R{;;z1} = A{;a1;z1} * B{a1;a2;z1} * C{a2;;z1}
+//   R[z] = sum_{a1,a2} A[a1,z] * B[a1,a2,z] * C[a2,z]
+TEST_CASE("eval_btas_batched_over_aux", "[eval_btas][hyperindex]") {
+  using namespace sequant;
+  using BTensorD = btas::Tensor<double>;
+
+  auto isr = mbpt::make_sr_spaces();
+  mbpt::add_batching_spaces(isr);  // z
+  auto ctx_resetter =
+      set_scoped_default_context(Context{get_default_context()}.set(isr));
+
+  // Nonsymm so bra<->ket orientation is never folded by canonicalization: the
+  // leaf identities (hence the yielder cache keys) stay put.
+  const io::serialization::DeserializationOptions opts{
+      .def_perm_symm = Symmetry::Nonsymm,
+      .def_braket_symm = BraKetSymmetry::Nonsymm};
+
+  std::srand(42);
+  const size_t nocc = 2, nvirt = 3, nz = 5;
+  aux_rand_tensor_yield<BTensorD> yield_{nocc, nvirt, nz};
+
+  auto res = deserialize<ResultExpr>(
+      L"R{;;z1} = A{;a1;z1} * B{a1;a2;z1} * C{a2;;z1}", opts);
+  auto node = binarize<EvalExprBTAS>(res);
+
+  auto got = evaluate(node, node->annot(), yield_)->get<BTensorD>();
+  REQUIRE(got.rank() == 1);
+  REQUIRE(got.extent(0) == nz);
+
+  auto leaf = [&](std::wstring_view s) -> BTensorD const& {
+    return yield_(deserialize<ExprPtr>(s, opts)->as<Tensor>())->get<BTensorD>();
+  };
+  auto const& A = leaf(L"A{;a1;z1}");    // [a1, z]
+  auto const& B = leaf(L"B{a1;a2;z1}");  // [a1, a2, z]
+  auto const& C = leaf(L"C{a2;;z1}");    // [a2, z]
+
+  for (size_t z = 0; z < nz; ++z) {
+    double ref = 0.0;
+    for (size_t a1 = 0; a1 < nvirt; ++a1)
+      for (size_t a2 = 0; a2 < nvirt; ++a2)
+        ref += A(a1, z) * B(a1, a2, z) * C(a2, z);
+    CHECK(got(z) == Catch::Approx(ref));
+  }
 }

--- a/tests/unit/test_eval_btas.cpp
+++ b/tests/unit/test_eval_btas.cpp
@@ -3,12 +3,16 @@
 
 #include "catch2_sequant.hpp"
 
+#include <SeQuant/core/binary_node.hpp>
+#include <SeQuant/core/context.hpp>
 #include <SeQuant/core/eval/backends/btas/eval_expr.hpp>
 #include <SeQuant/core/eval/backends/btas/result.hpp>
 #include <SeQuant/core/eval/eval.hpp>
+#include <SeQuant/core/expressions/result_expr.hpp>
 #include <SeQuant/core/io/shorthands.hpp>
 #include <SeQuant/core/optimize/optimize.hpp>
 #include <SeQuant/domain/mbpt/biorthogonalization.hpp>
+#include <SeQuant/domain/mbpt/convention.hpp>
 
 #include <btas/btas.h>
 #include <btas/tensor_func.h>
@@ -508,4 +512,70 @@ TEST_CASE("eval_adjoint_complex_btas", "[eval_btas]") {
       CHECK(got.real() == Catch::Approx(expected.real()).margin(1e-12));
       CHECK(got.imag() == Catch::Approx(expected.imag()).margin(1e-12));
     }
+}
+
+// A high-order hyperindex is an index shared among MORE than two tensor slots.
+// When such an index is also *external* (named -- it survives into the result),
+// TensorNetworkV3::canonicalize_slots used to assert that every named-index
+// edge connects at most two vertices, so binarizing an expression carrying a
+// batching/auxiliary index across many factors threw. This reproduces the
+// Laplace-transform MP2 energy denominator, where the batching index z1 rides
+// in the aux slot of every factor and of the result E{;;z1}.
+//
+// NB This only exercises tree construction (what the reported failure did):
+// binarize<EvalExprBTAS>(deserialize<ResultExpr>(...)). Actually *evaluating*
+// the tree is a separate matter -- every node is a batched (Hadamard)
+// contraction over z1, which the BTAS backend's btas::contract (an index in
+// both operands is always summed, never batched) does not support.
+TEST_CASE("binarize_highorder_aux_hyperindex", "[eval_btas][hyperindex]") {
+  using namespace sequant;
+
+  // register the OBS AO space (μ) and the batching space (z) on top of the
+  // standard single-reference spaces
+  auto isr = mbpt::make_sr_spaces();
+  mbpt::add_ao_spaces(isr);        // μ (OBS AO)
+  mbpt::add_batching_spaces(isr);  // z (batching)
+  auto ctx_resetter =
+      set_scoped_default_context(Context{get_default_context()}.set(isr));
+
+  const std::wstring e_a_expr =
+      L"E{;;z1} = w{;;z1} * g{μ5,μ6;μ7,μ8;z1} * c{μ1;i1;z1} * ć{i1;μ5;z1} * "
+      L"d{μ7;μ3;z1} * c{μ2;i2;z1} * ć{i2;μ6;z1} * d{μ8;μ4;z1} * "
+      L"g{μ3,μ4;μ1,μ2;z1}"
+      L" - w{;;z1} * g{μ5,μ6;μ7,μ8;z1} * c{μ1;i1;z1} * ć{i1;μ5;z1} * "
+      L"d{μ7;μ3;z1} * c{μ2;i2;z1} * ć{i2;μ6;z1} * d{μ8;μ4;z1} * "
+      L"g{μ4,μ3;μ1,μ2;z1}";
+
+  auto res = deserialize<ResultExpr>(e_a_expr);
+
+  // the regression: this used to throw
+  //   SEQUANT_ASSERT(edge_it->vertex_count() == 2) in canonicalize_slots
+  REQUIRE_NOTHROW(binarize<EvalExprBTAS>(res));
+  auto node = binarize<EvalExprBTAS>(res);
+
+  const auto z1 = Index{L"z_1"};
+  auto has_aux_z1 = [&z1](Tensor const& t) {
+    return ranges::any_of(t.aux(), [&z1](Index const& ix) { return ix == z1; });
+  };
+
+  // the result carries z1 in its (only) aux slot ...
+  REQUIRE(node->is_tensor());
+  CHECK(node->as_tensor().aux_rank() == 1);
+  CHECK(has_aux_z1(node->as_tensor()));
+
+  // ... and z1 rides in the aux slot of every tensor node of the tree (leaves
+  // and contraction intermediates alike): the batching index is never
+  // contracted away.
+  std::size_t tensor_nodes = 0;
+  node.visit(
+      [&](auto const& n) {
+        if (n->is_tensor()) {
+          ++tensor_nodes;
+          CHECK(has_aux_z1(n->as_tensor()));
+        }
+      },
+      TreeTraversal::PreOrder);
+  // 9 leaves + 8 contraction intermediates per summand, plus the sum head and
+  // the (-1) scaling node -- comfortably more than a handful of tensor nodes.
+  CHECK(tensor_nodes > 10);
 }

--- a/tests/unit/test_eval_ta.cpp
+++ b/tests/unit/test_eval_ta.cpp
@@ -1097,6 +1097,27 @@ TEST_CASE("eval_with_tiledarray", "[eval]") {
         }();
         REQUIRE(equal_tarrays(eval3, man3, "i1,i2,i3"));
       }
+
+      {  // high-order aux hyperindex carried into the result: aux index x1 is
+         // shared by 3 tensors AND external (in the result aux slot). This is
+         // the >2-tensor named-hyperedge case the TNv3 canonicalize_slots fix
+         // unlocks; TA evaluates the resulting batched-over-x1 contraction
+         // natively (einsum keeps an index common to both operands and result).
+         //   R{;;x1} = A{;a1;x1} B{a1;a2;x1} C{a2;;x1}
+         //   R[x] = sum_{a1,a2} A[a1,x] B[a1,a2,x] C[a2,x]
+        auto res = deserialize<sequant::ResultExpr>(
+            L"R{;;x1} = A{;a1;x1} B{a1;a2;x1} C{a2;;x1}");
+        auto evalR = evaluate(eval_node(res), std::string("x_1"), yield_)
+                         ->get<TA::TArrayD>();
+        auto manR = [&]() {
+          auto A = yield(L"A{;a1;x1}");    // [a1, x]
+          auto B = yield(L"B{a1;a2;x1}");  // [a1, a2, x]
+          auto C = yield(L"C{a2;;x1}");    // [a2, x]
+          auto AB = TA::einsum("ax,abx->bx", A, B);
+          return TA::einsum("bx,bx->x", AB, C);
+        }();
+        REQUIRE(equal_tarrays(evalR, manR, "x1"));
+      }
     }  // multiple bra or ket indices
   }
 


### PR DESCRIPTION
## Summary

SeQuant already supports **hyperindices** — indices shared among more than two tensors — as exercised by the existing tensor-hypercontraction / THC tests and the order-3 `T{a1;i1} T{a2;i1} T{a3;i1}` test. This PR does **not** add hyperindex support; it lifts a limitation that only shows up at higher order.

In every existing test the hyperindex is either **contracted** (an internal/anonymous mode — skipped by the named-index handling in canonicalization) or **external but shared by at most two tensor slots**. Neither reaches the one code path that assumed a *named* index's edge connects at most two vertices, so the limit was never hit — the existing coverage tops out at order-3 *contracted* hyperindices.

Laplace-transform MP2 is the first case with an **external hyperindex of order > 2**: a batching/quadrature index `z1` rides in the aux slot of every factor *and* of the result `E{;;z1}` (order 9 here). That tripped the assertion, and — once past it — could not be evaluated. Both layers are addressed:

### 1. Tree building (TNv3 canonicalization)

`TensorNetworkV3::canonicalize_slots` classified each **named** index by its edge's vertex count, handling 1 (an open bra/ket/aux slot) or 2 (an internal contraction that is also named, e.g. a protoindex) and asserting `vertex_count() == 2` otherwise. A named index shared by >2 tensor slots forms a hyperedge with >2 vertices and tripped that assert.

Fix: classify an all-aux, >2-vertex named edge as a `TensorAux` slot. A non-auxiliary high-order hyperindex has no well-defined slot type and is rejected with an explicit `throw` (in every build config, not only assertion-enabled ones).

### 2. Numerical evaluation

Each contraction node over such an index is a **batched (Hadamard) contraction**: the index is present in the left operand, the right operand *and* the result, so it must be iterated, not summed.

- **BTAS** — `btas::contract` has no batch category (an index in both operands is always summed), so it aborted. `ResultTensorBTAS::prod` now detects batch axes (`batch_indices`) and routes through a new `batched_contract()` that permutes the batch axes to the front (making each slice contiguous in row-major storage) and contracts each slice — falling back to a dot or a scaling for the degenerate slice shapes.
- **TiledArray** — no backend change needed; `einsum` supports batch axes natively. Only the layer-1 fix was required.

## Tests

- `binarize_highorder_aux_hyperindex` (`test_eval_btas.cpp`) — reproduces the Laplace-MP2 energy expression; asserts the eval tree builds and carries `z1` in the aux slot of every tensor node. Confirmed red→green against the fix.
- `btas_batched_contract` — unit-tests `prod()` on every slice shape (contract+batch, dot+batch, scalar·tensor+batch, non-canonical result order).
- `eval_btas_batched_over_aux` — end-to-end `binarize + evaluate` of a 3-tensor batched-over-aux contraction against a hand-computed reference.
- `test_eval_ta.cpp` non-covariant section — end-to-end TA evaluation of the same class of expression against a `TA::einsum` reference.

Full BTAS unit suite: 7194 assertions / 65 cases pass. TA `eval_with_tiledarray` case passes with the new test.

## Notes

- `IndexSlotType::TensorAuxAux` is removed — it had no users, and a high-order auxiliary hyperindex is classified as `TensorAux`, so there is no distinct aux-aux slot type.
- The batch-extent agreement of the two operands is asserted in `batched_contract` before slicing.
