### PR TITLE
Make eval/FullBinaryNode tree traversal iterative (stack-safe for deep trees)

### DIFF
--- a/SeQuant/core/binary_node.hpp
+++ b/SeQuant/core/binary_node.hpp
@@ -3,10 +3,12 @@
 
 #include <SeQuant/core/utility/macros.hpp>
 
+#include <deque>
 #include <memory>
 #include <sstream>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #include <range/v3/numeric/accumulate.hpp>
 #include <range/v3/range/access.hpp>
@@ -240,9 +242,44 @@ class FullBinaryNode {
   FullBinaryNode<T>* parent_{nullptr};
 
   node_ptr deep_copy() const {
-    return leaf() ? std::make_unique<FullBinaryNode<T>>(data_)
-                  : std::make_unique<FullBinaryNode<T>>(
-                        data_, left_->deep_copy(), right_->deep_copy());
+    // Iterative post-order clone: build the copy bottom-up with an explicit
+    // stack so cloning a deep tree does not recurse to the tree's depth (which
+    // could overflow the C++ call stack).
+    struct Frame {
+      explicit Frame(FullBinaryNode const* s) : src{s} {}
+      FullBinaryNode const* src;
+      int stage = 0;
+      node_ptr left, right;
+    };
+    std::deque<Frame> stk;
+    stk.push_back(Frame{this});
+    node_ptr ret;
+    while (!stk.empty()) {
+      Frame& f = stk.back();
+      if (f.src->leaf()) {
+        ret = std::make_unique<FullBinaryNode<T>>(f.src->data_);
+        stk.pop_back();
+        continue;
+      }
+      switch (f.stage) {
+        case 0:
+          f.stage = 1;
+          stk.push_back(Frame{f.src->left_.get()});
+          break;
+        case 1:
+          f.left = std::move(ret);
+          f.stage = 2;
+          stk.push_back(Frame{f.src->right_.get()});
+          break;
+        default:
+          f.right = std::move(ret);
+          ret = std::make_unique<FullBinaryNode<T>>(
+              f.src->data_, std::move(f.left), std::move(f.right));
+          stk.pop_back();
+          break;
+      }
+    }
+    return ret;
   }
 
   template <typename Ptr>
@@ -358,6 +395,26 @@ class FullBinaryNode {
     // parent_ remains unchanged
 
     return *this;
+  }
+
+  ///
+  /// Destructor. Dismantles the subtree iteratively so that destroying a deep
+  /// tree does not recurse to the tree's depth: children are owned by
+  /// unique_ptr, so the implicitly-generated destructor would recurse and can
+  /// overflow the C++ call stack. Each node is detached from its children
+  /// before being destroyed, so every individual node destruction is O(1).
+  ~FullBinaryNode() {
+    if (!left_ && !right_) return;
+    std::vector<node_ptr> pending;
+    if (left_) pending.push_back(std::move(left_));
+    if (right_) pending.push_back(std::move(right_));
+    while (!pending.empty()) {
+      node_ptr n = std::move(pending.back());
+      pending.pop_back();
+      if (n->left_) pending.push_back(std::move(n->left_));
+      if (n->right_) pending.push_back(std::move(n->right_));
+      // n is destroyed here with both children already detached => O(1).
+    }
   }
 
   ///
@@ -643,12 +700,49 @@ bool operator==(FullBinaryNode<T> const& lhs, FullBinaryNode<U> const& rhs) {
 template <typename T, typename F,
           typename = std::enable_if_t<std::is_invocable_v<F, T>>>
 auto transform_node(FullBinaryNode<T> const& node, F fun) {
-  if (node.leaf())
-    return FullBinaryNode(fun(*node));
-  else {
-    return FullBinaryNode(fun(*node), transform_node(node.left(), fun),
-                          transform_node(node.right(), fun));
+  using R = std::decay_t<std::invoke_result_t<F, T const&>>;
+  using RNode = FullBinaryNode<R>;
+  using rptr = typename RNode::node_ptr;
+  // Iterative post-order transform: build the transformed tree bottom-up with
+  // an explicit stack so transforming a deep tree does not recurse to the
+  // tree's depth (which could overflow the C++ call stack). `fun` is applied to
+  // each node's data exactly once; as a pure data map its application order is
+  // immaterial.
+  struct Frame {
+    explicit Frame(FullBinaryNode<T> const* s) : src{s} {}
+    FullBinaryNode<T> const* src;
+    int stage = 0;
+    rptr left, right;
+  };
+  std::deque<Frame> stk;
+  stk.push_back(Frame{&node});
+  rptr ret;
+  while (!stk.empty()) {
+    Frame& f = stk.back();
+    if (f.src->leaf()) {
+      ret = std::make_unique<RNode>(fun(**f.src));
+      stk.pop_back();
+      continue;
+    }
+    switch (f.stage) {
+      case 0:
+        f.stage = 1;
+        stk.push_back(Frame{&f.src->left()});
+        break;
+      case 1:
+        f.left = std::move(ret);
+        f.stage = 2;
+        stk.push_back(Frame{&f.src->right()});
+        break;
+      default:
+        f.right = std::move(ret);
+        ret = std::make_unique<RNode>(fun(**f.src), std::move(f.left),
+                                      std::move(f.right));
+        stk.pop_back();
+        break;
+    }
   }
+  return RNode{std::move(*ret)};
 }
 
 ///

--- a/SeQuant/core/eval/eval.hpp
+++ b/SeQuant/core/eval/eval.hpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <any>
 #include <chrono>
+#include <deque>
 #include <iostream>
 #include <optional>
 #include <stdexcept>
@@ -494,9 +495,20 @@ template <typename Node>
 /// \tparam EvalTrace If Trace::On, trace is written to the logger's stream.
 ///                   Default is to follow Trace::Default, which is itself
 ///                   equal to Trace::On or Trace::Off.
-/// \tparam Cache If CacheCache::Checked (default) the \p cache will be
-///               checked before evaluating. It is used to detect the base case
-///               for recursion to prevent infinite recursion.
+/// \tparam Cache If CacheCache::Checked (default) the root \p node is looked up
+///               in \p cache before evaluating; a hit short-circuits it. Child
+///               nodes are always evaluated Checked. Unchecked skips the lookup
+///               for the root only.
+///
+/// \note The traversal is iterative: it maintains its own explicit work stack
+///       (a `std::deque` of frames) rather than recursing, so evaluation depth
+///       is bounded by the heap, not the C++ call stack. This keeps deep trees
+///       (e.g. a Sum or product chain with thousands of operands) stack-safe.
+///       Custom-evaluator interception is preserved exactly: it is consulted
+///       when a frame is first visited and a non-null result short-circuits the
+///       subtree (its children are never pushed), so subtree pruning -- the
+///       mechanism batched eval relies on -- is unaffected.
+///
 /// \param node A node that can be evaluated using \p le as the leaf
 ///             evaluator.
 /// \param le The leaf evaluator that satisfies
@@ -511,168 +523,245 @@ template <Trace EvalTrace = Trace::Default,
 ResultPtr evaluate(Node const& node,  //
                    F const& le,       //
                    CacheManager<N, FHC>& cache) {
-  if constexpr (Cache == detail::CacheCheck::Checked) {  // return from cache if
-                                                         // found
+  // Multiply a (possibly cached) result by its node's canonicalization phase.
+  // Formerly the `mult_by_phase` lambda local to the Checked wrapper.
+  auto apply_phase = [&cache](auto const& nd, ResultPtr res) -> ResultPtr {
+    auto phase = nd->canon_phase();
+    if (phase == 1) return res;
 
-    auto mult_by_phase = [&node, &cache](ResultPtr res) {
-      auto phase = node->canon_phase();
-      if (phase == 1) return res;
+    ResultPtr post;
+    auto time =
+        detail::timed_eval_inplace([&]() { post = res->mult_by_phase(phase); });
 
-      ResultPtr post;
-      auto time = detail::timed_eval_inplace(
-          [&]() { post = res->mult_by_phase(phase); });
-
-      if constexpr (detail::trace(EvalTrace)) {
-        size_t hwmark = log::bytes(cache, post).value;
-        if (!cache.alive(node)) hwmark += log::bytes(res).value;
-        auto stat =
-            log::EvalStat{.mode = log::EvalMode::MultByPhase,
-                          .time = time,
-                          .mem_result = log::bytes(post),
-                          .mem_alloc = log::bytes(post),
-                          .mem_hwmark = {cache.note_working_set(hwmark)}};
-        log::eval(stat, std::format("{} * {}", phase, node->label()));
-      }
-      return post;
-    };
-
-    if (auto ptr = cache.access(node); ptr) {
-      if constexpr (detail::trace(EvalTrace))
-        log::cache(node, cache, log::label(node));
-
-      return mult_by_phase(ptr);
-    } else if (cache.exists(node)) {
-      auto ptr = cache.store(
-          node,
-          mult_by_phase(evaluate<EvalTrace, detail::CacheCheck::Unchecked>(
-              node, le, cache)));
-      if constexpr (detail::trace(EvalTrace))
-        log::cache(node, cache, log::label(node));
-
-      return mult_by_phase(ptr);
-    } else {
-      // do nothing
+    if constexpr (detail::trace(EvalTrace)) {
+      size_t hwmark = log::bytes(cache, post).value;
+      if (!cache.alive(nd)) hwmark += log::bytes(res).value;
+      auto stat = log::EvalStat{.mode = log::EvalMode::MultByPhase,
+                                .time = time,
+                                .mem_result = log::bytes(post),
+                                .mem_alloc = log::bytes(post),
+                                .mem_hwmark = {cache.note_working_set(hwmark)}};
+      log::eval(stat, std::format("{} * {}", phase, nd->label()));
     }
-  }
+    return post;
+  };
 
-  ResultPtr result;
-  ResultPtr left;
-  ResultPtr right;
+  // One entry of the explicit evaluation stack. `stage` records how far a node
+  // has progressed; `left`/`right` hold its evaluated operands; `store_after`
+  // marks a Checked node that exists in the cache map but has not been stored
+  // yet, so its computed result must be cached (this replaces the recursive
+  // wrapper's `evaluate<..., Unchecked>` re-entry).
+  enum class Stage { Enter, NeedLeft, NeedRight, NeedLeftAdj };
+  struct Frame {
+    Node node;
+    bool checked;
+    Stage stage = Stage::Enter;
+    bool store_after = false;
+    ResultPtr left, right;
+  };
 
-  log::Duration time;
+  // Finalize a freshly computed Phase-B result: if this Checked node needs
+  // storing, cache it (phase-applied) and hand back the phase-applied cached
+  // pointer -- exactly the recursive Checked wrapper's store path. Otherwise
+  // pass the raw result through unchanged.
+  auto finish_phase_b = [&cache, &apply_phase](Frame const& f,
+                                               ResultPtr rb) -> ResultPtr {
+    if (!f.store_after) return rb;
+    auto ptr = cache.store(f.node, apply_phase(f.node, std::move(rb)));
+    if constexpr (detail::trace(EvalTrace))
+      log::cache(f.node, cache, log::label(f.node));
+    return apply_phase(f.node, ptr);
+  };
 
-  // Custom-evaluator interception: before the standard scheme, a non-leaf node
-  // may be evaluated by the cache's custom evaluator (e.g. blocked over a
-  // contracted index to bound peak memory). A non-null result is used (and
-  // cached by the Checked wrapper) as-is; null declines to the standard scheme
-  // below. See CacheManager::custom_evaluator_type.
-  if (!node.leaf()) {
-    if (auto const& custom_eval = cache.custom_evaluator(); custom_eval) {
-      ResultPtr intercepted;
-      time = detail::timed_eval_inplace(
-          [&]() { intercepted = custom_eval(node, cache); });
-      if (intercepted) {
-        if constexpr (detail::trace(EvalTrace)) {
-          log::eval(log::EvalStat{.mode = log::eval_mode(node),
+  // A `std::deque` is used so that a reference to the top frame stays valid
+  // across push_back (which reallocates a `std::vector`).
+  std::deque<Frame> stk;
+  stk.push_back(
+      Frame{.node = node, .checked = (Cache == detail::CacheCheck::Checked)});
+
+  ResultPtr ret;  // result handed up by the frame that most recently finalized
+
+  // Deliver `r` to the parent frame and pop the just-completed frame.
+  auto finalize = [&stk, &ret](ResultPtr r) {
+    ret = std::move(r);
+    stk.pop_back();
+  };
+
+  while (!stk.empty()) {
+    Frame& f = stk.back();
+
+    switch (f.stage) {
+      case Stage::Enter: {
+        // --- Checked cache wrapper: a hit returns directly; a miss on a node
+        //     that exists in the map schedules a store once computed. ---
+        if (f.checked) {
+          if (auto ptr = cache.access(f.node); ptr) {
+            if constexpr (detail::trace(EvalTrace))
+              log::cache(f.node, cache, log::label(f.node));
+            finalize(apply_phase(f.node, ptr));
+            break;
+          }
+          f.store_after = cache.exists(f.node);
+        }
+
+        // --- Custom-evaluator interception (non-leaf only): a non-null result
+        //     short-circuits the subtree -- children are never pushed. This is
+        //     the subtree pruning batched eval relies on; see the class note. A
+        //     null return declines to the standard scheme below. ---
+        if (!f.node.leaf()) {
+          if (auto const& custom_eval = cache.custom_evaluator(); custom_eval) {
+            ResultPtr intercepted;
+            auto time = detail::timed_eval_inplace(
+                [&]() { intercepted = custom_eval(f.node, cache); });
+            if (intercepted) {
+              if constexpr (detail::trace(EvalTrace)) {
+                log::eval(
+                    log::EvalStat{.mode = log::eval_mode(f.node),
                                   .time = time,
                                   .mem_result = log::bytes(intercepted),
                                   .mem_alloc = log::bytes(intercepted),
                                   .mem_hwmark = {cache.note_working_set(
                                       log::bytes(cache, intercepted).value)}},
-                    log::label(node));
+                    log::label(f.node));
+              }
+              finalize(finish_phase_b(f, std::move(intercepted)));
+              break;
+            }
+          }
         }
-        return intercepted;
+
+        // --- Leaf. ---
+        if (f.node.leaf()) {
+          ResultPtr result;
+          auto time =
+              detail::timed_eval_inplace([&]() { result = le(f.node); });
+          if constexpr (detail::trace(EvalTrace)) {
+            log::eval(log::EvalStat{.mode = log::eval_mode(f.node),
+                                    .time = time,
+                                    .mem_result = log::bytes(result),
+                                    .mem_alloc = log::bytes(result),
+                                    .mem_hwmark = {cache.note_working_set(
+                                        log::bytes(cache, result).value)}},
+                      log::label(f.node));
+          }
+          finalize(finish_phase_b(f, std::move(result)));
+          break;
+        }
+
+        // --- Internal node: request the left operand (always Checked). The
+        //     stage must advance before the push (push may grow the deque). ---
+        f.stage = (f.node->op_type() == EvalOp::Adjoint) ? Stage::NeedLeftAdj
+                                                         : Stage::NeedLeft;
+        stk.push_back(Frame{.node = f.node.left(), .checked = true});
+        break;
+      }
+
+      case Stage::NeedLeftAdj: {
+        // Unary IR op (Adjoint): only the left operand is evaluated; the right
+        // child is the Constant(1) sentinel kept to preserve FullBinaryNode's
+        // invariant, and is intentionally never pushed.
+        f.left = std::move(ret);
+        SEQUANT_ASSERT(f.left);
+        std::array<std::any, 2> const adj_ann{f.node.left()->annot(),
+                                              f.node->annot()};
+        ResultPtr result;
+        auto time = detail::timed_eval_inplace(
+            [&]() { result = f.left->adjoint(adj_ann); });
+
+        if constexpr (detail::trace(EvalTrace)) {
+          // `right` is null here (see log::bytes() null tolerance).
+          size_t hwmark = log::bytes(cache, result).value;
+          if (!cache.alive(f.node.left()) || f.node.left()->canon_phase() != 1)
+            hwmark += log::bytes(f.left).value;
+          log::eval(
+              log::EvalStat{.mode = log::eval_mode(f.node),
+                            .time = time,
+                            .mem_result = log::bytes(result),
+                            .mem_alloc = log::bytes(result),
+                            .mem_hwmark = {cache.note_working_set(hwmark)},
+                            .mem_left = log::bytes(f.left),
+                            .mem_right = log::bytes(f.right)},
+              log::label(f.node));
+        }
+        finalize(finish_phase_b(f, std::move(result)));
+        break;
+      }
+
+      case Stage::NeedLeft: {
+        f.left = std::move(ret);
+        SEQUANT_ASSERT(f.left);
+        f.stage = Stage::NeedRight;
+        stk.push_back(Frame{.node = f.node.right(), .checked = true});
+        break;
+      }
+
+      case Stage::NeedRight: {
+        f.right = std::move(ret);
+        SEQUANT_ASSERT(f.left);
+        SEQUANT_ASSERT(f.right);
+
+        std::array<std::any, 3> const ann{
+            f.node.left()->annot(), f.node.right()->annot(), f.node->annot()};
+        ResultPtr result;
+        log::Duration time;
+        if (f.node->op_type() == EvalOp::Sum) {
+          time = detail::timed_eval_inplace(
+              [&]() { result = f.left->sum(*f.right, ann); });
+        } else {
+          SEQUANT_ASSERT(f.node->op_type() == EvalOp::Product);
+          // Consult the shaped-product hook (if set) before evaluating the
+          // product. The hook receives the node (wrapped in a std::any as a
+          // std::reference_wrapper so the full IR node is inspectable) plus the
+          // evaluated operands and annotations; a non-null return *replaces*
+          // the normal product (e.g. a shape-constrained emission of it), a
+          // null return declines and the standard prod() below runs. An empty
+          // hook is never consulted; default-empty => byte-identical behavior.
+          auto const de_nest =
+              f.node.left()->tot() && f.node.right()->tot() && !f.node->tot();
+          if (auto const& hook = cache.shaped_product_hook(); hook) {
+            time = detail::timed_eval_inplace([&]() {
+              result =
+                  hook(std::any{std::cref(f.node)}, *f.left, *f.right, ann);
+            });
+          }
+          if (!result) {
+            time = detail::timed_eval_inplace([&]() {
+              result = f.left->prod(*f.right, ann,
+                                    de_nest ? DeNest::True : DeNest::False);
+            });
+          }
+        }
+
+        SEQUANT_ASSERT(result);
+
+        if constexpr (detail::trace(EvalTrace)) {
+          // A cached child is *distinct* from the local left/right when its
+          // canon_phase != 1, because apply_phase allocates a fresh buffer
+          // while the cache still holds the pre-phase data. So only skip the
+          // local's bytes when the cache aliases the same buffer (phase == 1).
+          size_t hwmark = log::bytes(cache, result).value;
+          if (!cache.alive(f.node.left()) || f.node.left()->canon_phase() != 1)
+            hwmark += log::bytes(f.left).value;
+          if (f.right && (!cache.alive(f.node.right()) ||
+                          f.node.right()->canon_phase() != 1))
+            hwmark += log::bytes(f.right).value;
+          log::eval(
+              log::EvalStat{.mode = log::eval_mode(f.node),
+                            .time = time,
+                            .mem_result = log::bytes(result),
+                            .mem_alloc = log::bytes(result),
+                            .mem_hwmark = {cache.note_working_set(hwmark)},
+                            .mem_left = log::bytes(f.left),
+                            .mem_right = log::bytes(f.right)},
+              log::label(f.node));
+        }
+        finalize(finish_phase_b(f, std::move(result)));
+        break;
       }
     }
   }
 
-  if (node.leaf()) {
-    time = detail::timed_eval_inplace([&]() { result = le(node); });
-  } else if (node->op_type() == EvalOp::Adjoint) {
-    // Unary IR op: dispatch on left operand only; right is the Constant(1)
-    // sentinel kept around to preserve FullBinaryNode's invariant. We
-    // intentionally skip evaluating the sentinel — leaf evaluators that
-    // can't manufacture scalar constants (rare in practice but possible)
-    // would otherwise be invoked needlessly.
-    left = evaluate<EvalTrace>(node.left(), le, cache);
-    SEQUANT_ASSERT(left);
-    std::array<std::any, 2> const adj_ann{node.left()->annot(), node->annot()};
-    time =
-        detail::timed_eval_inplace([&]() { result = left->adjoint(adj_ann); });
-  } else {
-    left = evaluate<EvalTrace>(node.left(), le, cache);
-    right = evaluate<EvalTrace>(node.right(), le, cache);
-    SEQUANT_ASSERT(left);
-    SEQUANT_ASSERT(right);
-
-    std::array<std::any, 3> const ann{node.left()->annot(),
-                                      node.right()->annot(), node->annot()};
-    if (node->op_type() == EvalOp::Sum) {
-      time = detail::timed_eval_inplace(
-          [&]() { result = left->sum(*right, ann); });
-    } else {
-      SEQUANT_ASSERT(node->op_type() == EvalOp::Product);
-      // Consult the shaped-product hook (if set) before evaluating the product.
-      // The hook receives the node (wrapped in a std::any as a
-      // std::reference_wrapper so the full IR node is inspectable) plus the
-      // evaluated operands and annotations; a non-null return *replaces* the
-      // normal product (e.g. a shape-constrained emission of it), a null return
-      // declines and the standard prod() below runs.  An empty hook is never
-      // consulted; default-empty => byte-identical behavior.
-      auto const de_nest =
-          node.left()->tot() && node.right()->tot() && !node->tot();
-      if (auto const& hook = cache.shaped_product_hook(); hook) {
-        time = detail::timed_eval_inplace([&]() {
-          result = hook(std::any{std::cref(node)}, *left, *right, ann);
-        });
-      }
-      if (!result) {
-        time = detail::timed_eval_inplace([&]() {
-          result =
-              left->prod(*right, ann, de_nest ? DeNest::True : DeNest::False);
-        });
-      }
-    }
-  }
-
-  SEQUANT_ASSERT(result);
-
-  // logging
-  if constexpr (detail::trace(EvalTrace)) {
-    if (node.leaf()) {
-      log::eval(log::EvalStat{.mode = log::eval_mode(node),
-                              .time = time,
-                              .mem_result = log::bytes(result),
-                              .mem_alloc = log::bytes(result),
-                              .mem_hwmark = {cache.note_working_set(
-                                  log::bytes(cache, result).value)}},
-                log::label(node));
-    } else {
-      // A cached child is *distinct* from the local left/right when its
-      // canon_phase != 1, because mult_by_phase allocates a fresh buffer
-      // while the cache still holds the pre-phase data. So only skip the
-      // local's bytes when the cache aliases the same buffer (phase == 1).
-      // Adjoint nodes evaluate only the left operand (the right child is the
-      // sentinel Constant(1) — see the Adjoint branch above), so `right` is
-      // null; log::bytes() tolerates a null shared_ptr for that reason.
-      size_t hwmark = log::bytes(cache, result).value;
-      if (!cache.alive(node.left()) || node.left()->canon_phase() != 1)
-        hwmark += log::bytes(left).value;
-      if (right &&
-          (!cache.alive(node.right()) || node.right()->canon_phase() != 1))
-        hwmark += log::bytes(right).value;
-      log::eval(log::EvalStat{.mode = log::eval_mode(node),
-                              .time = time,
-                              .mem_result = log::bytes(result),
-                              .mem_alloc = log::bytes(result),
-                              .mem_hwmark = {cache.note_working_set(hwmark)},
-                              .mem_left = log::bytes(left),
-                              .mem_right = log::bytes(right)},
-                log::label(node));
-    }
-  }
-
-  return result;
+  return ret;
 }
 
 ///

--- a/tests/unit/test_binary_node.cpp
+++ b/tests/unit/test_binary_node.cpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <range/v3/view/all.hpp>
 #include <range/v3/view/iota.hpp>
@@ -345,4 +346,48 @@ TEST_CASE("binary_node", "[FullBinaryNode]") {
       str2.clear();
     }
   }
+}
+
+// Deep-tree operations must not recurse to the tree's depth: deep_copy,
+// transform_node, and the destructor are all iterative, so a chain thousands of
+// nodes deep -- which overflowed the pre-refactor recursive versions at depth
+// ~thousands (default ~8 MB stack) -- is handled by the heap instead. Built
+// iteratively (O(N) moves) with int data so the test stays cheap. visit() is
+// used to read the tree because it is an iterative (parent-pointer) walk;
+// size()/operator== are still recursive and would themselves overflow here.
+TEST_CASE("FullBinaryNode deep-tree ops are stack-safe",
+          "[FullBinaryNode][stack-safety]") {
+  using sequant::FullBinaryNode;
+  using sequant::transform_node;
+
+  constexpr int N = 200000;
+  FullBinaryNode<int> node{0};
+  for (int k = 1; k < N; ++k)
+    node = FullBinaryNode<int>{k, std::move(node), FullBinaryNode<int>{-k}};
+  // depth-N left-deep chain: root value N-1, leftmost leaf value 0; each
+  // internal node k has a right leaf -k. Node count = (N-1) internal + N
+  // leaves.
+
+  auto values = [](auto const& root) {
+    std::vector<std::decay_t<decltype(*root)>> v;
+    root.visit([&v](auto const& n) { v.push_back(*n); });
+    return v;
+  };
+
+  auto const orig = values(node);
+  REQUIRE(orig.size() == static_cast<std::size_t>(2 * N - 1));
+
+  // Copy ctor -> iterative deep_copy (would have overflowed).
+  FullBinaryNode<int> const copy = node;
+  CHECK(values(copy) == orig);
+
+  // transform_node -> iterative (would have overflowed).
+  auto const doubled =
+      transform_node(node, [](int v) { return static_cast<long>(2 * v); });
+  std::vector<long> expected;
+  expected.reserve(orig.size());
+  for (int v : orig) expected.push_back(2L * v);
+  CHECK(values(doubled) == expected);
+
+  // node, copy, doubled are destroyed here via the iterative destructor.
 }

--- a/tests/unit/test_eval_tapp.cpp
+++ b/tests/unit/test_eval_tapp.cpp
@@ -509,3 +509,59 @@ TEST_CASE("eval_adjoint_complex_tapp", "[eval_tapp]") {
       CHECK(got.imag() == Catch::Approx(expected.imag()).margin(1e-12));
     }
 }
+
+// Custom-evaluator interception (the pruning mechanism batched eval relies on),
+// exercised on the plain non-batched code path: evaluate() must consult the
+// cache's custom evaluator on each non-leaf node before its standard scheme,
+// and a non-null return must short-circuit the subtree -- its children are
+// never evaluated. The iterative traversal must preserve this exactly.
+TEST_CASE("evaluate consults the custom evaluator and short-circuits",
+          "[eval_tapp][custom-evaluator]") {
+  using namespace sequant;
+
+  std::srand(2023);
+  const size_t nocc = 2, nvirt = 20;
+  auto yield_ = rand_tensor_yield<TAPPTensorD>{nocc, nvirt};
+
+  // A two-tensor product binarizes to a single non-leaf (Product) root with two
+  // tensor leaves.
+  auto node = eval_node(deserialize(L"g_{i1,i2}^{a1,a2} * t_{a1,a2}^{i1,i2}",
+                                    {.def_perm_symm = Symmetry::Antisymm}));
+  REQUIRE_FALSE(node.leaf());
+
+  // Leaf evaluator that counts how many leaves get evaluated.
+  size_t leaf_calls = 0;
+  auto counting_leaf = [&](auto const& n) -> ResultPtr {
+    ++leaf_calls;
+    return yield_(n);
+  };
+
+  SECTION("non-null result short-circuits: children are never evaluated") {
+    auto cache = cache_manager(std::vector{node});
+    size_t intercept_calls = 0;
+    ResultPtr const marker = eval_result<ResultScalar<double>>(42.0);
+    cache.set_custom_evaluator([&](auto const&, auto&) -> ResultPtr {
+      ++intercept_calls;
+      return marker;  // "I evaluated this subtree myself"
+    });
+
+    auto const result = evaluate(node, counting_leaf, cache);
+    CHECK(intercept_calls == 1);  // consulted once, on the only non-leaf (root)
+    CHECK(leaf_calls == 0);       // children never descended into
+    CHECK(result == marker);      // the custom result is used as-is
+  }
+
+  SECTION("null result declines: the standard scheme evaluates the children") {
+    auto cache = cache_manager(std::vector{node});
+    size_t decline_calls = 0;
+    cache.set_custom_evaluator([&](auto const&, auto&) -> ResultPtr {
+      ++decline_calls;
+      return nullptr;  // decline
+    });
+
+    auto const result = evaluate(node, counting_leaf, cache);
+    CHECK(decline_calls == 1);  // consulted once on the root (non-leaf)
+    CHECK(leaf_calls == 2);     // both tensor leaves evaluated
+    REQUIRE(result);
+  }
+}


### PR DESCRIPTION
Squash the code-recursive tree traversals in the eval layer so evaluation of a deep tree (a long contraction chain, or a nested Sum) is bounded by the heap rather than the C++ call stack. Previously such a tree overflowed the stack at depth ~thousands -- in the `evaluate()` walk, and (before evaluation even ran) in `FullBinaryNode`'s copy/transform/destroy.

### `binary_node`: `deep_copy`, `transform_node`, and the destructor iterative
`FullBinaryNode` owns its children by `unique_ptr`, so the implicit destructor recursed to the tree's depth; `deep_copy()` and the free function `transform_node()` likewise recursed.

- `~FullBinaryNode()` dismantles the subtree via a work list, detaching each node's children before it is destroyed, so every node destruction is O(1).
- `deep_copy()` and `transform_node()` do an iterative post-order build with an explicit frame stack (`std::deque`, so a top-frame reference survives `push_back`). `transform_node` applies its data map post-order; as a pure map its order is immaterial, and its only callers (typed `binarize<T>` and the TA `to_ta_node` helper) are order-insensitive.

The tree fold (`fold_left_to_node` / the range-accumulate ctor) and the tree visitors (`detail::visit`, parent-pointer based) were already iterative. `size()`, `operator==`, and `digraph`/`tikz` remain recursive but are not on the build/eval/destroy path.

### `eval`: the core `evaluate()` traversal iterative
The core `evaluate(node, le, cache)` -- the only overload with unbounded recursion (the layout/multi-root overloads just wrap or loop over it) -- now walks with an explicit `std::deque` work stack. The per-node cache key is `EvalExpr`'s stored O(1) hash, so nothing in the walk recurses.

Behavior is preserved:
- Checked cache wrapper: a hit returns the phase-applied cached pointer; a miss on a mapped node schedules a store once computed (a `store_after` flag replaces the recursive `evaluate<..., Unchecked>` re-entry).
- Custom-evaluator interception is consulted when a frame is first visited, and a non-null result short-circuits the subtree (children never pushed) -- the subtree pruning custom evaluators rely on is unchanged.
- leaf / Adjoint / Sum / Product dispatch, the shaped-product hook, de-nesting, canonicalization-phase multiplication, and every trace log site carry over unchanged.

### Tests
- `[FullBinaryNode][stack-safety]`: build, copy, `transform_node`, and destroy a depth-200000 tree (all O(N)); pre-refactor this overflowed the stack.
- `[eval_tapp][custom-evaluator]`: pins the interception contract on the plain (non-batched) path -- a non-null custom result short-circuits the subtree (leaves never evaluated), a null result declines to the standard scheme.