### PR TITLE
Outer-product (disconnected-subgraph) pruning of the single-term DP

### DIFF
--- a/SeQuant/core/optimize/cost_model.hpp
+++ b/SeQuant/core/optimize/cost_model.hpp
@@ -24,17 +24,19 @@ template <class Model, typename TIdxs>
 container::vector<typename Model::State> solve_single_term(
     Model const& m, TensorNetwork const& network, TIdxs const& tidxs,
     typename Model::Context& ctx) {
-  (void)tidxs;
   auto const nt = network.tensors().size();
   container::vector<typename Model::State> st(size_t{1} << nt);
+  auto const connected = outer_product_connectivity(network, tidxs);
   for (size_t n = 1; n < st.size(); ++n) {
     if (std::popcount(n) == 1) {
       st[n] = m.leaf(ctx, n);
       continue;
     }
+    if (!connected[n]) continue;  // never form a disconnected subset
     typename Model::State acc = m.init(ctx, n);
     for (auto&& [lp, rp] : bits::bipartitions(n))
-      if (lp != 0 && rp != 0) m.relax(ctx, n, lp, rp, st[lp], st[rp], acc);
+      if (lp != 0 && rp != 0 && connected[lp] && connected[rp])
+        m.relax(ctx, n, lp, rp, st[lp], st[rp], acc);
     st[n] = std::move(acc);
     m.finalize(ctx, n, st);
   }
@@ -105,7 +107,8 @@ struct AdditiveModel {
     ctx.results.resize(size_t{1} << network.tensors().size());
     init_results(network, tidxs, ctx.results);
     if (subnet_cse) {
-      auto md = build_subnet_metadata(network, ctx.results);
+      auto connected = outer_product_connectivity(network, tidxs);
+      auto md = build_subnet_metadata(network, ctx.results, connected);
       ctx.meta_ids = std::move(md.meta_ids);
       ctx.unique_meta_costs = std::move(md.unique_meta_costs);
     }
@@ -202,6 +205,13 @@ struct AdditiveModel {
       if (pc == 1) {
         seq[n].emplace_back(std::countr_zero(n));
       } else if (pc >= 2) {
+        // Pruned (outer-product) subsets are never relaxed, so lp/rp stay at
+        // their default 0/0 sentinel (bits::bipartitions guarantees a real
+        // split always assigns both nonzero together); skip them here too --
+        // they are never referenced as a child by a subset actually on the
+        // reconstructed path, since solve_single_term only relaxes into a
+        // parent through children that are themselves connected.
+        if (st[n].lp == 0 && st[n].rp == 0) continue;
         auto const& lseq = seq[st[n].lp];
         auto const& rseq = seq[st[n].rp];
         seq[n] = (lseq[0] < rseq[0] ? concat(lseq, rseq) : concat(rseq, lseq)) |

--- a/SeQuant/core/optimize/cost_model.hpp
+++ b/SeQuant/core/optimize/cost_model.hpp
@@ -26,7 +26,8 @@ container::vector<typename Model::State> solve_single_term(
     typename Model::Context& ctx) {
   auto const nt = network.tensors().size();
   container::vector<typename Model::State> st(size_t{1} << nt);
-  auto const connected = outer_product_connectivity(network, tidxs);
+  auto const connected =
+      outer_product_connectivity(network, tidxs, m.prune_outer_products);
   for (size_t n = 1; n < st.size(); ++n) {
     if (std::popcount(n) == 1) {
       st[n] = m.leaf(ctx, n);
@@ -80,6 +81,9 @@ struct AdditiveModel {
   double volatile_weight;
   double footprint_weight;
   bool subnet_cse;
+  /// Prune disconnected (outer-product) subsets from the DP (see
+  /// OptimizeOptions::prune_outer_products). Default true.
+  bool prune_outer_products = true;
 
   /// Per-subset DP cell: the relevant OptRes fields the additive DP mutates.
   struct State {
@@ -107,7 +111,8 @@ struct AdditiveModel {
     ctx.results.resize(size_t{1} << network.tensors().size());
     init_results(network, tidxs, ctx.results);
     if (subnet_cse) {
-      auto connected = outer_product_connectivity(network, tidxs);
+      auto connected =
+          outer_product_connectivity(network, tidxs, prune_outer_products);
       auto md = build_subnet_metadata(network, ctx.results, connected);
       ctx.meta_ids = std::move(md.meta_ids);
       ctx.unique_meta_costs = std::move(md.unique_meta_costs);
@@ -305,6 +310,9 @@ struct PeakModel {
   /// peak increase for a potentially large flop reduction (e.g. forming a
   /// persistent 4-PNO integral instead of recomputing a ladder).
   double peak_flops_tolerance = 0.0;
+  /// Prune disconnected (outer-product) subsets from the DP (see
+  /// OptimizeOptions::prune_outer_products). Default true.
+  bool prune_outer_products = true;
 
   /// One non-dominated (peak, flops) trade-off for a subset, with the
   /// bipartition / order / child-frontier-indices needed to reconstruct it.
@@ -494,6 +502,9 @@ struct PeakBatchedModel {
   /// batchable index (Ap != 0), into the all-co-resident peak term, to price
   /// the accumulator + contribution co-residency of K += contribution.
   double accumulation_factor = 0.0;
+  /// Prune disconnected (outer-product) subsets from the DP (see
+  /// OptimizeOptions::prune_outer_products). Default true.
+  bool prune_outer_products = true;
 
   /// One non-dominated (peak, flops) trade-off for a (subset, sliced-set \c B)
   /// cell. \c aprime is the sliced-set chosen at this node; the children are

--- a/SeQuant/core/optimize/cost_model.hpp
+++ b/SeQuant/core/optimize/cost_model.hpp
@@ -109,10 +109,12 @@ struct AdditiveModel {
                         TIdxs const& tidxs) const {
     Context ctx;
     ctx.results.resize(size_t{1} << network.tensors().size());
-    init_results(network, tidxs, ctx.results);
+    // Outer-product pruning: skip building index sets for disconnected subsets
+    // the DP will never form (solve_single_term also skips them).
+    auto const connected =
+        outer_product_connectivity(network, tidxs, prune_outer_products);
+    init_results(network, tidxs, ctx.results, &connected);
     if (subnet_cse) {
-      auto connected =
-          outer_product_connectivity(network, tidxs, prune_outer_products);
       auto md = build_subnet_metadata(network, ctx.results, connected);
       ctx.meta_ids = std::move(md.meta_ids);
       ctx.unique_meta_costs = std::move(md.unique_meta_costs);
@@ -363,12 +365,16 @@ struct PeakModel {
     auto const nt = network.tensors().size();
     auto const sz = size_t{1} << nt;
     container::vector<OptRes> results(sz);
-    init_results(network, tidxs, results);
+    // Outer-product pruning: skip building tables for disconnected subsets the
+    // DP will never form (solve_single_term also skips them).
+    auto const connected =
+        outer_product_connectivity(network, tidxs, prune_outer_products);
+    init_results(network, tidxs, results, &connected);
     auto fp = footprint_counter(idxsz, inner_pow);
     ctx.S.assign(sz, 0.0);
     ctx.idx.resize(sz);
     for (size_t n = 0; n < sz; ++n) {
-      ctx.S[n] = (n == 0) ? 0.0 : fp(results[n].indices);
+      ctx.S[n] = (n == 0 || !connected[n]) ? 0.0 : fp(results[n].indices);
       ctx.idx[n] = std::move(results[n].indices);
     }
     ctx.L.assign(sz, 0.0);
@@ -580,8 +586,17 @@ struct PeakBatchedModel {
         "DensePeakSizeBatched: accumulation_factor != 0 requires at most one "
         "batchable index");
     ctx.nB = std::size_t{1} << ctx.m;
+    // Outer-product pruning: skip building tables for disconnected subsets the
+    // DP will never form (solve_single_term also skips them). connected[n]==1
+    // for singletons/empty and for connected subsets; the (~2x connected)
+    // needed-mask is derived internally where a complement lookup requires it.
+    auto const connected =
+        outer_product_connectivity(network, tidxs, prune_outer_products);
     ctx.tables = sliced_footprints(network, tidxs, idxsz, is_batchable, batch,
-                                   ctx.aux, inner_pow);
+                                   ctx.aux, inner_pow, &connected);
+    // open_aux is NOT pruned: is_spectator_axis scans open_aux over the FULL
+    // subset lattice (including disconnected subsets) to verify an axis is
+    // never contracted, so every subset's open-axis bitmask must be real.
     ctx.open_aux = subset_open_aux(network, tidxs, ctx.aux);
     ctx.volatile_mask = leaf_volatile_mask(network, is_volatile_leaf);
     // Per-subset open indices + a flop counter, for the lexicographic
@@ -590,7 +605,7 @@ struct PeakBatchedModel {
     // it (work parity), so it consistently orders equal-peak schedules.
     auto const sz = std::size_t{1} << ctx.nt;
     container::vector<OptRes> results(sz);
-    init_results(network, tidxs, results);
+    init_results(network, tidxs, results, &connected);
     ctx.idx.resize(sz);
     for (std::size_t n = 0; n < sz; ++n)
       ctx.idx[n] = std::move(results[n].indices);

--- a/SeQuant/core/optimize/cost_model.hpp
+++ b/SeQuant/core/optimize/cost_model.hpp
@@ -9,8 +9,11 @@
 #include <bit>
 #include <cmath>
 #include <concepts>
+#include <cstdint>
 #include <functional>
 #include <limits>
+#include <map>
+#include <set>
 #include <utility>
 
 namespace sequant::opt::detail {
@@ -552,8 +555,87 @@ struct PeakBatchedModel {
     /// idx[n] = subset n's open (result) indices, for the flop tie-break.
     container::vector<IndexSet> idx;
     /// flops_of(lhs, rhs, result) = flop count of one binary contraction.
+    /// Retained as the reference for the fast_flops parity test; the relax
+    /// hot loop uses fast_flops (see below).
     std::function<double(IndexSet const&, IndexSet const&, IndexSet const&)>
         flops_of;
+
+    // --- fast per-subset flop precompute (relax tie-break hot path) ---
+    // Per subset, sorted (FullLabelCompare-ordered) atom IDs: outer atoms are
+    // the plain indices + the proto-indices of composites; inner atoms are the
+    // composites themselves -- exactly tot_indices()'s outer/inner split. IDs
+    // are assigned in FullLabelCompare order so the union merge multiplies in
+    // the SAME order as inner_aware_volume, giving a bit-identical result.
+    // fast_flops(lp, rp) == flops_of(idx[lp], idx[rp], idx[lp|rp]) by
+    // construction (gated by the [fast-flops-parity] test). use_fast_flops is
+    // false only in that test, to exercise the flops_of reference path.
+    bool use_fast_flops = true;
+    container::vector<container::svector<std::uint32_t>> f_outer;
+    container::vector<container::svector<std::uint32_t>> f_inner;
+    container::vector<double> fo_ext;         // outer atom -> extent
+    container::vector<double> fi_ext;         // inner atom -> extent (fallback)
+    container::vector<Index> fi_index;        // inner atom -> composite Index
+    container::vector<std::uint32_t> fi_grp;  // inner atom -> proto-group id
+    bool f_inner_engaged = false;
+    std::function<double(Index const&, std::size_t)> f_inner_pow;
+    mutable container::vector<std::uint32_t> f_grpcount;   // scratch (ngrp)
+    mutable container::svector<std::uint32_t> f_union_in;  // scratch
+
+    /// Flop count of the binary contraction (subset \c lp) x (subset \c rp),
+    /// equivalent to flops_of(idx[lp], idx[rp], idx[n]) with n = lp|rp, but
+    /// reading precomputed atom-ID lists instead of rebuilding index sets per
+    /// call. (idx[n] is a subset of idx[lp] U idx[rp], so it adds nothing.)
+    double fast_flops(std::size_t lp, std::size_t rp) const {
+      double mem = 1.0;
+      {
+        auto const& A = f_outer[lp];
+        auto const& B = f_outer[rp];
+        std::size_t i = 0, j = 0;
+        while (i < A.size() && j < B.size()) {
+          if (A[i] < B[j])
+            mem *= fo_ext[A[i++]];
+          else if (B[j] < A[i])
+            mem *= fo_ext[B[j++]];
+          else {
+            mem *= fo_ext[A[i]];
+            ++i;
+            ++j;
+          }
+        }
+        while (i < A.size()) mem *= fo_ext[A[i++]];
+        while (j < B.size()) mem *= fo_ext[B[j++]];
+      }
+      auto const& AI = f_inner[lp];
+      auto const& BI = f_inner[rp];
+      if (!AI.empty() || !BI.empty()) {
+        f_union_in.clear();
+        std::size_t i = 0, j = 0;
+        while (i < AI.size() && j < BI.size()) {
+          std::uint32_t id;
+          if (AI[i] < BI[j])
+            id = AI[i++];
+          else if (BI[j] < AI[i])
+            id = BI[j++];
+          else {
+            id = AI[i];
+            ++i;
+            ++j;
+          }
+          f_union_in.push_back(id);
+        }
+        while (i < AI.size()) f_union_in.push_back(AI[i++]);
+        while (j < BI.size()) f_union_in.push_back(BI[j++]);
+        if (f_inner_engaged) {
+          for (auto id : f_union_in) ++f_grpcount[fi_grp[id]];
+          for (auto id : f_union_in)
+            mem *= f_inner_pow(fi_index[id], f_grpcount[fi_grp[id]]);
+          for (auto id : f_union_in) f_grpcount[fi_grp[id]] = 0;
+        } else {
+          for (auto id : f_union_in) mem *= fi_ext[id];
+        }
+      }
+      return mem == 1.0 ? 0.0 : mem;
+    }
 
     /// Context-restricted size of subset s under sliced-set ctx (the table is
     /// indexed by the part of ctx actually open in s; mirrors the oracle).
@@ -612,6 +694,69 @@ struct PeakBatchedModel {
     ctx.flops_of = [c = flops_counter(idxsz, inner_pow)](
                        IndexSet const& lhs, IndexSet const& rhs,
                        IndexSet const& result) { return c(lhs, rhs, result); };
+
+    // Fast-flops atom tables (see Context::fast_flops). Atom IDs are assigned
+    // in FullLabelCompare order so the union-merge multiply order matches
+    // inner_aware_volume exactly (bit-identical flops). Disconnected subsets
+    // have empty ctx.idx (pruned) and contribute no atoms; fast_flops is only
+    // ever called for connected bipartitions.
+    {
+      std::set<Index, Index::FullLabelCompare> outer_atoms, inner_atoms;
+      for (std::size_t n = 0; n < sz; ++n)
+        for (auto const& ix : ctx.idx[n]) {
+          if (ix.has_proto_indices()) {
+            inner_atoms.insert(ix);
+            for (auto const& p : ix.proto_indices()) outer_atoms.insert(p);
+          } else {
+            outer_atoms.insert(ix);
+          }
+        }
+      std::map<Index, std::uint32_t, Index::FullLabelCompare> oid, iid;
+      ctx.fo_ext.reserve(outer_atoms.size());
+      for (auto const& a : outer_atoms) {
+        oid.emplace(a, static_cast<std::uint32_t>(ctx.fo_ext.size()));
+        ctx.fo_ext.push_back(static_cast<double>(idxsz(a)));
+      }
+      std::map<std::wstring, std::uint32_t> gid;  // proto-signature -> group id
+      ctx.fi_ext.reserve(inner_atoms.size());
+      for (auto const& c : inner_atoms) {
+        iid.emplace(c, static_cast<std::uint32_t>(ctx.fi_index.size()));
+        ctx.fi_index.push_back(c);
+        ctx.fi_ext.push_back(static_cast<double>(idxsz(c)));
+        std::wstring sig;
+        for (auto const& p : c.proto_indices()) {
+          sig += p.full_label();
+          sig += L',';
+        }
+        auto it = gid.find(sig);
+        ctx.fi_grp.push_back(
+            it != gid.end()
+                ? it->second
+                : gid.emplace(sig, static_cast<std::uint32_t>(gid.size()))
+                      .first->second);
+      }
+      ctx.f_grpcount.assign(gid.size(), 0);
+      ctx.f_outer.resize(sz);
+      ctx.f_inner.resize(sz);
+      for (std::size_t n = 0; n < sz; ++n) {
+        auto& oo = ctx.f_outer[n];
+        auto& ii = ctx.f_inner[n];
+        for (auto const& ix : ctx.idx[n]) {
+          if (ix.has_proto_indices()) {
+            ii.push_back(iid.at(ix));
+            for (auto const& p : ix.proto_indices()) oo.push_back(oid.at(p));
+          } else {
+            oo.push_back(oid.at(ix));
+          }
+        }
+        std::sort(oo.begin(), oo.end());
+        oo.erase(std::unique(oo.begin(), oo.end()), oo.end());
+        std::sort(ii.begin(), ii.end());
+        ii.erase(std::unique(ii.begin(), ii.end()), ii.end());
+      }
+      ctx.f_inner_engaged = option_engaged(inner_pow);
+      ctx.f_inner_pow = inner_pow;
+    }
     return ctx;
   }
 
@@ -634,10 +779,12 @@ struct PeakBatchedModel {
     // reduces peak (primary axis), not total work. machine_balance==0 => flops.
     double const w = (ctx.volatile_mask & n) ? volatile_weight : 1.0;
     double const cflops =
-        w * roofline_op_cost(ctx.flops_of(ctx.idx[lp], ctx.idx[rp], ctx.idx[n]),
-                             ctx.sz(lp, 0) + ctx.sz(rp, 0) + ctx.sz(n, 0),
-                             machine_balance, fast_mem_elems, block_tiles,
-                             block_prefactor);
+        w * roofline_op_cost(
+                ctx.use_fast_flops
+                    ? ctx.fast_flops(lp, rp)
+                    : ctx.flops_of(ctx.idx[lp], ctx.idx[rp], ctx.idx[n]),
+                ctx.sz(lp, 0) + ctx.sz(rp, 0) + ctx.sz(n, 0), machine_balance,
+                fast_mem_elems, block_tiles, block_prefactor);
     for (std::size_t B = 0; B < ctx.nB; ++B) {
       // Batchable indices contracted at THIS node: open at children but not at
       // the parent. By default batching is applied ACROSS THE BOARD: slicing

--- a/SeQuant/core/optimize/optimize.cpp
+++ b/SeQuant/core/optimize/optimize.cpp
@@ -92,7 +92,8 @@ ExprPtr opt_pure_product(Product const& prod, OptimizeOptions const& opts) {
                         opts.footprint_weight,
                         opts.peak_flops_tolerance,
                         opts.roofline,
-                        opts.batch_policy.accumulation_factor};
+                        opts.batch_policy.accumulation_factor,
+                        opts.prune_outer_products};
   auto run = [&]() -> ExprPtr {
     if (opts.objective_function == ObjectiveFunction::DenseFLOPs)
       return opt::single_term_opt<ObjectiveFunction::DenseFLOPs>(

--- a/SeQuant/core/optimize/options.hpp
+++ b/SeQuant/core/optimize/options.hpp
@@ -105,6 +105,9 @@ struct CostParams {
   /// DensePeakSizeBatched; see BatchPolicy::accumulation_factor. 0 (default) =
   /// no penalty.
   double accumulation_factor = 0.0;
+  /// Prune disconnected (outer-product) subsets from the single-term DP; see
+  /// OptimizeOptions::prune_outer_products. true (default) = prune.
+  bool prune_outer_products = true;
 };
 
 /// A type-erased provider mapping an Index to its extent. Used by the public
@@ -206,6 +209,16 @@ struct OptimizeOptions {
   /// tie-break (no behavior change). Consulted only by DensePeakSize /
   /// DensePeakSizeBatched.
   RooflineParams roofline = {};
+
+  /// Prune disconnected (outer-product) subsets from the single-term
+  /// contraction DP: a subset whose induced subgraph is disconnected under the
+  /// "share a contractible (non-target) index" relation is an outer product the
+  /// optimal tree never forms, so skipping it prunes search space without
+  /// changing the result. \c true (default) prunes; \c false searches the full
+  /// (unpruned) space and is exposed mainly for validation. (The environment
+  /// variable \c SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING force-disables pruning
+  /// regardless of this flag.)
+  bool prune_outer_products = true;
 };
 
 }  // namespace sequant

--- a/SeQuant/core/optimize/single_term.hpp
+++ b/SeQuant/core/optimize/single_term.hpp
@@ -72,6 +72,7 @@ EvalSequence single_term_opt(
   double const peak_flops_tolerance = cost.peak_flops_tolerance;
   double const accumulation_factor = cost.accumulation_factor;
   RooflineParams const& roofline = cost.roofline;
+  bool const prune_outer_products = cost.prune_outer_products;
   (void)is_volatile_leaf;
   (void)volatile_weight;
   (void)footprint_weight;
@@ -94,12 +95,17 @@ EvalSequence single_term_opt(
     (void)footprint_weight;  // peak objectives use the roofline tie-break
     // is_volatile_leaf / volatile_weight / roofline feed only the secondary
     // tie-break among equal-peak schedules (peak itself ignores them).
-    return run_single_term_opt(
-        PeakModel{idxsz, inner_pow, is_volatile_leaf, volatile_weight,
-                  roofline.machine_balance, roofline.fast_mem_elems,
-                  roofline.block_tiles, roofline.block_prefactor,
-                  peak_flops_tolerance},
-        network, tidxs);
+    PeakModel model{idxsz,
+                    inner_pow,
+                    is_volatile_leaf,
+                    volatile_weight,
+                    roofline.machine_balance,
+                    roofline.fast_mem_elems,
+                    roofline.block_tiles,
+                    roofline.block_prefactor,
+                    peak_flops_tolerance};
+    model.prune_outer_products = prune_outer_products;
+    return run_single_term_opt(model, network, tidxs);
   } else if constexpr (Metric == ObjectiveFunction::DensePeakSizeBatched) {
     SEQUANT_ASSERT(
         !subnet_cse &&
@@ -107,14 +113,21 @@ EvalSequence single_term_opt(
     (void)footprint_weight;  // peak objectives use the roofline tie-break
     // is_volatile_leaf gates batching; volatile_weight / roofline feed the
     // secondary tie-break among equal-peak schedules.
-    return run_single_term_opt(
-        PeakBatchedModel{idxsz, is_batchable_index, batch_target_size,
-                         is_volatile_leaf, inner_pow, volatile_weight,
-                         roofline.machine_balance, roofline.fast_mem_elems,
-                         roofline.block_tiles, roofline.block_prefactor,
-                         batch_persistent_only, peak_flops_tolerance,
-                         accumulation_factor},
-        network, tidxs);
+    PeakBatchedModel model{idxsz,
+                           is_batchable_index,
+                           batch_target_size,
+                           is_volatile_leaf,
+                           inner_pow,
+                           volatile_weight,
+                           roofline.machine_balance,
+                           roofline.fast_mem_elems,
+                           roofline.block_tiles,
+                           roofline.block_prefactor,
+                           batch_persistent_only,
+                           peak_flops_tolerance,
+                           accumulation_factor};
+    model.prune_outer_products = prune_outer_products;
+    return run_single_term_opt(model, network, tidxs);
   } else if constexpr (Metric == ObjectiveFunction::DenseFLOPs) {
     if (is_volatile_leaf && volatile_weight > 1.0) {
       size_t i = 0;
@@ -135,6 +148,7 @@ EvalSequence single_term_opt(
                         nr,
                         footprint_weight,
                         subnet_cse};
+    model.prune_outer_products = prune_outer_products;
     return run_single_term_opt(model, network, tidxs);
   } else {
     static_assert(Metric == ObjectiveFunction::DenseSize,
@@ -150,6 +164,7 @@ EvalSequence single_term_opt(
                         nr,
                         footprint_weight,
                         subnet_cse};
+    model.prune_outer_products = prune_outer_products;
     return run_single_term_opt(model, network, tidxs);
   }
 }

--- a/SeQuant/core/optimize/single_term_detail.hpp
+++ b/SeQuant/core/optimize/single_term_detail.hpp
@@ -453,17 +453,19 @@ inline container::vector<char> connected_subsets(
 
 /// \brief Outer-product pruning mask for a term. Returns \ref
 /// connected_subsets over \ref contractible_adjacency, EXCEPT it returns an
-/// all-connected mask when pruning is disabled (env
-/// `SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING`) or when the full network is
-/// itself disconnected (a genuine product term -- never a CC residual
-/// summand, by the linked-cluster theorem). Callers then apply one uniform
-/// `if (!mask[n]) skip` test and get unpruned behavior in both those cases.
+/// all-connected mask when pruning is disabled (\p prune == false, or the env
+/// `SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING` force-override) or when the full
+/// network is itself disconnected (a genuine product term -- never a CC
+/// residual summand, by the linked-cluster theorem). Callers then apply one
+/// uniform `if (!mask[n]) skip` test and get unpruned behavior in those cases.
+/// \param prune Whether to prune (OptimizeOptions::prune_outer_products). When
+///        false, the returned mask is all-connected (unpruned DP).
 template <typename TIdxs>
 inline container::vector<char> outer_product_connectivity(
-    TensorNetwork const& network, TIdxs const& tidxs) {
+    TensorNetwork const& network, TIdxs const& tidxs, bool prune = true) {
   std::size_t const nt = network.tensors().size();
   std::size_t const sz = std::size_t{1} << nt;
-  if (std::getenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING"))
+  if (!prune || std::getenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING"))
     return container::vector<char>(sz, 1);
   auto mask = connected_subsets(contractible_adjacency(network, tidxs), nt);
   if (!mask.empty() && !mask.back())  // full network disconnected: disable

--- a/SeQuant/core/optimize/single_term_detail.hpp
+++ b/SeQuant/core/optimize/single_term_detail.hpp
@@ -414,8 +414,14 @@ inline container::vector<std::size_t> contractible_adjacency(
   container::map<Index, std::size_t, Index::FullLabelCompare> carriers;
   std::size_t i = 0;
   for (auto&& t : network.tensors()) {
-    auto tp = std::dynamic_pointer_cast<Tensor>(t);
-    for (auto&& ix : ranges::views::concat(tp->bra(), tp->ket(), tp->aux())) {
+    // Iterate the abstract-tensor slots (bra/ket/aux) directly rather than
+    // casting to Tensor: TensorNetwork stores AbstractTensorPtr (not
+    // necessarily Tensor), and slot bundles may carry null (empty) placeholder
+    // indices -- a null carrier would be shared across every tensor with an
+    // empty slot and create a spurious edge that needlessly disables pruning.
+    // Mirrors init_results, which also enumerates indices via slots().
+    for (auto&& ix : slots(*t)) {
+      if (!ix.nonnull()) continue;                // skip empty slots
       if (ranges::contains(tidxs, ix)) continue;  // target/output: not summed
       carriers[ix] |= (std::size_t{1} << i);
     }

--- a/SeQuant/core/optimize/single_term_detail.hpp
+++ b/SeQuant/core/optimize/single_term_detail.hpp
@@ -422,6 +422,55 @@ inline container::vector<std::size_t> contractible_adjacency(
   return adj;
 }
 
+/// \brief `connected[n] == 1` iff the subgraph induced on the set bits of
+/// subset mask `n` is connected under `adjacency` (from \ref
+/// contractible_adjacency). Empty and singleton subsets are connected by
+/// definition. Size `1 << nt`.
+inline container::vector<char> connected_subsets(
+    container::vector<std::size_t> const& adjacency, std::size_t nt) {
+  container::vector<char> connected(std::size_t{1} << nt, 0);
+  for (std::size_t n = 0; n < connected.size(); ++n) {
+    if (std::popcount(n) <= 1) {
+      connected[n] = 1;
+      continue;
+    }
+    std::size_t const start = n & (~n + 1);  // lowest set bit
+    std::size_t reached = start, frontier = start;
+    while (frontier) {
+      std::size_t next = 0, f = frontier;
+      while (f) {
+        next |= adjacency[static_cast<std::size_t>(std::countr_zero(f))];
+        f &= f - 1;
+      }
+      next &= n & ~reached;
+      reached |= next;
+      frontier = next;
+    }
+    connected[n] = (reached == n) ? 1 : 0;
+  }
+  return connected;
+}
+
+/// \brief Outer-product pruning mask for a term. Returns \ref
+/// connected_subsets over \ref contractible_adjacency, EXCEPT it returns an
+/// all-connected mask when pruning is disabled (env
+/// `SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING`) or when the full network is
+/// itself disconnected (a genuine product term -- never a CC residual
+/// summand, by the linked-cluster theorem). Callers then apply one uniform
+/// `if (!mask[n]) skip` test and get unpruned behavior in both those cases.
+template <typename TIdxs>
+inline container::vector<char> outer_product_connectivity(
+    TensorNetwork const& network, TIdxs const& tidxs) {
+  std::size_t const nt = network.tensors().size();
+  std::size_t const sz = std::size_t{1} << nt;
+  if (std::getenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING"))
+    return container::vector<char>(sz, 1);
+  auto mask = connected_subsets(contractible_adjacency(network, tidxs), nt);
+  if (!mask.empty() && !mask.back())  // full network disconnected: disable
+    return container::vector<char>(sz, 1);
+  return mask;
+}
+
 struct SubnetMetadata {
   /// meta_ids[n] is the canonical-subnet id of subset n, or
   /// numeric_limits<size_t>::max() for subsets with popcount < 2.

--- a/SeQuant/core/optimize/single_term_detail.hpp
+++ b/SeQuant/core/optimize/single_term_detail.hpp
@@ -18,6 +18,7 @@
 #include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/external/bliss/graph.hh>
 
+#include <range/v3/algorithm/contains.hpp>
 #include <range/v3/algorithm/find.hpp>
 #include <range/v3/view/concat.hpp>
 
@@ -29,6 +30,7 @@
 
 #include <algorithm>
 #include <bit>
+#include <cstdlib>
 #include <functional>
 #include <limits>
 #include <type_traits>
@@ -381,6 +383,43 @@ void init_results(TensorNetwork const& network, TIdxs const& tidxs,
       results[i].sequence.emplace_back(std::countr_zero(i));
     // else results[i].sequence is left uninitialized
   }
+}
+
+/// \brief Per-tensor adjacency bitmask over "contractible" shared indices.
+///
+/// `adj[i]` has bit `j` set iff tensors `i` and `j` share at least one
+/// top-level (bra/ket/aux) index that is NOT a target index (`tidxs`) -- i.e.
+/// an index that is summed somewhere in the term. Protoindices are never
+/// compared, so two composites `a<i,j>`, `b<i,j>` that share only occupied
+/// protos create no edge. A hyperedge (a contractible index on three-plus
+/// tensors) makes all its carriers mutually adjacent. A tensor is never
+/// adjacent to itself.
+template <typename TIdxs>
+inline container::vector<std::size_t> contractible_adjacency(
+    TensorNetwork const& network, TIdxs const& tidxs) {
+  std::size_t const nt = network.tensors().size();
+  container::vector<std::size_t> adj(nt, 0);
+  // carrier bitmask per contractible (non-target) top-level index
+  container::map<Index, std::size_t, Index::FullLabelCompare> carriers;
+  std::size_t i = 0;
+  for (auto&& t : network.tensors()) {
+    auto tp = std::dynamic_pointer_cast<Tensor>(t);
+    for (auto&& ix : ranges::views::concat(tp->bra(), tp->ket(), tp->aux())) {
+      if (ranges::contains(tidxs, ix)) continue;  // target/output: not summed
+      carriers[ix] |= (std::size_t{1} << i);
+    }
+    ++i;
+  }
+  for (auto&& [ix, cm] : carriers) {
+    if (std::popcount(cm) < 2) continue;  // appears on < 2 tensors
+    std::size_t rest = cm;
+    while (rest) {
+      std::size_t const b = static_cast<std::size_t>(std::countr_zero(rest));
+      adj[b] |= (cm & ~(std::size_t{1} << b));  // neighbors, excluding self
+      rest &= rest - 1;
+    }
+  }
+  return adj;
 }
 
 struct SubnetMetadata {

--- a/SeQuant/core/optimize/single_term_detail.hpp
+++ b/SeQuant/core/optimize/single_term_detail.hpp
@@ -491,7 +491,8 @@ struct SubnetMetadata {
 ///
 /// Side effect: `results[n].indices` may be reordered by `canonicalize_slots`.
 inline SubnetMetadata build_subnet_metadata(
-    TensorNetwork const& network, container::vector<OptRes>& results) {
+    TensorNetwork const& network, container::vector<OptRes>& results,
+    container::vector<char> const& connected) {
   SubnetMetadata out;
   // Use max as sentinel for entries with popcount < 2 (singletons/empty),
   // which are skipped below and never assigned a real meta ID.
@@ -502,6 +503,7 @@ inline SubnetMetadata build_subnet_metadata(
 
   for (size_t n = 0; n < results.size(); ++n) {
     if (std::popcount(n) < 2) continue;
+    if (!connected[n]) continue;  // outer-product subset, never an intermediate
     auto ts = bits::on_bits_index(n) | bits::sieve(network.tensors());
     container::vector<ExprPtr> ts_expr;
     for (auto&& t : ts)

--- a/SeQuant/core/optimize/single_term_detail.hpp
+++ b/SeQuant/core/optimize/single_term_detail.hpp
@@ -230,13 +230,15 @@ struct OptRes {
 template <typename TIdxs, typename IdxToSz>
 container::vector<double> subset_footprints(
     TensorNetwork const& network, TIdxs const& tidxs, IdxToSz&& idxsz,
-    std::function<double(Index const&, std::size_t)> const& inner_pow = {}) {
+    std::function<double(Index const&, std::size_t)> const& inner_pow = {},
+    container::vector<char> const* connected = nullptr) {
   container::vector<OptRes> results((size_t{1} << network.tensors().size()));
-  init_results(network, tidxs, results);
+  init_results(network, tidxs, results, connected);
   auto fp = footprint_counter(std::forward<IdxToSz>(idxsz), inner_pow);
   container::vector<double> S(results.size(), 0.0);
   for (size_t n = 0; n < results.size(); ++n)
-    S[n] = (n == 0) ? 0.0 : fp(results[n].indices);
+    S[n] = (n == 0 || (connected && !(*connected)[n])) ? 0.0
+                                                       : fp(results[n].indices);
   return S;
 }
 
@@ -295,7 +297,8 @@ container::vector<container::vector<double>> sliced_footprints(
     std::function<bool(Index const&)> const& is_batchable,
     std::function<std::size_t(Index const&)> const& batch_target_size,
     container::vector<Index> const& aux_list,
-    std::function<double(Index const&, std::size_t)> const& inner_pow = {}) {
+    std::function<double(Index const&, std::size_t)> const& inner_pow = {},
+    container::vector<char> const* connected = nullptr) {
   std::size_t const m = aux_list.size();
   container::vector<container::vector<double>> tables(std::size_t{1} << m);
   for (std::size_t B = 0; B < tables.size(); ++B) {
@@ -312,7 +315,7 @@ container::vector<container::vector<double>> sliced_footprints(
       }
       return e;
     };
-    tables[B] = subset_footprints(network, tidxs, extent, inner_pow);
+    tables[B] = subset_footprints(network, tidxs, extent, inner_pow, connected);
   }
   return tables;
 }
@@ -366,14 +369,22 @@ struct SubNetEqual {
 /// Singleton subsets also get their one-element \c sequence pre-populated.
 template <typename TIdxs>
 void init_results(TensorNetwork const& network, TIdxs const& tidxs,
-                  container::vector<OptRes>& results) {
+                  container::vector<OptRes>& results,
+                  container::vector<char> const* connected = nullptr) {
   using IndexContainer = decltype(OptRes::indices);
   auto tensor_indices = network.tensors()          //
                         | ranges::views::indirect  //
                         | ranges::views::transform(slots);
-  auto imed_indices = subset_target_indices(tensor_indices, tidxs);
+  auto imed_indices = subset_target_indices(tensor_indices, tidxs, connected);
   SEQUANT_ASSERT(ranges::distance(imed_indices) == ranges::distance(results));
   for (size_t i = 0; i < results.size(); ++i) {
+    // Outer-product pruning: a disconnected subset is never an intermediate the
+    // DP forms; leave the sentinel. connected[i]==1 for singletons/empty, so
+    // leaves are always computed. See outer_product_connectivity.
+    if (connected && !(*connected)[i]) {
+      results[i].ops = std::numeric_limits<decltype(OptRes::ops)>::max();
+      continue;
+    }
     results[i].indices =
         imed_indices[i] | ranges::views::move | ranges::to<IndexContainer>;
     results[i].ops = std::popcount(i) > 1
@@ -544,6 +555,8 @@ container::vector<std::size_t> subset_open_aux(
     container::vector<Index> const& aux_list) {
   container::vector<OptRes> results(
       (std::size_t{1} << network.tensors().size()));
+  // NOT pruned: is_spectator_axis consumes open_aux over the full subset
+  // lattice (including disconnected subsets), so every entry must be real.
   init_results(network, tidxs, results);
   container::vector<std::size_t> open_aux(results.size(), 0);
   for (std::size_t n = 0; n < results.size(); ++n) {

--- a/SeQuant/core/utility/indices.hpp
+++ b/SeQuant/core/utility/indices.hpp
@@ -764,13 +764,18 @@ decltype(auto) as_view_of_index_groups(
 /// @return A vector of maps, where `result[mask]` contains a map of
 /// `Index` to its count in the subset defined by `mask`.
 ///
-auto subset_index_counts(meta::range_of<Index, 2> auto const& rng) {
+auto subset_index_counts(meta::range_of<Index, 2> auto const& rng,
+                         container::vector<char> const* needed = nullptr) {
   size_t const N = ranges::distance(rng);
   SEQUANT_ASSERT(N <= 24 &&
                  "subset_index_counts: N > 24 would require excessive memory");
   container::vector<container::map<Index, size_t, Index::FullLabelCompare>>
       result((size_t{1} << N));
   for (size_t i = 1; i < result.size(); ++i) {
+    // When a `needed` mask is supplied, only these subsets' counts are ever
+    // consulted (see subset_target_indices); skip the rest (result[i] stays
+    // empty). Callers pass the pruning-derived mask to avoid the full 2^N work.
+    if (needed && !(*needed)[i]) continue;
     for (auto&& ixs : bits::on_bits_index(i) | bits::sieve(rng)) {
       for (auto&& ix : ixs)
         if (auto [it, inserted] = result[i].try_emplace(ix, 1); !inserted)  //
@@ -802,26 +807,44 @@ auto subset_index_counts(meta::range_of<Index, 2> auto const& rng) {
 /// `Index` objects for the subset defined by `mask`.
 ///
 auto subset_target_indices(meta::range_of<Index, 2> auto const& rng,
-                           meta::range_of<Index> auto const& tixs) {
+                           meta::range_of<Index> auto const& tixs,
+                           container::vector<char> const* connected = nullptr) {
   using IndexSet = container::set<Index, Index::FullLabelCompare>;
   size_t const N = ranges::distance(rng);
   SEQUANT_ASSERT(
       N <= 24 &&
       "subset_target_indices: N > 24 would require excessive memory");
-  container::vector<IndexSet> result((size_t{1} << N));
+  size_t const S = size_t{1} << N;
+  container::vector<IndexSet> result(S);
+
+  // Outer-product pruning: the caller only reads result[i] for connected
+  // subsets i, but computing result[i] consults counts[i] AND counts of the
+  // COMPLEMENT (S-1-i) -- the complement of a connected subset is usually
+  // disconnected -- so the index-count work is needed for the wider set
+  // `needed[i] = connected[i] || connected[complement(i)]`.
+  container::vector<char> needed_storage;
+  container::vector<char> const* needed = nullptr;
+  if (connected) {
+    needed_storage.assign(S, 0);
+    for (size_t i = 0; i < S; ++i)
+      needed_storage[i] = (*connected)[i] || (*connected)[S - 1 - i];
+    needed = &needed_storage;
+  }
 
   for (size_t i = 0; i < N; ++i)
     for (auto&& ix : ranges::at(rng, i)) result[(size_t{1} << i)].emplace(ix);
 
-  auto counts = subset_index_counts(rng);
+  auto counts = subset_index_counts(rng, needed);
 
   for (auto&& [k, v] : *counts.rbegin())
     if (v == 1 || ranges::contains(tixs, k)) result.rbegin()->emplace(k);
 
-  for (size_t i = 0; i < result.size(); ++i)
+  for (size_t i = 0; i < result.size(); ++i) {
+    if (connected && !(*connected)[i]) continue;  // pruned: result[i] unused
     for (auto&& [k, v] : counts[i])
       if (v == 1 || (v > 0 && counts.at(counts.size() - i - 1).contains(k)))
         result[i].emplace(k);
+  }
 
   return result;
 }

--- a/doc/dev/plans/2026-07-08-outer-product-dp-pruning-plan.md
+++ b/doc/dev/plans/2026-07-08-outer-product-dp-pruning-plan.md
@@ -1,0 +1,718 @@
+# Outer-product (disconnected-subgraph) DP pruning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prune the single-term contraction DP so it never spends work on outer
+products (bipartitions whose two parts share no contractible index), collapsing
+the per-term search to the number of connected subnetworks, with the optimal
+factorization unchanged.
+
+**Architecture:** Add two pure helpers -- `contractible_adjacency` (pairwise
+"share a non-target index" graph as per-tensor neighbor bitmasks) and
+`connected_subsets` (per-subset induced-connectivity) -- plus a thin
+`outer_product_connectivity` wrapper that returns the connectivity mask (or an
+all-connected mask when pruning is disabled or the full network is a genuine
+product). `solve_single_term` computes this mask from the `network`/`tidxs` it
+already receives and skips disconnected subsets / relaxes only connected-child
+bipartitions; `build_subnet_metadata` takes the same mask and skips
+canonicalizing disconnected subsets. No `build_context`/CostModel-concept
+signature changes.
+
+**Tech Stack:** SeQuant C++20, `SeQuant/core/optimize/`, Catch2 unit tests.
+
+## Global Constraints
+
+- Repo: SeQuant, branch `feature/eval-predicted-peak-trace`. Branch-only: no
+  push, no PR, no remote operations, do not switch branches.
+- Commit messages: plain, describing the change. **No `Co-Authored-By` trailers
+  or any AI/tool attribution.**
+- **Do NOT stage, commit, or modify** `SeQuant/core/tensor_network/slot.hpp`
+  (unrelated pre-existing local edit) or `tests/unit/test_eval_dryrun.cpp`
+  (an uncommitted local spike). Commit only the files each task names.
+- ASCII only in all source and docs. No U+2013 (en-dash), no U+00A0
+  (non-breaking space) -- a pre-commit hook rejects them.
+- Run `clang-format` before every commit:
+  `/opt/homebrew/opt/llvm@17/bin/clang-format --style=file -i <files>` (skip
+  `.tpp` files; none here).
+- Build and test in the existing configured tree `SeQuant/build-test`:
+  - build: `cd SeQuant/build-test && make unit_tests-sequant 2>&1 | tail -8`
+  - run a tag: `./tests/unit/unit_tests-sequant "[tag]"` from `build-test`.
+- **Never run the unfiltered unit suite** (it hangs on an unrelated slow DP
+  test). Always pass a Catch2 tag/name filter. **Never run two SeQuant test
+  binaries concurrently.**
+- Adjacency compares **top-level** (bra/ket/aux) indices only, never
+  protoindices. "Contractible" index := an index **not** in the target set
+  `tidxs`.
+- Loss-free requirement: for every objective, the pruned DP must return the
+  byte-identical optimized expression as the unpruned DP (the parity gate,
+  Task 4). Existing `[optimize]` tests must continue to pass unchanged.
+
+## Test scaffolding (reuse in every new test case)
+
+Mirror the existing `"optimize"` `TEST_CASE` (`test_optimize.cpp:168-201`)
+exactly -- do not invent a new context or parser:
+
+- **Context:** inside each `TEST_CASE`, do
+  `auto ctx_resetter = set_scoped_default_context(get_default_context().clone());`
+  then `auto reg = get_default_context().mutable_index_space_registry();` and set
+  `reg->retrieve_ptr(L"i")->approximate_size(10);` (occ),
+  `reg->retrieve_ptr(L"a")->approximate_size(100);` (virt),
+  `reg->retrieve_ptr(L"x")->approximate_size(4);` (aux).
+- **Spaces:** occupied = `i`, virtual = `a`, aux = `x`.
+- **Parse:** `auto parse = [](auto const& s){ return deserialize(s, {.def_perm_symm = Symmetry::Antisymm}); };`
+  Shorthand is LaTeX-like: `g_{i3,i4}^{a3,a4}` = bra `i3,i4`, ket `a3,a4`. A single
+  tensor string (e.g. `L"g_{i1}^{a1}"`) parses to a tensor expression; build a
+  `TensorNetwork` from the `Tensor` factors of a parsed product, mirroring
+  `single_term_detail.hpp:447-452` (`for (auto&& f : prod.factors()) if (f->is<Tensor>()) v.push_back(f);`
+  then `TensorNetwork{v}`).
+- **Include** `<cstdlib>` in the test TU for `setenv`/`unsetenv`.
+- **Tensor ordering:** `TensorNetwork` may reorder its tensors, so assert
+  **order-independent** properties (edge count, whole-set connectivity, all-zero)
+  rather than a specific `adj[i]` value tied to input position.
+
+---
+
+## File Structure
+
+- `SeQuant/core/optimize/single_term_detail.hpp` -- add `contractible_adjacency`,
+  `connected_subsets`, `outer_product_connectivity` (namespace
+  `sequant::opt::detail`); add the `connected` parameter + skip to
+  `build_subnet_metadata`.
+- `SeQuant/core/optimize/cost_model.hpp` -- `solve_single_term` computes the mask
+  and applies the skip/guard; `AdditiveModel::build_context` computes the mask
+  and passes it to `build_subnet_metadata`.
+- `tests/unit/test_optimize.cpp` -- new `TEST_CASE`s for the helpers, the parity
+  gate, the performance smoke, and the multi-component safety net.
+
+---
+
+### Task 1: `contractible_adjacency` helper
+
+**Files:**
+- Modify: `SeQuant/core/optimize/single_term_detail.hpp` (add helper near
+  `init_results`, ~line 414; add `#include <cstdlib>` and
+  `#include <range/v3/algorithm/contains.hpp>` with the other includes if not
+  present)
+- Test: `tests/unit/test_optimize.cpp`
+
+**Interfaces:**
+- Produces:
+  `template <typename TIdxs> container::vector<std::size_t> contractible_adjacency(TensorNetwork const& network, TIdxs const& tidxs)`
+  in `sequant::opt::detail`. Returns `adj` of size `network.tensors().size()`;
+  `adj[i]` has bit `j` set iff tensors `i` and `j` share a top-level index that
+  is not in `tidxs`. Never sets a tensor's own bit.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/test_optimize.cpp`. Use the Test-scaffolding context/parse;
+assert order-independent facts (undirected edge count = half the summed
+popcount; whole-set connectivity via `connected_subsets`).
+
+```cpp
+TEST_CASE("contractible_adjacency", "[optimize][pruning]") {
+  using namespace sequant;
+  namespace o = sequant::opt::detail;
+  auto ctx_resetter = set_scoped_default_context(get_default_context().clone());
+  auto reg = get_default_context().mutable_index_space_registry();
+  reg->retrieve_ptr(L"i")->approximate_size(10);
+  reg->retrieve_ptr(L"a")->approximate_size(100);
+  reg->retrieve_ptr(L"x")->approximate_size(4);
+  auto parse = [](auto const& s) {
+    return deserialize(s, {.def_perm_symm = Symmetry::Antisymm});
+  };
+  auto net_of = [](ExprPtr const& prod) {
+    container::vector<ExprPtr> v;
+    for (auto&& f : prod->as<Product>().factors())
+      if (f->is<Tensor>()) v.push_back(f);
+    return TensorNetwork{v};
+  };
+  auto edge_count = [](container::vector<std::size_t> const& adj) {
+    std::size_t s = 0;
+    for (auto m : adj) s += static_cast<std::size_t>(std::popcount(m));
+    return s / 2;  // each undirected edge counted twice
+  };
+
+  // Chain: f-g share a1; g-h share a2. Targets {i1,i2}. 2 edges.
+  auto chain = net_of(parse(L"f_{i1}^{a1} g_{a1}^{a2} h_{a2}^{i2}"));
+  std::vector<Index> tgt2{Index{L"i_1"}, Index{L"i_2"}};
+  auto adj_chain = o::contractible_adjacency(chain, tgt2);
+  REQUIRE(adj_chain.size() == 3);
+  CHECK(edge_count(adj_chain) == 2);
+
+  // Hyperedge: p,q,r all carry summed a5 -> clique (3 edges).
+  auto hyper = net_of(parse(L"p_{i1}^{a5} q_{i2}^{a5} r_{i3}^{a5}"));
+  std::vector<Index> tgt3{Index{L"i_1"}, Index{L"i_2"}, Index{L"i_3"}};
+  auto adj_hyper = o::contractible_adjacency(hyper, tgt3);
+  CHECK(edge_count(adj_hyper) == 3);
+
+  // Spectator-only: two tensors share only the target index i1 -> no edges.
+  auto spec = net_of(parse(L"u_{i1}^{a1} v_{i1}^{a2}"));
+  std::vector<Index> tgt_spec{Index{L"i_1"}, Index{L"a_1"}, Index{L"a_2"}};
+  auto adj_spec = o::contractible_adjacency(spec, tgt_spec);
+  CHECK(edge_count(adj_spec) == 0);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `SeQuant/build-test`, after adding the case): build fails to compile
+(`contractible_adjacency` not declared). That is the expected initial failure.
+
+```
+cd SeQuant/build-test && make unit_tests-sequant 2>&1 | tail -8
+```
+Expected: compile error, `no member named 'contractible_adjacency'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `single_term_detail.hpp`, in `namespace sequant::opt { namespace detail {`,
+after `init_results` (~line 414), add:
+
+```cpp
+/// \brief Per-tensor adjacency bitmask over "contractible" shared indices.
+///
+/// `adj[i]` has bit `j` set iff tensors `i` and `j` share at least one top-level
+/// (bra/ket/aux) index that is NOT a target index (`tidxs`) -- i.e. an index
+/// that is summed somewhere in the term. Protoindices are never compared, so two
+/// composites `a<i,j>`, `b<i,j>` that share only occupied protos create no edge.
+/// A hyperedge (a contractible index on three-plus tensors) makes all its
+/// carriers mutually adjacent. A tensor is never adjacent to itself.
+template <typename TIdxs>
+inline container::vector<std::size_t> contractible_adjacency(
+    TensorNetwork const& network, TIdxs const& tidxs) {
+  std::size_t const nt = network.tensors().size();
+  container::vector<std::size_t> adj(nt, 0);
+  // carrier bitmask per contractible (non-target) top-level index
+  container::map<Index, std::size_t, Index::FullLabelCompare> carriers;
+  std::size_t i = 0;
+  for (auto&& t : network.tensors()) {
+    auto tp = std::dynamic_pointer_cast<Tensor>(t);
+    for (auto&& ix : ranges::views::concat(tp->bra(), tp->ket(), tp->aux())) {
+      if (ranges::contains(tidxs, ix)) continue;  // target/output: not summed
+      carriers[ix] |= (std::size_t{1} << i);
+    }
+    ++i;
+  }
+  for (auto&& [ix, cm] : carriers) {
+    if (std::popcount(cm) < 2) continue;  // appears on < 2 tensors
+    std::size_t rest = cm;
+    while (rest) {
+      std::size_t const b = static_cast<std::size_t>(std::countr_zero(rest));
+      adj[b] |= (cm & ~(std::size_t{1} << b));  // neighbors, excluding self
+      rest &= rest - 1;
+    }
+  }
+  return adj;
+}
+```
+
+Add includes near the top of `single_term_detail.hpp` if absent:
+`#include <cstdlib>` and `#include <range/v3/algorithm/contains.hpp>`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+cd SeQuant/build-test && make unit_tests-sequant 2>&1 | tail -8 \
+  && ./tests/unit/unit_tests-sequant "[pruning]"
+```
+Expected: builds; `contractible_adjacency` case passes.
+
+- [ ] **Step 5: clang-format and commit**
+
+```bash
+/opt/homebrew/opt/llvm@17/bin/clang-format --style=file -i \
+  SeQuant/core/optimize/single_term_detail.hpp tests/unit/test_optimize.cpp
+git add SeQuant/core/optimize/single_term_detail.hpp tests/unit/test_optimize.cpp
+git commit -m "optimize: add contractible_adjacency helper for DP pruning"
+```
+
+---
+
+### Task 2: `connected_subsets` + `outer_product_connectivity`
+
+**Files:**
+- Modify: `SeQuant/core/optimize/single_term_detail.hpp` (add both helpers after
+  `contractible_adjacency`)
+- Test: `tests/unit/test_optimize.cpp`
+
+**Interfaces:**
+- Consumes: `contractible_adjacency` (Task 1).
+- Produces:
+  - `container::vector<char> connected_subsets(container::vector<std::size_t> const& adjacency, std::size_t nt)`
+    -- `connected[n] == 1` iff the subgraph induced on the set bits of `n` is
+    connected; size `1 << nt`; empty/singleton subsets are `1`.
+  - `template <typename TIdxs> container::vector<char> outer_product_connectivity(TensorNetwork const& network, TIdxs const& tidxs)`
+    -- returns `connected_subsets(contractible_adjacency(network, tidxs), nt)`,
+    EXCEPT it returns an all-`1` mask (size `1 << nt`) when the env var
+    `SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING` is set OR when the full-network entry
+    (`mask.back()`) is `0` (a genuine multi-component product). So callers apply
+    one uniform `if (!mask[n]) skip` test and get the unpruned behavior in both
+    the disabled and product-term cases.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/test_optimize.cpp`:
+
+```cpp
+TEST_CASE("connected_subsets and outer_product_connectivity",
+          "[optimize][pruning]") {
+  using namespace sequant;
+  namespace o = sequant::opt::detail;
+
+  // Path 0-1-2 : adj[0]={1}, adj[1]={0,2}, adj[2]={1}.
+  container::vector<std::size_t> path{0b010, 0b101, 0b010};
+  auto c = o::connected_subsets(path, 3);
+  REQUIRE(c.size() == 8);
+  CHECK(c[0b001] == 1);  // singleton
+  CHECK(c[0b011] == 1);  // {0,1} share edge
+  CHECK(c[0b110] == 1);  // {1,2} share edge
+  CHECK(c[0b101] == 0);  // {0,2} NOT adjacent -> disconnected
+  CHECK(c[0b111] == 1);  // {0,1,2} connected via 1
+
+  // Two disjoint components {0,1} and {2,3}: full set disconnected.
+  container::vector<std::size_t> prod{0b0010, 0b0001, 0b1000, 0b0100};
+  auto cp = o::connected_subsets(prod, 4);
+  CHECK(cp[0b0011] == 1);   // {0,1}
+  CHECK(cp[0b1100] == 1);   // {2,3}
+  CHECK(cp[0b1111] == 0);   // full: disconnected product
+
+  // outer_product_connectivity: env-disabled -> all ones.
+  auto ctx_resetter = set_scoped_default_context(get_default_context().clone());
+  auto reg = get_default_context().mutable_index_space_registry();
+  reg->retrieve_ptr(L"i")->approximate_size(10);
+  reg->retrieve_ptr(L"a")->approximate_size(100);
+  reg->retrieve_ptr(L"x")->approximate_size(4);
+  auto prod = deserialize(L"f_{i1}^{a1} g_{a1}^{i2}",
+                          {.def_perm_symm = Symmetry::Antisymm});
+  container::vector<ExprPtr> v;
+  for (auto&& f : prod->as<Product>().factors())
+    if (f->is<Tensor>()) v.push_back(f);
+  TensorNetwork tn{v};
+  std::vector<Index> tgt{Index{L"i_1"}, Index{L"i_2"}};
+  setenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING", "1", 1);
+  auto m_off = o::outer_product_connectivity(tn, tgt);
+  unsetenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING");
+  for (auto val : m_off) CHECK(val == 1);
+}
+```
+
+Add `#include <cstdlib>` to the test's includes for `setenv`/`unsetenv`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+cd SeQuant/build-test && make unit_tests-sequant 2>&1 | tail -8
+```
+Expected: compile error, `connected_subsets` / `outer_product_connectivity` not
+declared.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `single_term_detail.hpp`, after `contractible_adjacency`:
+
+```cpp
+/// \brief `connected[n] == 1` iff the subgraph induced on the set bits of subset
+/// mask `n` is connected under `adjacency` (from \ref contractible_adjacency).
+/// Empty and singleton subsets are connected by definition. Size `1 << nt`.
+inline container::vector<char> connected_subsets(
+    container::vector<std::size_t> const& adjacency, std::size_t nt) {
+  container::vector<char> connected(std::size_t{1} << nt, 0);
+  for (std::size_t n = 0; n < connected.size(); ++n) {
+    if (std::popcount(n) <= 1) {
+      connected[n] = 1;
+      continue;
+    }
+    std::size_t const start = n & (~n + 1);  // lowest set bit
+    std::size_t reached = start, frontier = start;
+    while (frontier) {
+      std::size_t next = 0, f = frontier;
+      while (f) {
+        next |= adjacency[static_cast<std::size_t>(std::countr_zero(f))];
+        f &= f - 1;
+      }
+      next &= n & ~reached;
+      reached |= next;
+      frontier = next;
+    }
+    connected[n] = (reached == n) ? 1 : 0;
+  }
+  return connected;
+}
+
+/// \brief Outer-product pruning mask for a term. Returns
+/// \ref connected_subsets over \ref contractible_adjacency, EXCEPT it returns an
+/// all-connected mask when pruning is disabled (env
+/// `SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING`) or when the full network is itself
+/// disconnected (a genuine product term -- never a CC residual summand, by the
+/// linked-cluster theorem). Callers then apply one uniform `if (!mask[n]) skip`
+/// test and get unpruned behavior in both those cases.
+template <typename TIdxs>
+inline container::vector<char> outer_product_connectivity(
+    TensorNetwork const& network, TIdxs const& tidxs) {
+  std::size_t const nt = network.tensors().size();
+  std::size_t const sz = std::size_t{1} << nt;
+  if (std::getenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING"))
+    return container::vector<char>(sz, 1);
+  auto mask = connected_subsets(contractible_adjacency(network, tidxs), nt);
+  if (!mask.empty() && !mask.back())  // full network disconnected: disable
+    return container::vector<char>(sz, 1);
+  return mask;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+cd SeQuant/build-test && make unit_tests-sequant 2>&1 | tail -8 \
+  && ./tests/unit/unit_tests-sequant "[pruning]"
+```
+Expected: both `[pruning]` cases pass.
+
+- [ ] **Step 5: clang-format and commit**
+
+```bash
+/opt/homebrew/opt/llvm@17/bin/clang-format --style=file -i \
+  SeQuant/core/optimize/single_term_detail.hpp tests/unit/test_optimize.cpp
+git add SeQuant/core/optimize/single_term_detail.hpp tests/unit/test_optimize.cpp
+git commit -m "optimize: add connected_subsets + outer_product_connectivity"
+```
+
+---
+
+### Task 3: Apply the mask in the DP driver and CSE metadata
+
+**Files:**
+- Modify: `SeQuant/core/optimize/cost_model.hpp` (`solve_single_term`
+  ~lines 26-45; `AdditiveModel::build_context` ~lines 138-143)
+- Modify: `SeQuant/core/optimize/single_term_detail.hpp` (`build_subnet_metadata`
+  ~lines 435-463)
+- Test: existing `[optimize]` suite (regression) + a smoke assertion added to
+  the parity case is deferred to Task 4; here the test is the unchanged suite.
+
+**Interfaces:**
+- Consumes: `outer_product_connectivity` (Task 2).
+- Produces: `build_subnet_metadata` gains a trailing parameter
+  `container::vector<char> const& connected`; it skips subsets with
+  `!connected[n]`. `solve_single_term` behavior: disconnected subsets are not
+  formed and only connected-child bipartitions are relaxed (both governed by the
+  uniform mask).
+
+- [ ] **Step 1: Add the failing regression checkpoint**
+
+No new test code; the gate is that the existing `[optimize]` suite still passes
+after wiring. First confirm it passes BEFORE the change (baseline):
+
+```
+cd SeQuant/build-test && make unit_tests-sequant 2>&1 | tail -4 \
+  && ./tests/unit/unit_tests-sequant "[optimize]" 2>&1 | tail -5
+```
+Expected: all `[optimize]` assertions pass (record the counts).
+
+- [ ] **Step 2: Modify `build_subnet_metadata` (add the skip)**
+
+In `single_term_detail.hpp`, change the signature and loop:
+
+```cpp
+inline SubnetMetadata build_subnet_metadata(
+    TensorNetwork const& network, container::vector<OptRes>& results,
+    container::vector<char> const& connected) {   // NEW trailing param
+  SubnetMetadata out;
+  out.meta_ids.resize(results.size(), std::numeric_limits<size_t>::max());
+  container::unordered_map<TensorNetwork::SlotCanonicalizationMetadata, size_t,
+                           SubNetHash, SubNetEqual>
+      meta_to_id;
+
+  for (size_t n = 0; n < results.size(); ++n) {
+    if (std::popcount(n) < 2) continue;
+    if (!connected[n]) continue;   // NEW: outer-product subset, never an intermediate
+    auto ts = bits::on_bits_index(n) | bits::sieve(network.tensors());
+    // ... unchanged body ...
+  }
+  out.unique_meta_costs.resize(meta_to_id.size(), 0.0);
+  return out;
+}
+```
+
+- [ ] **Step 3: Modify `AdditiveModel::build_context` (compute + pass the mask)**
+
+In `cost_model.hpp` (~line 138):
+
+```cpp
+    if (subnet_cse) {
+      auto connected = outer_product_connectivity(network, tidxs);  // NEW
+      auto md = build_subnet_metadata(network, ctx.results, connected);  // pass mask
+      ctx.meta_ids = std::move(md.meta_ids);
+      ctx.unique_meta_costs = std::move(md.unique_meta_costs);
+    }
+```
+
+- [ ] **Step 4: Modify `solve_single_term` (skip + guard)**
+
+In `cost_model.hpp` (~line 26):
+
+```cpp
+template <class Model, typename TIdxs>
+container::vector<typename Model::State> solve_single_term(
+    Model const& m, TensorNetwork const& network, TIdxs const& tidxs,
+    typename Model::Context& ctx) {
+  auto const nt = network.tensors().size();
+  container::vector<typename Model::State> st(size_t{1} << nt);
+  auto const connected = outer_product_connectivity(network, tidxs);  // NEW
+  for (size_t n = 1; n < st.size(); ++n) {
+    if (std::popcount(n) == 1) {
+      st[n] = m.leaf(ctx, n);
+      continue;
+    }
+    if (!connected[n]) continue;  // NEW: never form a disconnected subset
+    typename Model::State acc = m.init(ctx, n);
+    for (auto&& [lp, rp] : bits::bipartitions(n))
+      if (lp != 0 && rp != 0 && connected[lp] && connected[rp])  // NEW guard
+        m.relax(ctx, n, lp, rp, st[lp], st[rp], acc);
+    st[n] = std::move(acc);
+    m.finalize(ctx, n, st);
+  }
+  return st;
+}
+```
+
+Remove the now-unused `(void)tidxs;` line (tidxs is used now).
+
+- [ ] **Step 5: Build and run the regression + verify parity by env toggle**
+
+```
+cd SeQuant/build-test && make unit_tests-sequant 2>&1 | tail -8 \
+  && ./tests/unit/unit_tests-sequant "[optimize]" 2>&1 | tail -5
+```
+Expected: identical pass counts to Step 1 (pruning is loss-free, so every
+existing optimize assertion is unchanged).
+
+- [ ] **Step 6: clang-format and commit**
+
+```bash
+/opt/homebrew/opt/llvm@17/bin/clang-format --style=file -i \
+  SeQuant/core/optimize/single_term_detail.hpp SeQuant/core/optimize/cost_model.hpp
+git add SeQuant/core/optimize/single_term_detail.hpp SeQuant/core/optimize/cost_model.hpp
+git commit -m "optimize: prune outer-product subsets in the single-term DP"
+```
+
+---
+
+### Task 4: Parity gate across all objectives (primary correctness test)
+
+**Files:**
+- Test: `tests/unit/test_optimize.cpp`
+
+**Interfaces:**
+- Consumes: `optimize(ExprPtr, OptimizeOptions)` (public) and the env switch
+  `SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING` (Task 2).
+
+- [ ] **Step 1: Write the parity test**
+
+Add to `tests/unit/test_optimize.cpp`. It optimizes each term under each
+objective twice -- pruning on (default) and off (env) -- and asserts the
+optimized expressions are identical (`to_latex`). Includes a connected hyperedge
+term so the "Hadamard intermediate is kept" path is exercised.
+
+```cpp
+TEST_CASE("outer-product pruning parity (pruned == unpruned)",
+          "[optimize][pruning]") {
+  using namespace sequant;
+  auto ctx_resetter = set_scoped_default_context(get_default_context().clone());
+  auto reg = get_default_context().mutable_index_space_registry();
+  reg->retrieve_ptr(L"i")->approximate_size(10);
+  reg->retrieve_ptr(L"a")->approximate_size(100);
+  reg->retrieve_ptr(L"x")->approximate_size(4);
+
+  auto opts_for = [&](ObjectiveFunction obj) {
+    OptimizeOptions o;
+    o.objective_function = obj;
+    o.idx_to_extent = [](Index const& ix) -> std::size_t {
+      return ix.nonnull() ? ix.space().approximate_size() : 1;
+    };
+    o.batch_policy.is_batchable_index = [](Index const&) { return false; };
+    o.batch_policy.batch_target_size = [](Index const&) -> std::size_t {
+      return 1;
+    };
+    return o;
+  };
+
+  std::vector<ObjectiveFunction> const objs{
+      ObjectiveFunction::DenseFLOPs,
+      ObjectiveFunction::DenseSize,
+      ObjectiveFunction::DenseSpaceTime,
+      ObjectiveFunction::DenseTimeSpace,
+      ObjectiveFunction::DenseSpaceTimeBatched,
+      ObjectiveFunction::DenseTimeSpaceBatched};
+
+  std::vector<std::wstring> const terms{
+      L"1/4 g_{i2,i3}^{a2,a3} t_{a2,a3}^{i2,i3} t_{a1}^{i1}",
+      L"x_{i1,i2}^{a3,a4} y_{a1,a2}^{i1,i2} z_{a3,a4}^{a1,a2}",
+      L"g_{i1,i2}^{a1,a2} t_{a1}^{i1} t_{a2}^{i2} t_{a3}^{i3}",
+      // hyperedge-flavored: three tensors sharing a common summed index a5
+      L"p_{i1}^{a5} q_{i2}^{a5} r_{i3}^{a5} s_{a5}^{i4}",
+  };
+
+  auto run = [&](std::wstring const& term, ObjectiveFunction obj, bool prune) {
+    if (prune)
+      unsetenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING");
+    else
+      setenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING", "1", 1);
+    auto expr = deserialize(term, {.def_perm_symm = Symmetry::Antisymm});
+    auto out = optimize(expr, opts_for(obj));
+    unsetenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING");
+    return to_latex(out);
+  };
+
+  for (std::size_t ti = 0; ti < terms.size(); ++ti)
+    for (auto obj : objs) {
+      auto pruned = run(terms[ti], obj, true);
+      auto unpruned = run(terms[ti], obj, false);
+      CAPTURE(ti, static_cast<int>(obj));
+      CHECK(pruned == unpruned);
+    }
+}
+```
+
+- [ ] **Step 2: Run and verify it passes**
+
+```
+cd SeQuant/build-test && make unit_tests-sequant 2>&1 | tail -8 \
+  && ./tests/unit/unit_tests-sequant "[pruning]"
+```
+Expected: all parity checks pass. If any objective's opts need a non-trivial
+`inner_pow` or roofline to run, set them in `opts_for` (mirror the defaults used
+in the existing `"optimize"` test's `single_term_opt` lambda). A CHECK failure
+means a genuine factorization divergence -- investigate before proceeding
+(do not weaken the assertion).
+
+- [ ] **Step 3: clang-format and commit**
+
+```bash
+/opt/homebrew/opt/llvm@17/bin/clang-format --style=file -i tests/unit/test_optimize.cpp
+git add tests/unit/test_optimize.cpp
+git commit -m "optimize: parity test for outer-product pruning across objectives"
+```
+
+---
+
+### Task 5: Performance smoke + multi-component safety net
+
+**Files:**
+- Test: `tests/unit/test_optimize.cpp`
+
+**Interfaces:**
+- Consumes: `optimize` + the env switch.
+
+- [ ] **Step 1: Write the tests**
+
+Add to `tests/unit/test_optimize.cpp`:
+
+```cpp
+TEST_CASE("outer-product pruning: large connected term optimizes quickly",
+          "[optimize][pruning]") {
+  using namespace sequant;
+  auto ctx_resetter = set_scoped_default_context(get_default_context().clone());
+  auto reg = get_default_context().mutable_index_space_registry();
+  reg->retrieve_ptr(L"i")->approximate_size(10);
+  reg->retrieve_ptr(L"a")->approximate_size(100);
+  reg->retrieve_ptr(L"x")->approximate_size(4);
+  // A connected chain: each adjacent pair shares one summed index, so the whole
+  // term is one connected component. The pruned DP explores only connected
+  // subsets and finishes fast; the unpruned 3^n enumeration is far slower.
+  auto expr = deserialize(
+      L"g_{a0,a1}^{a2,a3} t_{a2}^{a4} t_{a3}^{a5} t_{a4}^{a6} t_{a5}^{a7} "
+      L"t_{a6}^{a8} t_{a7}^{a9} v_{a8,a9}^{a0,a1}",
+      {.def_perm_symm = Symmetry::Antisymm});
+  OptimizeOptions o;
+  o.objective_function = ObjectiveFunction::DenseTimeSpace;
+  o.idx_to_extent = [](Index const& ix) -> std::size_t {
+    return ix.nonnull() ? ix.space().approximate_size() : 1;
+  };
+  // Pruning ON (default): must complete (the assertion is that it returns).
+  auto out = optimize(expr, o);
+  CHECK(out);
+}
+
+TEST_CASE("outer-product pruning: multi-component product falls back unpruned",
+          "[optimize][pruning]") {
+  using namespace sequant;
+  namespace o = sequant::opt::detail;
+  auto ctx_resetter = set_scoped_default_context(get_default_context().clone());
+  auto reg = get_default_context().mutable_index_space_registry();
+  reg->retrieve_ptr(L"i")->approximate_size(10);
+  reg->retrieve_ptr(L"a")->approximate_size(100);
+  reg->retrieve_ptr(L"x")->approximate_size(4);
+  auto net_of = [](ExprPtr const& p) {
+    container::vector<ExprPtr> v;
+    for (auto&& f : p->as<Product>().factors())
+      if (f->is<Tensor>()) v.push_back(f);
+    return TensorNetwork{v};
+  };
+
+  // Two independent contractions sharing NO summed index: {f,g} over a1,
+  // {p,q} over a2. The full adjacency graph has two components.
+  auto prod = deserialize(L"f_{i1}^{a1} g_{a1}^{i2} p_{i3}^{a2} q_{a2}^{i4}",
+                          {.def_perm_symm = Symmetry::Antisymm});
+  auto tn = net_of(prod);
+  std::vector<Index> tgt{Index{L"i_1"}, Index{L"i_2"}, Index{L"i_3"},
+                         Index{L"i_4"}};
+  auto mask = o::outer_product_connectivity(tn, tgt);
+  for (auto v : mask) CHECK(v == 1);  // disconnected full net -> all-connected
+
+  // And optimize() on the product term must match the env-disabled result.
+  OptimizeOptions opt;
+  opt.objective_function = ObjectiveFunction::DenseFLOPs;
+  opt.idx_to_extent = [](Index const& ix) -> std::size_t {
+    return ix.nonnull() ? ix.space().approximate_size() : 1;
+  };
+  auto with = to_latex(optimize(prod, opt));
+  setenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING", "1", 1);
+  auto without = to_latex(optimize(prod, opt));
+  unsetenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING");
+  CHECK(with == without);
+}
+```
+
+- [ ] **Step 2: Run and verify**
+
+```
+cd SeQuant/build-test && make unit_tests-sequant 2>&1 | tail -8 \
+  && ./tests/unit/unit_tests-sequant "[pruning]"
+```
+Expected: both cases pass; the large-term case returns promptly (well under the
+test's normal budget).
+
+- [ ] **Step 3: clang-format and commit**
+
+```bash
+/opt/homebrew/opt/llvm@17/bin/clang-format --style=file -i tests/unit/test_optimize.cpp
+git add tests/unit/test_optimize.cpp
+git commit -m "optimize: perf smoke + multi-component safety net for DP pruning"
+```
+
+---
+
+## Post-implementation validation (final review, not a task)
+
+After all tasks pass, confirm the real-world win on the C60 term that motivated
+this (needs the TA/dryrun build, not `build-test`): the perf-first optimize of
+the 13-tensor residual term that previously did not finish in 38 minutes now
+completes in seconds. Re-run the local `[dryrun-perfcost]` / batchability-audit
+spike (uncommitted, in `test_eval_dryrun.cpp`) and record the wall time. This is
+the motivating evidence, verified once at the end; it is not a committed test.
+
+## Self-review notes
+
+- **Spec coverage:** adjacency (Task 1) = spec "Adjacency: share a contractible
+  (non-target) index"; connectivity + toggle (Task 2) = spec "Precompute" +
+  "Product terms"; driver + CSE skip (Task 3) = spec "The pruning rule" +
+  "CSE metadata skips disconnected subsets"; parity (Task 4) = spec "Testing (1)"
+  and the "Correctness / loss-free" gate; perf + product safety net (Task 5) =
+  spec "Testing (3),(4)".
+- The plan folds the spec's explicit `full_connected` guard into
+  `outer_product_connectivity` (returns an all-connected mask when the full
+  network is disconnected), so the driver/CSE apply one uniform `!mask[n]` test.
+  Behavior is identical to the spec sketch.
+- Multi-component per-component optimization is NOT implemented (spec non-goal;
+  CC residual summands are single-component by linked-cluster). Product terms
+  take the unpruned path via the mask.

--- a/doc/dev/specs/2026-07-08-outer-product-dp-pruning-design.md
+++ b/doc/dev/specs/2026-07-08-outer-product-dp-pruning-design.md
@@ -217,6 +217,30 @@ Disconnected subsets keep the `numeric_limits<size_t>::max()` sentinel `meta_id`
 `ctx.meta_ids[n]` only for subsets the driver actually DPs -- now connected-only
 -- so no sentinel id is ever dereferenced.
 
+### Reconstruct skips the unrelaxed (pruned) subsets
+
+`AdditiveModel::reconstruct` walks **every** subset to rebuild the winning
+expression from the DP table's `lp`/`rp` back-pointers. A pruned subset was
+never relaxed, so its entry keeps the `lp == 0, rp == 0` sentinel; feeding that
+to the reconstruction arithmetic aborts. The reconstruct loop therefore skips
+the same subsets the driver pruned, keyed off the sentinel rather than
+recomputing connectivity:
+
+```cpp
+else if (std::popcount(n) >= 2) {
+  if (st[n].lp == 0 && st[n].rp == 0) continue;   // pruned: never relaxed
+  ... rebuild n from st[n].lp, st[n].rp ...
+}
+```
+
+This is safe because singletons are handled earlier (the `popcount == 1`
+branch), a genuinely relaxed subset always has non-zero `lp`/`rp` (bit 0 can
+never be a standalone left/right part of a >= 2-bit split), and the connected
+root is always relaxed, so the final expression is always populated. The parity
+test exercises this path: the connected "star" fixture is the one term whose
+`{t,t}` subset is left unrelaxed, so a mishandled sentinel here surfaces as a
+parity mismatch.
+
 ## Correctness
 
 **Loss-free for connected components (under the standard property).** Every

--- a/doc/dev/specs/2026-07-08-outer-product-dp-pruning-design.md
+++ b/doc/dev/specs/2026-07-08-outer-product-dp-pruning-design.md
@@ -296,10 +296,67 @@ points, which share `solve_single_term`.
    perf-first now optimizes in seconds (assert an upper bound on wall time, or
    simply that it completes within the test's normal budget).
 
+## Results (C60 dry-run) and the build_context correction
+
+Measuring the pruned DP on the real C60 term revealed that the DP-level
+subset skip (`solve_single_term`) alone was **not** where the wall time went.
+Two follow-on changes, landed with this PR, were needed to actually realize the
+speedup; the dry-run spike (`test_eval_dryrun.cpp`, local/uncommitted)
+quantified each.
+
+### The dominant cost was `build_context`, not the relax loop
+
+The motivation section above framed the waste as outer-product *relaxes*. In
+practice, for the batched objective the dominant cost is
+`build_context`: `sliced_footprints` builds `2^m` copies (one per sliced-set
+`B`) of the full `2^N`-subset footprint table, and `init_results` /
+`subset_target_indices` build the per-subset index sets for all `2^N` subsets.
+The DP-level subset skip does not touch any of this -- it runs *after*
+`build_context` -- so pruning alone left ~`2^N/connected` (~ 43x on term 0,
+8192 subsets vs ~190 connected) of the work in place.
+
+The fix (see `cost_model.hpp` build_contexts) threads the `connected` mask into
+`init_results` / `subset_footprints` / `sliced_footprints` so tables are built
+only for the subsets the DP will form. Because `sliced_footprints` is
+`2^m * 2^N`, cutting `2^N` to the connected count also cuts the `2^m` factor --
+so the skip **does** attack the batched machinery's cost, contra the initial
+expectation that pruning was orthogonal to `2^m`. `open_aux` is deliberately
+left unpruned: `PeakBatchedModel::is_spectator_axis` scans it over the full
+subset lattice.
+
+### Fast per-subset flop cost
+
+The residual per-relax cost (rebuilding a deduplicated index set and running
+range-v3 views through a `std::function` on every bipartition) is removed by
+`Context::fast_flops`, a precomputed sorted-union merge over per-subset integer
+atom IDs, bit-identical to `flops_of` by construction (gated by
+`[optimize][fast-flops-parity]`).
+
+### Measured (RelWithDebInfo, faithful C60 regime, PAO batching on, m = 7)
+
+All configurations produce the **byte-identical** optimum
+(`biggest_realized = 20.916354976744188 GB` on term 0), confirming loss-free.
+
+| term 0 configuration (fast_flops on)        | wall     |
+|---------------------------------------------|----------|
+| unpruned (no DP skip, no build_context skip)| 430.4 s  |
+| pruned + build_context skip                 | 2.47 s   |
+
+That is ~174x on a single term; before these changes term 0 alone did not
+finish in 10 min. The **full 55-term C60 residual** now sweeps in **~50 s**
+(all terms complete), versus previously un-sweepable. Isolating the
+build_context skip alone (PAO off, m = 1) it is ~15x on top of the DP skip; the
+remaining gain at m = 7 comes from the `2^m` interaction above.
+
+(The remaining over-budget *peak-memory* verdicts in the sweep are a separate
+axis -- node footprint vs the memory budget -- addressed by external-occ forest
+batching, not by this DP-speed work.)
+
 ## Non-goals / future work
 
 - No change to any objective's cost formula, selection policy, or the batched
-  sliced-set (`B`/`Acand`) machinery.
+  sliced-set (`B`/`Acand`) machinery (the build_context skip changes only
+  *which* subsets' tables are built, not their values).
 - **Per-component optimization of product terms.** Multi-component terms disable
   pruning (unpruned DP). Optimizing each component separately and combining by
   outer products is a possible future refinement, deferred because CC residual

--- a/doc/dev/specs/2026-07-08-outer-product-dp-pruning-design.md
+++ b/doc/dev/specs/2026-07-08-outer-product-dp-pruning-design.md
@@ -1,0 +1,282 @@
+# Outer-product (disconnected-subgraph) pruning for the single-term DP
+
+**Goal:** Prune the single-term contraction-ordering DP so it never spends work
+on *outer products* -- bipartitions whose two parts share no **contractible**
+index (an index that is summed somewhere in the term). This collapses the
+per-term search from ~3^n (n = number of tensors) to the number of *connected*
+subnetworks, which is polynomial for the path/tree-shaped tensor networks CC
+residual terms actually produce. Hadamard/partial contractions over a shared
+index that is summed only later (a hyperedge) are **kept** -- they are legitimate
+intermediates, not outer products. The optimal factorization of a connected
+network is unchanged (loss-free); only the search space shrinks.
+
+**Architecture:** Precompute, once per term, a pairwise **contractible-index
+adjacency** over the tensors (edge `i-j` iff they share an index that is not an
+output/target index), and from it the connected components (union-find) and a
+per-subset connectivity table `connected[n]`. In the generic DP driver
+`solve_single_term` (`SeQuant/core/optimize/cost_model.hpp`), skip disconnected
+subsets and relax a bipartition `(lp, rp)` only when both parts are connected
+subnetworks. In the CSE metadata precompute (`build_subnet_metadata`,
+`single_term_detail.hpp`, additive objectives) skip the same disconnected
+subsets, so no outer-product subnetwork is ever canonicalized. A term whose
+adjacency graph has more than one component is a genuine **product** -- which
+CC residual summands never are (linked-cluster theorem) -- and is recognized up
+front from `connected[full]`; there the guards go inert and the term is
+optimized by the original unpruned enumeration. The relax-loop prune is fully
+model-independent; the only per-model touch is a uniform `connected[]` parameter
+threaded through `build_context`.
+
+**Tech stack:** SeQuant C++20, `SeQuant/core/optimize/`.
+
+---
+
+## Problem and motivation
+
+The generic single-term DP driver (`cost_model.hpp:27` `solve_single_term`)
+enumerates, for every subset `n` of the tensors, every bipartition `(lp, rp)`
+and calls `m.relax(...)`:
+
+```cpp
+for (size_t n = 1; n < st.size(); ++n) {
+  if (std::popcount(n) == 1) { st[n] = m.leaf(ctx, n); continue; }
+  typename Model::State acc = m.init(ctx, n);
+  for (auto&& [lp, rp] : bits::bipartitions(n))
+    if (lp != 0 && rp != 0) m.relax(ctx, n, lp, rp, st[lp], st[rp], acc);
+  st[n] = std::move(acc);
+  m.finalize(ctx, n, st);
+}
+```
+
+For the batched objective (`PeakBatchedModel::relax`, `cost_model.hpp:694`) each
+`relax` iterates over all `2^m` sliced-set contexts `B` (m = number of batchable
+aux indices) and, per `B`, all subsets of `Acand` -- **before** it ever inspects
+the child frontiers. So every outer-product bipartition still pays the full
+`2^m * 2^|Acand|` inner cost even though it can never be part of an optimal
+schedule. The number of `(subset, bipartition)` pairs is `~3^n`, and a large
+fraction of them are outer products (splits across a disconnection).
+
+### Evidence
+
+Under the faithful C60 pVDZ-F12 regime (`test_eval_dryrun.cpp`), a **single**
+13-tensor residual term optimized under the perf-first `DenseTimeSpaceBatched`
+objective **did not complete in 38 minutes**. The full 55-term residual is
+therefore un-sweepable, and -- more importantly -- MPQC's own end-to-end
+perf-first path inherits the same wall-clock cost. Perf-first uses no CSE, so
+the cost is entirely these wasted relaxes, not per-subset canonicalization.
+
+## The pruning rule: connected-subgraph DP
+
+A bipartition `(lp, rp)` of a subset `n` is an **outer product** iff `lp` and
+`rp` share no index that is ever summed -- i.e. no *contractible* index. Merging
+them is then a pure tensor product that only inflates rank and can never be part
+of an optimal schedule of a connected term. Sharing an index that survives to
+the result (an output/spectator index) does **not** save a merge: nothing is
+combined, it is still an outer product.
+
+Crucially, a merge that shares a contractible index which is summed only *later*
+(a **hyperedge** -- an index on three-plus tensors, or on two tensors whose
+result is consumed further up) is **not** an outer product. It is a legitimate
+Hadamard/partial-contraction intermediate on the way to that later sum, and it
+is kept. Requiring a merge to *share a contractible index* (rather than to
+*sum one immediately*) is exactly what keeps these and removes the need for any
+whole-network fallback (see below).
+
+Model the tensors as a graph with an edge between two tensors iff they share a
+contractible index (adjacency below). Then:
+
+1. A subset `n` is **connected** iff the subgraph induced on its tensors is
+   connected. A connected subset can always be assembled by allowed merges
+   (grow it one tensor at a time; connectivity guarantees each addition shares a
+   contractible index with the current group). A **disconnected** subset can
+   only be formed by an outer product across its components -- never wanted.
+2. The optimal contraction tree of a connected network is built entirely from
+   connected subsets: its root split `(lp, rp)` has both parts connected (a
+   disconnected part would itself need an internal outer product), recursively.
+
+The rule follows:
+
+```cpp
+// precompute
+connected = connected_subsets(adjacency, nt);   // vector<char>, size 2^nt
+bool full_connected = connected[(1u << nt) - 1];
+
+for (size_t n = 1; n < st.size(); ++n) {
+  if (std::popcount(n) == 1) { st[n] = m.leaf(ctx, n); continue; }
+  if (full_connected && !connected[n]) continue;   // never form a disconnected subset
+  typename Model::State acc = m.init(ctx, n);
+  for (auto&& [lp, rp] : bits::bipartitions(n))
+    if (lp != 0 && rp != 0 &&
+        (!full_connected || (connected[lp] && connected[rp])))
+      m.relax(ctx, n, lp, rp, st[lp], st[rp], acc);
+  st[n] = std::move(acc);
+  m.finalize(ctx, n, st);
+}
+```
+
+When the full network is connected (`full_connected`, the only case that arises
+for CC -- see "Product terms" below), disconnected subsets are skipped entirely
+(no `init`/`relax`/`finalize` -- they pay nothing), and a connected subset is
+relaxed only through bipartitions whose **both** children are connected, so its
+skipped disconnected neighbours are never read as children. When the full
+network is *not* connected, the guards are inert and the loop is the original
+unpruned enumeration.
+
+### Adjacency: share a contractible (non-target) index
+
+`contractible_adjacency(network, tidxs)`: tensors `i` and `j` are adjacent iff
+they share at least one index that is **not** an output/target index of the term
+(`x` with `x not in tidxs`). Such an `x` is summed somewhere in the term -- now,
+if it is private to `i,j`, or later, when the last of its carriers is contracted
+in.
+
+This is a genuine **pairwise, context-independent** graph. The target list is
+consulted only to *classify each index* (contractible vs. output) -- a property
+of the index, not a per-merge context.
+
+- A **hyperedge** -- a contractible index on three-plus tensors -- makes all its
+  carriers mutually adjacent (a clique). This is what lets the DP form the
+  necessary Hadamard intermediates. Example: `A{i;;r} B{j;;r} C{k;;r}` with
+  targets `{i,j,k}` and `r` contractible. `r` links `A,B,C` into one component;
+  the DP is free to form `AB{i,j,r}` (a Hadamard over `r`) and sum `r` when `C`
+  joins. No merge here is a disconnected outer product.
+- A **spectator / output** index -- an external occupied index carried only as a
+  composite protoindex, an aux (mu-tilde / K) index that survives to the output
+  -- is in `tidxs`, so it is **not** contractible and creates **no** edge. Two
+  branches that share *only* the external occ `i,j` are not adjacent: their
+  occ-Hadamard product is never formed early. ("Sharing batched/spectator
+  indices only is still an outer product.")
+
+Adjacency compares indices at the granularity they contract, so two tensors
+carrying different composites with the same protoindices (`a<i,j>` vs `b<i,j>`)
+are **not** adjacent through the shared occupied protos -- those protos are
+outputs, never summed.
+
+### Precompute: index degree + target flag
+
+One pass over all tensor slots yields, per index: its **degree** (number of
+slots it occupies) and whether it **is a target** (`in tidxs`). From these:
+
+- **adjacency / classification:** an index is contractible iff it is not a
+  target (and degree >= 2, i.e. actually shared). `contractible_adjacency` and
+  the component union-find are built directly from the per-index carrier lists.
+- **open-set membership in O(1):** index `x` is *excluded from* `open[n]` (i.e.
+  summed / internal to `n`) iff `x` is not a target **and** all `degree(x)` of
+  its slots lie in `n`. The memorized degree is exactly what decides "is it
+  internal yet?" for hyperedges without rescanning; targets are always open.
+
+`connected_subsets(adjacency, nt)` then fills `connected[n]` for all `2^nt`
+subsets of a component by a BFS/union-find over the induced subgraph. Cost is
+`O(2^nt * nt^2)` (n=13: ~1.4M boolean ops), negligible against the DP it guards.
+It is computed **once per component** and shared by every consumer (it depends
+only on `network` and `tidxs`): built in the `run_single_term_opt` /
+`run_single_term_opt_axes` entry points and handed to both `build_context` (CSE
+metadata) and `solve_single_term` (relax loop).
+
+### Product terms: detected up front, pruning simply disabled
+
+Whether a term is a single connected network or a product of several components
+is read off `connected[(1<<nt)-1]` -- i.e. up front, not by filling the `2^nt`
+table and discovering a dead end at the top.
+
+- **One component** (every CC residual summand -- the linked-cluster theorem
+  guarantees CC residual diagrams are connected -- and every case the perf-first
+  blowup comes from): `full_connected == true`, the pruned DP runs.
+- **More than one component** (a genuine product; does not arise for CC
+  residuals): `full_connected == false`, and the guards above are inert, so the
+  driver and the CSE metadata both fall back to the original unpruned
+  enumeration for that term. It is correct and, because such terms do not occur
+  in the target workload, its cost is irrelevant.
+
+Note this is *not* the over-pruning fallback we started from: the contractible-
+index adjacency already keeps every Hadamard/hyperedge merge, so connected terms
+(including hyperedge terms like `A{i;;r}B{j;;r}C{k;;r}`) are fully pruned with
+**no** fallback. Only genuinely disconnected products -- which CC never produces
+-- take the unpruned path, and they are recognized in `O(nt^2)` before any DP
+work. Optimizing each component separately (and combining by outer products) is
+a possible future refinement, deferred as unnecessary for the target workload.
+
+### CSE metadata skips disconnected subsets too
+
+The CSE-enabled additive objectives precompute, per subset of size >= 2, a
+canonical-subnet id via `build_subnet_metadata` (`single_term_detail.hpp:445`),
+which builds and bliss-canonicalizes a `TensorNetwork` for **every** such
+subset. A disconnected subset is an outer product the pruned DP never forms, so
+its canonical cost is **never looked up** -- canonicalizing it is pure waste
+(a bliss-graph build is not cheap). The same pruning applies here:
+
+```cpp
+for (size_t n = 0; n < results.size(); ++n) {
+  if (std::popcount(n) < 2) continue;
+  if (!connected[n]) continue;            // outer-product subset: never an intermediate
+  ... canonicalize, assign meta id ...
+}
+```
+
+Disconnected subsets keep the `numeric_limits<size_t>::max()` sentinel `meta_id`
+(exactly as singletons do today). `finalize` (`cost_model.hpp:204`) reads
+`ctx.meta_ids[n]` only for subsets the driver actually DPs -- now connected-only
+-- so no sentinel id is ever dereferenced.
+
+## Correctness
+
+**Loss-free for connected components (under the standard property).** Every
+schedule the pruned DP removes contains a *disconnected* intermediate -- an
+outer product `A(x)B` between two groups sharing no contractible index, which
+materializes the full index union of both. For the dense flop / footprint / peak
+objectives here, forming such an intermediate strictly increases both the
+intermediate size and the subsequent contraction's flops relative to a connected
+split whenever one exists. Under this *no-beneficial-outer-product* property, the
+unpruned optimum of a connected component is built entirely from connected
+subsets through connected-child splits (statement (2)), so
+`pruned-optimal == unpruned-optimal` -- identical factorization *and* cost -- for
+every objective. Hadamard/partial-contraction intermediates over hyperedges are
+**not** removed (they share a contractible index), so nothing legitimate is lost.
+
+This is the same heuristic `opt_einsum`/`netcon` apply by default. It is not
+*unconditionally* identical to exhaustive search: there exist pathological
+networks where an outer-product intermediate lowers total cost. Those do not
+arise for the CC/DF-PNO terms this optimizer targets, and the **parity test
+(below) is the empirical guarantee**: it asserts pruned == unpruned on the real
+terms we rely on. A parity failure would flag a genuine outer-product-optimal
+case for reconsideration rather than silently mis-optimizing.
+
+**Product terms are handled by the unpruned path.** A multi-component term
+(`full_connected == false`) disables the guards, so it is optimized exactly as
+today -- no pruning, no change in result. Correctness there is trivially the
+status quo.
+
+**Scope of the change.** The prune is in the shared driver, so it applies to
+every objective (`DenseFLOPs`, `DenseSize`, `DenseSpaceTime`,
+`DenseSpaceTimeBatched`, `DenseTimeSpaceBatched`) and both the sequence-only
+(`run_single_term_opt`) and axes-reporting (`run_single_term_opt_axes`) entry
+points, which share `solve_single_term`.
+
+## Testing
+
+1. **Parity (the primary gate).** For a battery of existing multi-tensor test
+   terms (the small optimize-test networks and a handful of real CC terms),
+   assert the pruned DP returns the byte-identical optimal `EvalSequence` **and**
+   modelled cost as the unpruned DP, for **each** objective. Implemented by
+   running the DP twice behind a temporary "disable pruning" switch (test-only)
+   and comparing. This is the correctness net for the whole change.
+2. **Adjacency / connectivity unit tests.** `contractible_adjacency` /
+   `connected_subsets` on hand-built networks: a path; a star; the
+   `A{i;;r}B{j;;r}C{k;;r}` hyperedge (must be **one** component and the DP must
+   form the `AB{i,j,r}` Hadamard intermediate); a term sharing only a spectator
+   (output) index (must **not** create an edge); a genuine two-component product.
+3. **Product-term (multi-component) safety net.** A deliberately disconnected
+   two-component term optimizes to the same result as before the change
+   (`full_connected == false` disables the guards). Confirms the unpruned path is
+   intact and `connected[full]` correctly detects the product.
+4. **Performance.** The 13-tensor C60 term that did not finish in 38 min under
+   perf-first now optimizes in seconds (assert an upper bound on wall time, or
+   simply that it completes within the test's normal budget).
+
+## Non-goals / future work
+
+- No change to any objective's cost formula, selection policy, or the batched
+  sliced-set (`B`/`Acand`) machinery.
+- **Per-component optimization of product terms.** Multi-component terms disable
+  pruning (unpruned DP). Optimizing each component separately and combining by
+  outer products is a possible future refinement, deferred because CC residual
+  summands are always single-component (linked-cluster) so it would never run.

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -2074,3 +2074,44 @@ TEST_CASE("contractible_adjacency", "[optimize][pruning]") {
       o::contractible_adjacency(composite_same, tgt_composite_same);
   CHECK(edge_count(adj_composite_same) == 1);
 }
+
+TEST_CASE("connected_subsets and outer_product_connectivity",
+          "[optimize][pruning]") {
+  using namespace sequant;
+  namespace o = sequant::opt::detail;
+
+  // Path 0-1-2 : adj[0]={1}, adj[1]={0,2}, adj[2]={1}.
+  container::vector<std::size_t> path{0b010, 0b101, 0b010};
+  auto c = o::connected_subsets(path, 3);
+  REQUIRE(c.size() == 8);
+  CHECK(c[0b001] == 1);  // singleton
+  CHECK(c[0b011] == 1);  // {0,1} share edge
+  CHECK(c[0b110] == 1);  // {1,2} share edge
+  CHECK(c[0b101] == 0);  // {0,2} NOT adjacent -> disconnected
+  CHECK(c[0b111] == 1);  // {0,1,2} connected via 1
+
+  // Two disjoint components {0,1} and {2,3}: full set disconnected.
+  container::vector<std::size_t> prod{0b0010, 0b0001, 0b1000, 0b0100};
+  auto cp = o::connected_subsets(prod, 4);
+  CHECK(cp[0b0011] == 1);  // {0,1}
+  CHECK(cp[0b1100] == 1);  // {2,3}
+  CHECK(cp[0b1111] == 0);  // full: disconnected product
+
+  // outer_product_connectivity: env-disabled -> all ones.
+  auto ctx_resetter = set_scoped_default_context(get_default_context().clone());
+  auto reg = get_default_context().mutable_index_space_registry();
+  reg->retrieve_ptr(L"i")->approximate_size(10);
+  reg->retrieve_ptr(L"a")->approximate_size(100);
+  reg->retrieve_ptr(L"x")->approximate_size(4);
+  auto prod_expr = deserialize(L"f_{i1}^{a1} g_{a1}^{i2}",
+                               {.def_perm_symm = Symmetry::Antisymm});
+  container::vector<ExprPtr> v;
+  for (auto&& f : prod_expr->as<Product>().factors())
+    if (f->is<Tensor>()) v.push_back(f);
+  TensorNetwork tn{v};
+  std::vector<Index> tgt{Index{L"i_1"}, Index{L"i_2"}};
+  setenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING", "1", 1);
+  auto m_off = o::outer_product_connectivity(tn, tgt);
+  unsetenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING");
+  for (auto val : m_off) CHECK(val == 1);
+}

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -2149,7 +2149,36 @@ TEST_CASE("outer-product pruning parity (pruned == unpruned)",
       L"g_{i1,i2}^{a1,a2} t_{a1}^{i1} t_{a2}^{i2} t_{a3}^{i3}",
       // hyperedge-flavored: three tensors sharing a common summed index a5
       L"p_{i1}^{a5} q_{i2}^{a5} r_{i3}^{a5} s_{a5}^{i4}",
+      // "star": g bridges both t's (whole network connected), but {t,t}
+      // shares no index, so the {t,t} subset is a genuinely prunable outer
+      // product. This is the fixture that actually exercises the pruning
+      // skip -- see the non-vacuousness guard below.
+      L"g_{i1,i2}^{a1,a2} t_{a1}^{i1} t_{a2}^{i2}",
   };
+
+  // Non-vacuousness guard: the parity checks below only prove pruning is
+  // loss-free if the pruned DP actually skips subsets the unpruned DP visits.
+  // A fixture whose full network is disconnected falls back to an all-connected
+  // mask (pruning is a no-op), so parity would hold even with a broken skip.
+  // Assert that the "star" fixture yields a connected full network yet a
+  // disconnected proper subset -- i.e. its mask really does prune something.
+  {
+    namespace o = sequant::opt::detail;
+    unsetenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING");
+    auto star = deserialize(L"g_{i1,i2}^{a1,a2} t_{a1}^{i1} t_{a2}^{i2}",
+                            {.def_perm_symm = Symmetry::Antisymm});
+    container::vector<ExprPtr> sv;
+    for (auto&& f : star->as<Product>().factors())
+      if (f->is<Tensor>()) sv.push_back(f);
+    TensorNetwork star_tn{sv};
+    std::vector<Index> const star_tgt{};  // fully contracted -> empty target
+    auto star_mask = o::outer_product_connectivity(star_tn, star_tgt);
+    REQUIRE(star_mask.back() == 1);  // full network connected (not fallback)
+    bool has_pruned_subset = false;
+    for (auto v : star_mask)
+      if (v == 0) has_pruned_subset = true;
+    REQUIRE(has_pruned_subset);  // at least one subset is genuinely pruned
+  }
 
   auto run = [&](std::wstring const& term, ObjectiveFunction obj, bool prune) {
     if (prune)

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -2046,4 +2046,31 @@ TEST_CASE("contractible_adjacency", "[optimize][pruning]") {
   std::vector<Index> tgt_spec{Index{L"i_1"}, Index{L"a_1"}, Index{L"a_2"}};
   auto adj_spec = o::contractible_adjacency(spec, tgt_spec);
   CHECK(edge_count(adj_spec) == 0);
+
+  // Composite (CSV/PNO) indices: u and v carry DIFFERENT top-level composite
+  // indices (distinct base labels a vs g) that happen to share the SAME
+  // occupied protoindices {i1,i2}. contractible_adjacency only iterates
+  // top-level bra/ket/aux indices, so a1<i1,i2> and g1<i1,i2> are two
+  // distinct entries in the carrier map (different base label/space) even
+  // though their protoindices coincide; those shared protoindices i1,i2 are
+  // never themselves iterated as standalone indices, so no edge must form.
+  // Targets are the plain externals i3,i4 only -- neither the composite
+  // indices nor their protoindices are targets, so a zero edge count here is
+  // not merely an artifact of exclusion-via-target.
+  auto composite_diff = net_of(parse(L"u_{i3}^{a1<i1,i2>} v_{i4}^{g1<i1,i2>}"));
+  std::vector<Index> tgt_composite_diff{Index{L"i_3"}, Index{L"i_4"}};
+  auto adj_composite_diff =
+      o::contractible_adjacency(composite_diff, tgt_composite_diff);
+  CHECK(edge_count(adj_composite_diff) == 0);
+
+  // Positive control: u and v now genuinely share the SAME top-level
+  // composite index a1<i1,i2> (not merely the same protoindices), which
+  // must produce an edge. This confirms the zero count above is because the
+  // composites differ, not because composite indices can never be
+  // adjacency carriers at all.
+  auto composite_same = net_of(parse(L"u_{i5}^{a1<i1,i2>} v_{a1<i1,i2>}^{i6}"));
+  std::vector<Index> tgt_composite_same{Index{L"i_5"}, Index{L"i_6"}};
+  auto adj_composite_same =
+      o::contractible_adjacency(composite_same, tgt_composite_same);
+  CHECK(edge_count(adj_composite_same) == 1);
 }

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -2200,3 +2200,67 @@ TEST_CASE("outer-product pruning parity (pruned == unpruned)",
       CHECK(pruned == unpruned);
     }
 }
+
+TEST_CASE("outer-product pruning: large connected term optimizes quickly",
+          "[optimize][pruning]") {
+  using namespace sequant;
+  auto ctx_resetter = set_scoped_default_context(get_default_context().clone());
+  auto reg = get_default_context().mutable_index_space_registry();
+  reg->retrieve_ptr(L"i")->approximate_size(10);
+  reg->retrieve_ptr(L"a")->approximate_size(100);
+  reg->retrieve_ptr(L"x")->approximate_size(4);
+  // A connected chain: each adjacent pair shares one summed index, so the whole
+  // term is one connected component. The pruned DP explores only connected
+  // subsets and finishes fast; the unpruned 3^n enumeration is far slower.
+  auto expr = deserialize(
+      L"g_{a0,a1}^{a2,a3} t_{a2}^{a4} t_{a3}^{a5} t_{a4}^{a6} t_{a5}^{a7} "
+      L"t_{a6}^{a8} t_{a7}^{a9} v_{a8,a9}^{a0,a1}",
+      {.def_perm_symm = Symmetry::Antisymm});
+  OptimizeOptions o;
+  o.objective_function = ObjectiveFunction::DensePeakSize;
+  o.idx_to_extent = [](Index const& ix) -> std::size_t {
+    return ix.nonnull() ? ix.space().approximate_size() : 1;
+  };
+  // Pruning ON (default): must complete (the assertion is that it returns).
+  auto out = optimize(expr, o);
+  CHECK(out);
+}
+
+TEST_CASE("outer-product pruning: multi-component product falls back unpruned",
+          "[optimize][pruning]") {
+  using namespace sequant;
+  namespace o = sequant::opt::detail;
+  auto ctx_resetter = set_scoped_default_context(get_default_context().clone());
+  auto reg = get_default_context().mutable_index_space_registry();
+  reg->retrieve_ptr(L"i")->approximate_size(10);
+  reg->retrieve_ptr(L"a")->approximate_size(100);
+  reg->retrieve_ptr(L"x")->approximate_size(4);
+  auto net_of = [](ExprPtr const& p) {
+    container::vector<ExprPtr> v;
+    for (auto&& f : p->as<Product>().factors())
+      if (f->is<Tensor>()) v.push_back(f);
+    return TensorNetwork{v};
+  };
+
+  // Two independent contractions sharing NO summed index: {f,g} over a1,
+  // {p,q} over a2. The full adjacency graph has two components.
+  auto prod = deserialize(L"f_{i1}^{a1} g_{a1}^{i2} p_{i3}^{a2} q_{a2}^{i4}",
+                          {.def_perm_symm = Symmetry::Antisymm});
+  auto tn = net_of(prod);
+  std::vector<Index> tgt{Index{L"i_1"}, Index{L"i_2"}, Index{L"i_3"},
+                         Index{L"i_4"}};
+  auto mask = o::outer_product_connectivity(tn, tgt);
+  for (auto v : mask) CHECK(v == 1);  // disconnected full net -> all-connected
+
+  // And optimize() on the product term must match the env-disabled result.
+  OptimizeOptions opt;
+  opt.objective_function = ObjectiveFunction::DenseFLOPs;
+  opt.idx_to_extent = [](Index const& ix) -> std::size_t {
+    return ix.nonnull() ? ix.space().approximate_size() : 1;
+  };
+  auto with = to_latex(optimize(prod, opt));
+  setenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING", "1", 1);
+  auto without = to_latex(optimize(prod, opt));
+  unsetenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING");
+  CHECK(with == without);
+}

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -2201,6 +2201,41 @@ TEST_CASE("outer-product pruning parity (pruned == unpruned)",
     }
 }
 
+TEST_CASE("prune_outer_products option controls pruning (default on)",
+          "[optimize][pruning]") {
+  using namespace sequant;
+  // The requirement: pruning is user-controllable and ON by default.
+  CHECK(OptimizeOptions{}.prune_outer_products == true);
+
+  auto ctx_resetter = set_scoped_default_context(get_default_context().clone());
+  auto reg = get_default_context().mutable_index_space_registry();
+  reg->retrieve_ptr(L"i")->approximate_size(10);
+  reg->retrieve_ptr(L"a")->approximate_size(100);
+  reg->retrieve_ptr(L"x")->approximate_size(4);
+  // "star" term: g bridges two mutually-disconnected t's, so the {t,t} subset
+  // is a genuinely prunable outer product (the option's code path fires).
+  auto expr = deserialize(L"g_{i1,i2}^{a1,a2} t_{a1}^{i1} t_{a2}^{i2}",
+                          {.def_perm_symm = Symmetry::Antisymm});
+  auto opts_for = [&](bool prune) {
+    OptimizeOptions o;
+    o.objective_function = ObjectiveFunction::DensePeakSize;
+    o.idx_to_extent = [](Index const& ix) -> std::size_t {
+      return ix.nonnull() ? ix.space().approximate_size() : 1;
+    };
+    o.prune_outer_products = prune;
+    return o;
+  };
+  // Pruning is loss-free, so both option values give the same factorization.
+  auto with_prune = to_latex(optimize(expr, opts_for(true)));
+  auto no_prune = to_latex(optimize(expr, opts_for(false)));
+  CHECK(with_prune == no_prune);
+  // prune_outer_products == false must reproduce the env force-disable path.
+  setenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING", "1", 1);
+  auto env_disabled = to_latex(optimize(expr, opts_for(true)));
+  unsetenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING");
+  CHECK(no_prune == env_disabled);
+}
+
 TEST_CASE("outer-product pruning: large connected term optimizes quickly",
           "[optimize][pruning]") {
   using namespace sequant;

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <bit>
 #include <cstddef>
+#include <cstdlib>
 #include <functional>
 #include <initializer_list>
 #include <limits>
@@ -2003,3 +2004,46 @@ TEST_CASE("quadratic bubble: early-K integral vs late-K t·(gC)",
   CHECK(real_config_integral(/*K_b=*/236));      // above crossover -> early-K
 }
 #endif  // __OPTIMIZE__
+
+TEST_CASE("contractible_adjacency", "[optimize][pruning]") {
+  using namespace sequant;
+  namespace o = sequant::opt::detail;
+  auto ctx_resetter = set_scoped_default_context(get_default_context().clone());
+  auto reg = get_default_context().mutable_index_space_registry();
+  reg->retrieve_ptr(L"i")->approximate_size(10);
+  reg->retrieve_ptr(L"a")->approximate_size(100);
+  reg->retrieve_ptr(L"x")->approximate_size(4);
+  auto parse = [](auto const& s) {
+    return deserialize(s, {.def_perm_symm = Symmetry::Antisymm});
+  };
+  auto net_of = [](ExprPtr const& prod) {
+    container::vector<ExprPtr> v;
+    for (auto&& f : prod->as<Product>().factors())
+      if (f->is<Tensor>()) v.push_back(f);
+    return TensorNetwork{v};
+  };
+  auto edge_count = [](container::vector<std::size_t> const& adj) {
+    std::size_t s = 0;
+    for (auto m : adj) s += static_cast<std::size_t>(std::popcount(m));
+    return s / 2;  // each undirected edge counted twice
+  };
+
+  // Chain: f-g share a1; g-h share a2. Targets {i1,i2}. 2 edges.
+  auto chain = net_of(parse(L"f_{i1}^{a1} g_{a1}^{a2} h_{a2}^{i2}"));
+  std::vector<Index> tgt2{Index{L"i_1"}, Index{L"i_2"}};
+  auto adj_chain = o::contractible_adjacency(chain, tgt2);
+  REQUIRE(adj_chain.size() == 3);
+  CHECK(edge_count(adj_chain) == 2);
+
+  // Hyperedge: p,q,r all carry summed a5 -> clique (3 edges).
+  auto hyper = net_of(parse(L"p_{i1}^{a5} q_{i2}^{a5} r_{i3}^{a5}"));
+  std::vector<Index> tgt3{Index{L"i_1"}, Index{L"i_2"}, Index{L"i_3"}};
+  auto adj_hyper = o::contractible_adjacency(hyper, tgt3);
+  CHECK(edge_count(adj_hyper) == 3);
+
+  // Spectator-only: two tensors share only the target index i1 -> no edges.
+  auto spec = net_of(parse(L"u_{i1}^{a1} v_{i1}^{a2}"));
+  std::vector<Index> tgt_spec{Index{L"i_1"}, Index{L"a_1"}, Index{L"a_2"}};
+  auto adj_spec = o::contractible_adjacency(spec, tgt_spec);
+  CHECK(edge_count(adj_spec) == 0);
+}

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -2236,6 +2236,79 @@ TEST_CASE("prune_outer_products option controls pruning (default on)",
   CHECK(no_prune == env_disabled);
 }
 
+// PeakBatchedModel's relax tie-break reads the precomputed per-subset atom
+// tables (Context::fast_flops) instead of rebuilding index sets and calling
+// flops_of per bipartition. fast_flops is loss-free by construction (atom IDs
+// in FullLabelCompare order => same multiply order as inner_aware_volume). Gate
+// that construction directly: for every connected bipartition of a composite
+// (PNO/OSV) term and a plain term, with and without inner_pow engaged,
+// fast_flops(lp, rp) must equal flops_of(idx[lp], idx[rp], idx[lp|rp]) exactly.
+TEST_CASE("fast_flops equals flops_of over all bipartitions (parity)",
+          "[optimize][fast-flops-parity]") {
+  using namespace sequant;
+  namespace o = opt::detail;
+  auto ctx_resetter = set_scoped_default_context(get_default_context().clone());
+  auto reg = get_default_context().mutable_index_space_registry();
+  mbpt::add_df_spaces(reg);
+  mbpt::add_pao_spaces(reg);
+  mbpt::add_ao_spaces(reg);
+  for (auto&& [k, v] :
+       std::initializer_list<std::pair<std::wstring_view, size_t>>{
+           {L"i", 10}, {L"a", 40}, {L"μ̃", 50}, {L"Κ", 90}})
+    reg->retrieve_ptr(k)->approximate_size(v);
+  auto idxsz = [](Index const& ix) -> std::size_t {
+    return ix.nonnull() ? ix.space().approximate_size() : std::size_t{1};
+  };
+  auto is_batchable = [](Index const& ix) {
+    return ix.space().base_key() == L"Κ";
+  };
+  auto batch = [](Index const&) -> std::size_t { return 30; };
+
+  std::function<double(Index const&, std::size_t)> const ip_on =
+      [](Index const&, std::size_t) -> double { return 12.0; };
+  std::function<double(Index const&, std::size_t)> const ip_off = {};
+
+  bool composite_inner_checked = false;
+  for (std::wstring const term :
+       {std::wstring(L"g{μ̃1;μ̃2;Κ1} C{a1<i1>;μ̃1} C{μ̃2;a2<i1,i2>} t{a1<i1>;i1}"),
+        std::wstring(L"g{i1;a1;Κ1} g{i2;a2;Κ1} t{a1;i1} t{a2;i2}")}) {
+    for (auto const* ip : {&ip_on, &ip_off}) {
+      auto prod = deserialize(term)->as<Product>();
+      std::vector<ExprPtr> ts;
+      for (auto&& f : prod.factors())
+        if (f->is<Tensor>()) ts.push_back(f);
+      TensorNetwork net{ts};
+      container::svector<Index> const targets;
+      o::PeakBatchedModel<decltype(idxsz)> model{idxsz, is_batchable, batch,
+                                                 /*is_volatile_leaf=*/{}, *ip};
+      auto ctx = model.build_context(net, targets);
+      REQUIRE(ctx.use_fast_flops);
+      auto const connected = o::outer_product_connectivity(net, targets);
+      std::size_t const root = (std::size_t{1} << ts.size()) - 1;
+      bool checked_bipart = false;
+      for (std::size_t n = 1; n <= root; ++n) {
+        if (std::popcount(n) < 2 || !connected[n]) continue;
+        // enumerate every proper non-empty submask lp of n (rp = n ^ lp)
+        for (std::size_t lp = (n - 1) & n; lp; lp = (lp - 1) & n) {
+          std::size_t const rp = n ^ lp;
+          if (rp == 0 || !connected[lp] || !connected[rp]) continue;
+          checked_bipart = true;
+          double const fast = ctx.fast_flops(lp, rp);
+          double const slow =
+              ctx.flops_of(ctx.idx[lp], ctx.idx[rp], ctx.idx[n]);
+          CAPTURE(term, (ip == &ip_on), n, lp, rp, fast, slow);
+          CHECK(fast == slow);  // bit-identical by construction
+          if (!ctx.f_inner[lp].empty() || !ctx.f_inner[rp].empty())
+            composite_inner_checked = true;
+        }
+      }
+      REQUIRE(checked_bipart);  // non-vacuous
+    }
+  }
+  // The composite term must actually exercise the inner (CSV/PNO) atom path.
+  REQUIRE(composite_inner_checked);
+}
+
 TEST_CASE("outer-product pruning: large connected term optimizes quickly",
           "[optimize][pruning]") {
   using namespace sequant;

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -2115,3 +2115,59 @@ TEST_CASE("connected_subsets and outer_product_connectivity",
   unsetenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING");
   for (auto val : m_off) CHECK(val == 1);
 }
+
+TEST_CASE("outer-product pruning parity (pruned == unpruned)",
+          "[optimize][pruning]") {
+  using namespace sequant;
+  auto ctx_resetter = set_scoped_default_context(get_default_context().clone());
+  auto reg = get_default_context().mutable_index_space_registry();
+  reg->retrieve_ptr(L"i")->approximate_size(10);
+  reg->retrieve_ptr(L"a")->approximate_size(100);
+  reg->retrieve_ptr(L"x")->approximate_size(4);
+
+  auto opts_for = [&](ObjectiveFunction obj) {
+    OptimizeOptions o;
+    o.objective_function = obj;
+    o.idx_to_extent = [](Index const& ix) -> std::size_t {
+      return ix.nonnull() ? ix.space().approximate_size() : 1;
+    };
+    o.batch_policy.is_batchable_index = [](Index const&) { return false; };
+    o.batch_policy.batch_target_size = [](Index const&) -> std::size_t {
+      return 1;
+    };
+    return o;
+  };
+
+  std::vector<ObjectiveFunction> const objs{
+      ObjectiveFunction::DenseFLOPs, ObjectiveFunction::DenseSize,
+      ObjectiveFunction::DensePeakSize,
+      ObjectiveFunction::DensePeakSizeBatched};
+
+  std::vector<std::wstring> const terms{
+      L"1/4 g_{i2,i3}^{a2,a3} t_{a2,a3}^{i2,i3} t_{a1}^{i1}",
+      L"x_{i1,i2}^{a3,a4} y_{a1,a2}^{i1,i2} z_{a3,a4}^{a1,a2}",
+      L"g_{i1,i2}^{a1,a2} t_{a1}^{i1} t_{a2}^{i2} t_{a3}^{i3}",
+      // hyperedge-flavored: three tensors sharing a common summed index a5
+      L"p_{i1}^{a5} q_{i2}^{a5} r_{i3}^{a5} s_{a5}^{i4}",
+  };
+
+  auto run = [&](std::wstring const& term, ObjectiveFunction obj, bool prune) {
+    if (prune)
+      unsetenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING");
+    else
+      setenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING", "1", 1);
+    auto expr = deserialize(term, {.def_perm_symm = Symmetry::Antisymm});
+    auto out = optimize(expr, opts_for(obj));
+    unsetenv("SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING");
+    REQUIRE(out);
+    return to_latex(out);
+  };
+
+  for (std::size_t ti = 0; ti < terms.size(); ++ti)
+    for (auto obj : objs) {
+      auto pruned = run(terms[ti], obj, true);
+      auto unpruned = run(terms[ti], obj, false);
+      CAPTURE(ti, static_cast<int>(obj));
+      CHECK(pruned == unpruned);
+    }
+}


### PR DESCRIPTION
## Outer-product (disconnected-subgraph) pruning of the single-term DP

Prunes the single-term contraction dynamic program so it never forms a
*disconnected* intermediate (an outer product). Any subset of tensors whose
induced subgraph is disconnected under the "share a contractible (non-target)
index" relation is skipped: it is an outer product the optimal tree never
forms, so removing it prunes search space without changing the result. Pruning
is applied uniformly in the shared driver (`solve_single_term`) **and** in
every objective's `build_context`, is exposed as a user option, and is paired
with a per-subset flop-cost precompute that removes the DP's other hot spot.

### Why

The single-term DP iterates subsets x bipartitions, and the peak/batched
models pay a full inner cost (sliced-set contexts x candidate frontiers) for
*every* bipartition before inspecting it -- so outer-product bipartitions,
which a good factorization never uses, dominate the cost on large terms. One
13-tensor term did not finish optimizing in 38 minutes. Skipping disconnected
subsets is the standard `opt_einsum`/`netcon` heuristic.

### Adjacency

Tensors `i, j` are adjacent iff they share a top-level (bra/ket/aux) index that
is **not** in the target (external) set -- i.e. a summed/contractible index. A
contractible index carried by 3+ tensors (a hyperedge) makes all its carriers a
clique, so Hadamard / partial-contraction intermediates are **not** pruned.
Protoindices are never consulted, so external indices carried as protoindices
create no spurious edges. A term whose full network is itself disconnected (a
product / multi-component term) disables pruning entirely and is optimized
exactly as before.

### User control

Pruning is on by default and user-controllable via
`OptimizeOptions::prune_outer_products` (default `true`), threaded to each
model. Setting it `false` reproduces the pre-pruning DP exactly. The test-only
env var `SEQUANT_DISABLE_OUTER_PRODUCT_PRUNING` force-overrides to the unpruned
path (used by the parity gate).

### build_context skip

The DP driver already skipped disconnected subsets, but each model's
`build_context` still eagerly built the per-subset index sets and footprint
tables for all 2^N subsets -- the bulk of build_context time on wide terms,
untouched by the driver-level skip. The `connected` mask is now threaded
through `init_results` / `subset_footprints` / `sliced_footprints` and the
three model build_contexts (`AdditiveModel`, `PeakModel`, `PeakBatchedModel`)
so tables are built only for subsets the DP will actually form. The
index-count utilities need a wider mask than `connected` alone --
`subset_target_indices[i]` consults `counts[complement(i)]`, and a connected
subset's complement is usually disconnected -- so `subset_index_counts` is
gated by `needed[i] = connected[i] || connected[complement(i)]`, derived
inside `subset_target_indices` where the dependency lives.

`open_aux` is deliberately **not** pruned: `PeakBatchedModel::is_spectator_axis`
scans `open_aux` over the full subset lattice (including disconnected subsets)
to verify an external axis is never contracted, so every entry must be real.

### Fast per-subset flop cost

`PeakBatchedModel::relax` evaluated its (peak, then flops) tie-break by calling
`flops_of(idx[lp], idx[rp], idx[n])` once per bipartition -- each call rebuilds
a deduplicated index set and runs range-v3 lazy views through a `std::function`,
far more than the arithmetic it performs; on wide terms this per-relax cost
dominates. `Context::fast_flops` precomputes, once in `build_context`, per-subset
sorted atom-ID lists (outer = plain indices + composite proto-indices; inner =
CSV/PNO composites) and computes a bipartition's flop count by a sorted-union
merge over integer IDs. IDs are assigned in `FullLabelCompare` order so the
union multiplies in the SAME order as `inner_aware_volume`, and composites are
grouped by proto-signature to reproduce the k-aware `inner_pow` charge, making
`fast_flops` **bit-identical** to `flops_of`. `flops_of` is retained as the
reference path (`use_fast_flops == false`).

### Loss-free

For a connected component the optimal tree is built entirely from connected
subsets, so `pruned-optimal == unpruned-optimal` -- identical factorization and
cost -- for every objective. This is asserted directly by a parity test
(`to_latex(pruned) == to_latex(unpruned)` across all objectives and several
terms, including a connected "star" fixture that genuinely exercises the
skip, guarded so the fixture can never silently degenerate). The build_context
skip is covered by that same gate (it only fires on the pruned path). The
flop-cost precompute has its own gate (see below).

See `doc/dev/specs/2026-07-08-outer-product-dp-pruning-design.md` for the full
design and correctness argument, and the matching plan under `doc/dev/plans/`.

### Tests

`tests/unit/test_optimize.cpp`:
- `[optimize][pruning]`: adjacency/connectivity unit coverage (including
  composite CSV/PNO indices), the loss-free parity gate, the
  `prune_outer_products` option default/equivalence test, a
  large-connected-term performance smoke test, and a multi-component
  safety-net test.
- `[optimize][fast-flops-parity]`: `fast_flops(lp, rp) == flops_of(idx[lp],
  idx[rp], idx[lp|rp])` for every connected bipartition of a composite (PNO)
  term and a plain term, with and without `inner_pow` engaged.
