### PR TITLE
Change defaults for `mbpt::lst`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,6 +367,7 @@ set(SeQuant_symb_src
         SeQuant/core/tensor_network/v2.hpp
         SeQuant/core/tensor_network/v3.cpp
         SeQuant/core/tensor_network/v3.hpp
+        SeQuant/core/utility/aggregate.hpp
         SeQuant/core/utility/atomic.hpp
         SeQuant/core/utility/context.hpp
         SeQuant/core/utility/debug.hpp

--- a/SeQuant/core/utility/aggregate.hpp
+++ b/SeQuant/core/utility/aggregate.hpp
@@ -18,6 +18,11 @@ class designated_init_only {
  public:
   constexpr designated_init_only(const designated_init_only&) noexcept =
       default;
+  /// declaring the copy constructor deprecates the *implicit* copy assignment
+  /// (-Wdeprecated-copy, an error under this project's -Werror), so declare it
+  /// too -- a guarded aggregate must stay copy-assignable
+  constexpr designated_init_only& operator=(
+      const designated_init_only&) noexcept = default;
   static constexpr designated_init_only make() noexcept { return {}; }
 
  private:
@@ -71,6 +76,13 @@ static_assert(std::is_aggregate_v<designated_init_only_probe>);
 static_assert(std::is_trivially_copyable_v<designated_init_only_probe>);
 static_assert(sizeof(designated_init_only_probe) == 2 * sizeof(bool),
               "[[no_unique_address]] must elide the tag member");
+/// odr-uses the copy assignment, which is what diagnoses -Wdeprecated-copy;
+/// a trait check alone would not, since it never defines the operator
+static_assert([] {
+  designated_init_only_probe p{};
+  p = designated_init_only_probe{.a = true};
+  return p.a;
+}());
 
 }  // namespace sequant::detail
 

--- a/SeQuant/core/utility/aggregate.hpp
+++ b/SeQuant/core/utility/aggregate.hpp
@@ -5,18 +5,72 @@
 #ifndef SEQUANT_CORE_UTILITY_AGGREGATE_HPP
 #define SEQUANT_CORE_UTILITY_AGGREGATE_HPP
 
+#include <type_traits>
+
 namespace sequant::detail {
 
-/// Tag type for a hidden first member of an aggregate `Options`-style struct,
-/// to force designated initialization at every call site, e.g.
-/// `Options{.foo = true}` rather than `Options{true, false}`. Positional
-/// aggregate init is otherwise still legal C++, so renaming, reordering, or
-/// adding a field silently reinterprets any positional-init caller instead of
-/// failing to compile.
-/// @note declare it `[[no_unique_address]] designated_only designated_only_ =
-/// {};` as the struct's first member; designated initializers may skip a
-/// defaulted member, so this does not need to be named at any call site.
-struct designated_only {};
+/// Tag type used by SEQUANT_DESIGNATED_INIT_ONLY; not meant to be named
+/// directly. Its default constructor is private, so the only way to produce one
+/// is `make()`, which is what the macro's default member initializer calls.
+/// That is what makes both `Opts{a, b}` (`bool` does not convert to this type)
+/// and `Opts{{}, a, b}` (no accessible default constructor) ill-formed.
+class designated_init_only {
+ public:
+  constexpr designated_init_only(const designated_init_only&) noexcept =
+      default;
+  static constexpr designated_init_only make() noexcept { return {}; }
+
+ private:
+  constexpr designated_init_only() noexcept = default;
+};
+
+}  // namespace sequant::detail
+
+// clang-format off
+/// Declares a hidden first member of an `Options`-style aggregate that makes
+/// positional (non-designated) aggregate initialization ill-formed, so that
+/// every call site must name the fields it sets:
+/// @code
+///   struct LSTOptions {
+///     SEQUANT_DESIGNATED_INIT_ONLY;
+///     bool unitary = false;
+///     bool use_connected_form = false;
+///   };
+/// @endcode
+/// Positional aggregate init is otherwise legal C++, and it is not merely
+/// unreadable: reordering the fields, or changing the meaning of one while
+/// keeping its position, silently reinterprets any positional caller instead of
+/// failing to compile. Designated initializers do not have that failure mode --
+/// renaming a field is a hard error at every call site that sets it.
+///
+/// Rejected: `Opts{a, b}` and `Opts{{}, a, b}`.
+/// Still accepted, and unaffected: `Opts{}`, `Opts{.field = a}`, copy and move,
+/// `Opts` as a defaulted function parameter (`f(Opts opts = {})`), and use in
+/// constant expressions.
+///
+/// @note Must be the *first* member, and requires C++20 designated
+/// initializers.
+/// @note The member is declared `[[no_unique_address]]`, so the aggregate's
+/// size is unchanged, and it stays an aggregate and trivially copyable.
+// clang-format on
+#define SEQUANT_DESIGNATED_INIT_ONLY                            \
+  [[no_unique_address]] ::sequant::detail::designated_init_only \
+      sequant_designated_init_only_ =                           \
+          ::sequant::detail::designated_init_only::make()
+
+namespace sequant::detail {
+
+/// self-test of SEQUANT_DESIGNATED_INIT_ONLY: the guard must not change what
+/// the aggregate *is*, only how it may be written
+struct designated_init_only_probe {
+  SEQUANT_DESIGNATED_INIT_ONLY;
+  bool a = false;
+  bool b = false;
+};
+static_assert(std::is_aggregate_v<designated_init_only_probe>);
+static_assert(std::is_trivially_copyable_v<designated_init_only_probe>);
+static_assert(sizeof(designated_init_only_probe) == 2 * sizeof(bool),
+              "[[no_unique_address]] must elide the tag member");
 
 }  // namespace sequant::detail
 

--- a/SeQuant/core/utility/aggregate.hpp
+++ b/SeQuant/core/utility/aggregate.hpp
@@ -1,0 +1,23 @@
+//
+// Created by Ajay Melekamburath on 8/4/26.
+//
+
+#ifndef SEQUANT_CORE_UTILITY_AGGREGATE_HPP
+#define SEQUANT_CORE_UTILITY_AGGREGATE_HPP
+
+namespace sequant::detail {
+
+/// Tag type for a hidden first member of an aggregate `Options`-style struct,
+/// to force designated initialization at every call site, e.g.
+/// `Options{.foo = true}` rather than `Options{true, false}`. Positional
+/// aggregate init is otherwise still legal C++, so renaming, reordering, or
+/// adding a field silently reinterprets any positional-init caller instead of
+/// failing to compile.
+/// @note declare it `[[no_unique_address]] designated_only designated_only_ =
+/// {};` as the struct's first member; designated initializers may skip a
+/// defaulted member, so this does not need to be named at any call site.
+struct designated_only {};
+
+}  // namespace sequant::detail
+
+#endif  // SEQUANT_CORE_UTILITY_AGGREGATE_HPP

--- a/SeQuant/core/utility/aggregate.hpp
+++ b/SeQuant/core/utility/aggregate.hpp
@@ -74,8 +74,15 @@ struct designated_init_only_probe {
 };
 static_assert(std::is_aggregate_v<designated_init_only_probe>);
 static_assert(std::is_trivially_copyable_v<designated_init_only_probe>);
+// [[no_unique_address]] elision is permitted, not required, and MSVC ignores
+// the standard spelling outright (it has [[msvc::no_unique_address]], since
+// honoring this one would change its ABI). A toolchain that does not elide
+// still gets a working guard -- the tag merely costs a byte -- so check the
+// size only where elision is guaranteed rather than failing the build over it.
+#if !defined(_MSC_VER) || defined(__clang__)
 static_assert(sizeof(designated_init_only_probe) == 2 * sizeof(bool),
               "[[no_unique_address]] must elide the tag member");
+#endif
 /// odr-uses the copy assignment, which is what diagnoses -Wdeprecated-copy;
 /// a trait check alone would not, since it never defines the operator
 static_assert([] {

--- a/SeQuant/domain/mbpt/models/cc.cpp
+++ b/SeQuant/domain/mbpt/models/cc.cpp
@@ -67,8 +67,11 @@ bool CC::use_topology() const { return use_topology_; }
 
 ExprPtr CC::hbar(std::optional<size_t> truncation_rank) const {
   const auto truncation = truncation_rank.value_or(hbar_comm_rank_.value_or(4));
+
+  // the non-unitary path supplies operator connectivity downstream (see
+  // energy(), t(), etc.), so the cheaper connected-product form is used there
   return mbpt::lst(H(), T(N, skip_singles()), truncation,
-                   {.unitary = unitary()});
+                   {.unitary = unitary(), .use_connected_form = !unitary()});
 }
 
 ExprPtr CC::energy(std::optional<size_t> comm_rank) const {
@@ -154,8 +157,9 @@ std::vector<ExprPtr> CC::λ() const {
 
   // element 0: λ pseudoenergy, computed as the CC energy with T → Λ⁺.
   {
-    const auto hbar_λ =
-        mbpt::lst(H(), adjoint(Λ(N, skip_singles())), commutator_rank);
+    const auto hbar_λ = mbpt::lst(
+        H(), adjoint(Λ(N, skip_singles())), commutator_rank,
+        {.use_connected_form = true});  // ref_av connects h/f/g with λ⁺
     result.at(0) = this->ref_av(
         hbar_λ, {{L"h", L"λ⁺"}, {L"f", L"λ⁺"}, {L"f̃", L"λ⁺"}, {L"g", L"λ⁺"}});
   }
@@ -219,9 +223,9 @@ std::vector<ExprPtr> CC::tʼ(size_t rank, size_t order,
   // for two-body perturbation operator; unless specified otherwise
   const auto h1_truncate_default = rank == 1 ? 2 : 4;
   const auto h1_truncate_at = pertbar_comm_rank_.value_or(h1_truncate_default);
-  const auto h1_bar =
-      mbpt::lst(Hʼ(rank, {.order = order, .nbatch = nbatch}),
-                T(N, skip_singles()), h1_truncate_at, {.unitary = unitary()});
+  const auto h1_bar = mbpt::lst(
+      Hʼ(rank, {.order = order, .nbatch = nbatch}), T(N, skip_singles()),
+      h1_truncate_at, {.unitary = unitary(), .use_connected_form = !unitary()});
 
   // construct [hbar, Tʼ(1)]
   const auto hbar_truncate_at = hbar_comm_rank_.value_or(
@@ -283,8 +287,9 @@ std::vector<ExprPtr> CC::λʼ(size_t rank, size_t order,
   // for two-body perturbation operator; unless specified otherwise
   const auto h1_truncate_at = (rank == 1) ? pertbar_comm_rank_.value_or(2)
                                           : pertbar_comm_rank_.value_or(4);
-  const auto h1_bar = mbpt::lst(Hʼ(rank, {.order = order, .nbatch = nbatch}),
-                                T(N, skip_singles()), h1_truncate_at);
+  const auto h1_bar = mbpt::lst(
+      Hʼ(rank, {.order = order, .nbatch = nbatch}), T(N, skip_singles()),
+      h1_truncate_at, {.use_connected_form = true});  // λʼ is non-unitary
 
   // construct [hbar, T(1)]
   const auto hbar_pert =

--- a/SeQuant/domain/mbpt/models/cc.cpp
+++ b/SeQuant/domain/mbpt/models/cc.cpp
@@ -68,10 +68,10 @@ bool CC::use_topology() const { return use_topology_; }
 ExprPtr CC::hbar(std::optional<size_t> truncation_rank) const {
   const auto truncation = truncation_rank.value_or(hbar_comm_rank_.value_or(4));
 
-  // the non-unitary path supplies operator connectivity downstream (see
-  // energy(), t(), etc.), so the cheaper connected-product form is used there
-  return mbpt::lst(H(), T(N, skip_singles()), truncation,
-                   {.unitary = unitary(), .use_connected_form = !unitary()});
+  // for a non-unitary ansatz this is the cheaper connected-product form, which
+  // is only equivalent to the commutator once the caller supplies operator
+  // connectivity to ref_av (see lst_options() and the @warning on hbar())
+  return mbpt::lst(H(), T(N, skip_singles()), truncation, lst_options());
 }
 
 ExprPtr CC::energy(std::optional<size_t> comm_rank) const {
@@ -157,9 +157,10 @@ std::vector<ExprPtr> CC::λ() const {
 
   // element 0: λ pseudoenergy, computed as the CC energy with T → Λ⁺.
   {
-    const auto hbar_λ = mbpt::lst(
-        H(), adjoint(Λ(N, skip_singles())), commutator_rank,
-        {.use_connected_form = true});  // ref_av connects h/f/g with λ⁺
+    // connected form; the ref_av below supplies the connectivity that makes it
+    // equivalent to the commutator, here {h,f,f̃,g} with λ⁺ rather than with t
+    const auto hbar_λ = mbpt::lst(H(), adjoint(Λ(N, skip_singles())),
+                                  commutator_rank, lst_options());
     result.at(0) = this->ref_av(
         hbar_λ, {{L"h", L"λ⁺"}, {L"f", L"λ⁺"}, {L"f̃", L"λ⁺"}, {L"g", L"λ⁺"}});
   }
@@ -223,9 +224,9 @@ std::vector<ExprPtr> CC::tʼ(size_t rank, size_t order,
   // for two-body perturbation operator; unless specified otherwise
   const auto h1_truncate_default = rank == 1 ? 2 : 4;
   const auto h1_truncate_at = pertbar_comm_rank_.value_or(h1_truncate_default);
-  const auto h1_bar = mbpt::lst(
-      Hʼ(rank, {.order = order, .nbatch = nbatch}), T(N, skip_singles()),
-      h1_truncate_at, {.unitary = unitary(), .use_connected_form = !unitary()});
+  const auto h1_bar =
+      mbpt::lst(Hʼ(rank, {.order = order, .nbatch = nbatch}),
+                T(N, skip_singles()), h1_truncate_at, lst_options());
 
   // construct [hbar, Tʼ(1)]
   const auto hbar_truncate_at = hbar_comm_rank_.value_or(
@@ -287,9 +288,12 @@ std::vector<ExprPtr> CC::λʼ(size_t rank, size_t order,
   // for two-body perturbation operator; unless specified otherwise
   const auto h1_truncate_at = (rank == 1) ? pertbar_comm_rank_.value_or(2)
                                           : pertbar_comm_rank_.value_or(4);
-  const auto h1_bar = mbpt::lst(
-      Hʼ(rank, {.order = order, .nbatch = nbatch}), T(N, skip_singles()),
-      h1_truncate_at, {.use_connected_form = true});  // λʼ is non-unitary
+  // connected form (this path is non-unitary, see the assert above); the
+  // op_connect built below is a superset of default_op_connections() and so
+  // supplies the connectivity that makes it equivalent to the commutator
+  const auto h1_bar =
+      mbpt::lst(Hʼ(rank, {.order = order, .nbatch = nbatch}),
+                T(N, skip_singles()), h1_truncate_at, lst_options());
 
   // construct [hbar, T(1)]
   const auto hbar_pert =

--- a/SeQuant/domain/mbpt/models/cc.hpp
+++ b/SeQuant/domain/mbpt/models/cc.hpp
@@ -3,6 +3,7 @@
 
 #include <SeQuant/core/op.hpp>
 #include <SeQuant/domain/mbpt/op.hpp>
+#include <SeQuant/domain/mbpt/utils.hpp>
 #include <SeQuant/domain/mbpt/vac_av.hpp>
 
 #include <cstddef>
@@ -94,7 +95,13 @@ class CC {
   /// connected product, \f$ (\hat{A}\hat{B})_c \f$, equivalent to \f$
   /// [\hat{A},\hat{B}] \f$ only once operator connectivity is supplied
   /// downstream. A unitary ansatz uses explicit commutators and needs no
-  /// connectivity.
+  /// connectivity. @see lst_options
+  /// @warning Because of the above, the expression returned for a non-unitary
+  /// ansatz is NOT self-contained: evaluating it with empty connectivity, e.g.
+  /// `op::ref_av(P(nₚ(2)) * cc.hbar(), {.connect = {}})`, silently retains the
+  /// disconnected terms that the commutator would have cancelled. Pass
+  /// `default_op_connections()` (the default of `op::ref_av`/`op::vac_av`), or
+  /// build H̄ yourself with `mbpt::lst(..., {})` if you need the explicit form.
   [[nodiscard]] ExprPtr hbar(
       std::optional<size_t> truncation_rank = std::nullopt) const;
 
@@ -177,6 +184,18 @@ class CC {
   bool use_topology_ = true;
   std::optional<size_t> hbar_comm_rank_ = std::nullopt;
   std::optional<size_t> pertbar_comm_rank_ = std::nullopt;
+
+  /// @return the `LSTOptions` this engine uses for every `mbpt::lst()` call
+  /// @note The choice of commutator representation is really a question of
+  /// whether the caller supplies operator connectivity downstream; for this
+  /// engine the two coincide. Every non-unitary path hands `ref_av` a
+  /// connectivity map (`default_op_connections()`, or the λ⁺/perturbed
+  /// supersets thereof), which is what makes the cheaper connected-product
+  /// form equivalent to the explicit commutator. The unitary paths hand
+  /// `ref_av` empty connectivity and so must use explicit commutators.
+  [[nodiscard]] LSTOptions lst_options() const {
+    return {.unitary = unitary(), .use_connected_form = !unitary()};
+  }
 
   /// @brief computes reference expectation value of an expression. Dispatches
   /// to `mbpt::op::ref_av()`

--- a/SeQuant/domain/mbpt/models/cc.hpp
+++ b/SeQuant/domain/mbpt/models/cc.hpp
@@ -94,14 +94,19 @@ class CC {
   /// @note For a non-unitary ansatz each commutator is represented as a
   /// connected product, \f$ (\hat{A}\hat{B})_c \f$, equivalent to \f$
   /// [\hat{A},\hat{B}] \f$ only once operator connectivity is supplied
-  /// downstream. A unitary ansatz uses explicit commutators and needs no
-  /// connectivity. @see lst_options
+  /// downstream; this engine always supplies it, by handing `ref_av`
+  /// `default_op_connections()` or a superset thereof. A unitary ansatz uses
+  /// explicit commutators instead, and is handed empty connectivity.
   /// @warning Because of the above, the expression returned for a non-unitary
   /// ansatz is NOT self-contained: evaluating it with empty connectivity, e.g.
   /// `op::ref_av(P(nₚ(2)) * cc.hbar(), {.connect = {}})`, silently retains the
   /// disconnected terms that the commutator would have cancelled. Pass
-  /// `default_op_connections()` (the default of `op::ref_av`/`op::vac_av`), or
-  /// build H̄ yourself with `mbpt::lst(..., {})` if you need the explicit form.
+  /// `default_op_connections()` (which `op::ref_av`/`op::vac_av` use when the
+  /// options argument is omitted -- note that passing `{}` instead gives empty
+  /// connections), or build H̄ yourself with `mbpt::lst(..., {})` if you need
+  /// the explicit form. For a unitary ansatz the reverse holds: H̄ is already
+  /// self-contained, so connectivity must be left empty. See the "Using H̄
+  /// outside the CC class" section of the user guide.
   [[nodiscard]] ExprPtr hbar(
       std::optional<size_t> truncation_rank = std::nullopt) const;
 

--- a/SeQuant/domain/mbpt/models/cc.hpp
+++ b/SeQuant/domain/mbpt/models/cc.hpp
@@ -90,6 +90,11 @@ class CC {
   /// the expansion; if not specified, will use the value of member
   /// `hbar_comm_rank`. If that is also not specified, will use 4 as the default
   /// value. If provided, will override all defaults.
+  /// @note For a non-unitary ansatz each commutator is represented as a
+  /// connected product, \f$ (\hat{A}\hat{B})_c \f$, equivalent to \f$
+  /// [\hat{A},\hat{B}] \f$ only once operator connectivity is supplied
+  /// downstream. A unitary ansatz uses explicit commutators and needs no
+  /// connectivity.
   [[nodiscard]] ExprPtr hbar(
       std::optional<size_t> truncation_rank = std::nullopt) const;
 

--- a/SeQuant/domain/mbpt/utils.cpp
+++ b/SeQuant/domain/mbpt/utils.cpp
@@ -12,10 +12,6 @@ namespace sequant::mbpt {
 ExprPtr lst(ExprPtr A, ExprPtr B, size_t commutator_rank, LSTOptions options) {
   if (commutator_rank == 0) return A;  // nothing to do here
 
-  // if use_commutators is not set, set to true if unitary is true, else false
-  if (!options.use_commutators.has_value())
-    options.use_commutators = options.unitary;
-
   // use cloned expr to avoid side effects
   if (!options.skip_clone) A = A->clone();
 
@@ -28,21 +24,21 @@ ExprPtr lst(ExprPtr A, ExprPtr B, size_t commutator_rank, LSTOptions options) {
     for (size_t k = 1; k <= commutator_rank; ++k) {
       ExprPtr op_Sk_comm_w_S;
 
-      if (options.use_commutators.value()) {
-        // commutator form: [O,B] = OB - BO
-        op_Sk_comm_w_S = op_Sk * B - B * op_Sk;
-
-        if (options.unitary) {
-          // [O, B-B^+] = [O,B] - [O,B^+]
-          op_Sk_comm_w_S -= (op_Sk * adjoint(B) - adjoint(B) * op_Sk);
-        }
-      } else {
+      if (options.use_connected_form) {
         // connected form: [O,B] = (O B)_c
         op_Sk_comm_w_S = op_Sk * B;
 
         if (options.unitary) {
           // [O,B-B^+] = (O B)_c + (B^+ O)_c
           op_Sk_comm_w_S += adjoint(B) * op_Sk;
+        }
+      } else {
+        // commutator form: [O,B] = OB - BO
+        op_Sk_comm_w_S = op_Sk * B - B * op_Sk;
+
+        if (options.unitary) {
+          // [O, B-B^+] = [O,B] - [O,B^+]
+          op_Sk_comm_w_S -= (op_Sk * adjoint(B) - adjoint(B) * op_Sk);
         }
       }
 

--- a/SeQuant/domain/mbpt/utils.hpp
+++ b/SeQuant/domain/mbpt/utils.hpp
@@ -8,6 +8,7 @@
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/rational.hpp>
 #include <SeQuant/core/runtime.hpp>
+#include <SeQuant/core/utility/aggregate.hpp>
 
 #include <SeQuant/domain/mbpt/op.hpp>
 
@@ -15,6 +16,11 @@ namespace sequant::mbpt {
 
 /// Options for Lie Similarity Transformation. @see lst
 struct LSTOptions {
+  /// Present only to force designated initialization, e.g.
+  /// `LSTOptions{.unitary = true}` rather than `LSTOptions{true, false}`.
+  /// Renaming/reordering the fields below would otherwise silently reinterpret
+  /// any positional-init caller instead of failing to compile.
+  [[no_unique_address]] sequant::detail::designated_only designated_only_ = {};
   /// If true, uses unitary generator
   bool unitary = false;
   /// If true, uses connected products [A,B] = (AB)_c; otherwise uses explicit

--- a/SeQuant/domain/mbpt/utils.hpp
+++ b/SeQuant/domain/mbpt/utils.hpp
@@ -17,10 +17,11 @@ namespace sequant::mbpt {
 struct LSTOptions {
   /// If true, uses unitary generator
   bool unitary = false;
-  /// If true, uses explicit commutators [A,B] = AB - BA; otherwise uses
-  /// connected products (AB)_c
-  /// If not explicitly set, LST will set this to the value of unitary
-  std::optional<bool> use_commutators = std::nullopt;
+  /// If true, uses connected products [A,B] = (AB)_c; otherwise uses explicit
+  /// commutators [A,B] = AB - BA. The connected-product form is only
+  /// equivalent if the caller supplies operator connectivity downstream, hence
+  /// the default is the explicit form.
+  bool use_connected_form = false;
   /// If true, will not clone the input expression
   bool skip_clone = false;
 };
@@ -36,9 +37,8 @@ struct LSTOptions {
 /// @sa LSTOptions
 /// Notes:
 /// - If \p options.unitary is true, the ansatz uses B - B^+ instead of B.
-/// - If \p options.use_commutators is false, commutators are computed via connected products: [A,B] = (AB)_c
-/// - If \p options.use_commutators is true, commutators are computed explicitly: [A,B] = AB - BA
-/// - If \p options.use_commutators is not set, it defaults to the value of \p options.unitary. i.e., unless explicitly specified, unitary ansatz will always use commutators.
+/// - By default commutators are computed explicitly: [A,B] = AB - BA
+/// - If \p options.use_connected_form is true, commutators are computed via connected products: [A,B] = (AB)_c ; this is only valid if the caller connects the operators (e.g. by passing OpConnections to vac_av/ref_av), so set it only if you do.
 /// @pre This function expects \p A and \p B to be composed of mbpt::Operators
 // clang-format on
 ExprPtr lst(ExprPtr A, ExprPtr B, size_t commutator_rank,

--- a/SeQuant/domain/mbpt/utils.hpp
+++ b/SeQuant/domain/mbpt/utils.hpp
@@ -16,11 +16,12 @@ namespace sequant::mbpt {
 
 /// Options for Lie Similarity Transformation. @see lst
 struct LSTOptions {
-  /// Present only to force designated initialization, e.g.
-  /// `LSTOptions{.unitary = true}` rather than `LSTOptions{true, false}`.
-  /// Renaming/reordering the fields below would otherwise silently reinterpret
-  /// any positional-init caller instead of failing to compile.
-  [[no_unique_address]] sequant::detail::designated_only designated_only_ = {};
+  /// makes positional init (`LSTOptions{true, false}`) ill-formed, so every
+  /// call site must name what it sets (`LSTOptions{.unitary = true}`); without
+  /// it, reordering the fields below -- or flipping the meaning of one while
+  /// keeping its position, as `use_connected_form` did to `use_commutators` --
+  /// silently reinterprets positional callers instead of failing to compile
+  SEQUANT_DESIGNATED_INIT_ONLY;
   /// If true, uses unitary generator
   bool unitary = false;
   /// If true, uses connected products [A,B] = (AB)_c; otherwise uses explicit

--- a/doc/user/guide/cc.rst
+++ b/doc/user/guide/cc.rst
@@ -44,7 +44,7 @@ The :class:`CC <sequant::mbpt::CC>` class supports several CC ansätze through t
 - ``Ansatz::oU``: Orbital-optimized unitary ansatz, combines both unitary and orbital optimized ansätze.
 
 Key Methods
-----------
+-----------
 
 Ground State Amplitudes
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -124,7 +124,7 @@ Response and Perturbation Equations
    :dedent: 2
 
 Advanced Usage
--------------
+--------------
 
 Truncating the Commutator Expansion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -136,6 +136,31 @@ The similarity-transformed Hamiltonian is built by ``mbpt::lst``, see :ref:`mbpt
    :start-after: start-snippet-4
    :end-before: end-snippet-4
    :dedent: 2
+
+.. _cc-hbar-connectivity:
+
+Using :math:`\bar{H}` outside the CC class
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:func:`CC::hbar() <sequant::mbpt::CC::hbar>` is public, but for a non-unitary ansatz the expression it returns is **not** self-contained: each commutator is written as a connected product (see :ref:`mbpt-lst`), which only equals the commutator once you connect the operators when taking the expectation value. The class always does this for you — every non-unitary path passes ``default_op_connections()`` (or a superset) to ``ref_av``. A caller who does not will silently retain the disconnected terms:
+
+.. code-block:: cpp
+
+   using namespace sequant::mbpt;
+
+   CC cc{2};
+
+   // correct: op::ref_av defaults to default_op_connections()
+   auto eqs = op::ref_av(op::P(nₚ(2)) * cc.hbar());
+
+   // WRONG: empty connectivity keeps terms the commutator would have cancelled
+   auto bad = op::ref_av(op::P(nₚ(2)) * cc.hbar(), {.connect = {}});
+
+   // also correct: ask lst for the explicit commutator form, which needs
+   // no connectivity
+   auto hbar = lst(op::H(), op::T(2), 4);
+
+A unitary ansatz is unaffected: it already uses explicit commutators and the class passes empty connectivity.
 
 .. _cc-spin-tracing:
 

--- a/doc/user/guide/cc.rst
+++ b/doc/user/guide/cc.rst
@@ -140,7 +140,7 @@ The similarity-transformed Hamiltonian is built by ``mbpt::lst``, see :ref:`mbpt
 .. _cc-hbar-connectivity:
 
 Using :math:`\bar{H}` outside the CC class
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :func:`CC::hbar() <sequant::mbpt::CC::hbar>` is public, but for a non-unitary ansatz the expression it returns is **not** self-contained: each commutator is written as a connected product (see :ref:`mbpt-lst`), which only equals the commutator once you connect the operators when taking the expectation value. The class always does this for you — every non-unitary path passes ``default_op_connections()`` (or a superset) to ``ref_av``. A caller who does not will silently retain the disconnected terms:
 
@@ -160,7 +160,16 @@ Using :math:`\bar{H}` outside the CC class
    // no connectivity
    auto hbar = lst(op::H(), op::T(2), 4);
 
-A unitary ansatz is unaffected: it already uses explicit commutators and the class passes empty connectivity.
+Note that ``op::ref_av(expr)`` and ``op::ref_av(expr, {})`` are *not* the same call: the connectivity defaults to ``default_op_connections()`` only when the argument is omitted entirely, since ``EVOptions::connect`` is itself empty by default.
+
+The two ``ref_av`` calls above swap roles for a unitary ansatz, so it is not simply "unaffected". There :func:`CC::hbar() <sequant::mbpt::CC::hbar>` already returns explicit commutators, and imposing connectivity on top of them would drop terms that must survive; a caller must therefore pass empty connections explicitly, as the class does internally:
+
+.. code-block:: cpp
+
+   CC ucc{2, {.ansatz = CC::Ansatz::U, .hbar_comm_rank = 3}};
+
+   // correct for a unitary ansatz: hbar is already self-contained
+   auto ueqs = op::ref_av(op::P(nₚ(2)) * ucc.hbar(), {.connect = {}});
 
 .. _cc-spin-tracing:
 

--- a/doc/user/guide/cc.rst
+++ b/doc/user/guide/cc.rst
@@ -46,17 +46,6 @@ The :class:`CC <sequant::mbpt::CC>` class supports several CC ansätze through t
 Key Methods
 ----------
 
-Lie Similarity Transformation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: cpp
-
-   ExprPtr lst(ExprPtr A, ExprPtr B, size_t r);
-
-Returns Lie similarity transformation, :math:`\bar{A} = e^{-\hat{B}} \hat{A} e^{\hat{B}}`, as a series of nested commutators, :math:`[\hat{A},\hat{B}]`, :math:`[[\hat{A},\hat{B}],\hat{B}]`, etc., up to order ``r``.
-
-The method ``lst`` is used internally by the CC class to construct the similarity-transformed Hamiltonian. It is, however, provided as a standalone utility and can be used independently by including the header ``<SeQuant/domain/mbpt/utils.hpp>``.
-
 Ground State Amplitudes
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -140,7 +129,7 @@ Advanced Usage
 Truncating the Commutator Expansion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For traditional CC with two-body Hamiltonians, the commutator expansion is truncated at the a 4th-order. However, for unitary CC or other Hamiltonians, you may need to explicitly set the commutator rank:
+The similarity-transformed Hamiltonian is built by ``mbpt::lst``, see :ref:`mbpt-lst`. For traditional CC with two-body Hamiltonians, the commutator expansion is truncated at 4th order. However, for unitary CC or other Hamiltonians, you may need to explicitly set the commutator rank:
 
 .. literalinclude:: /examples/user/cc.cpp
    :language: cpp

--- a/doc/user/guide/operator.rst
+++ b/doc/user/guide/operator.rst
@@ -149,6 +149,10 @@ Both forms give the same equations, given the right connectivity. They differ in
 
 Mind which overload you reach: the operator-level ``op::vac_av``/``op::ref_av`` default to ``default_op_connections()``, which connects the Hamiltonian (``h``, ``f``, ``f̃``, ``g``) with the cluster operator ``t``. Their tensor-level counterparts, ``op::tensor::vac_av``/``op::tensor::ref_av``, default to *empty* connections. Pairing ``use_connected_form = true`` with empty connectivity silently keeps the disconnected terms the commutator would have cancelled, so the result is wrong rather than merely more verbose.
 
+Mind also that omitting the options argument is not the same as passing ``{}``: ``default_op_connections()`` is the default of the *parameter*, whereas ``EVOptions::connect`` is itself empty by default, so ``op::ref_av(expr)`` connects the operators and ``op::ref_av(expr, {})`` does not.
+
+The same trade-off shows up in :func:`CC::hbar() <sequant::mbpt::CC::hbar>`, which returns the connected form for a non-unitary ansatz; see :ref:`cc-hbar-connectivity`.
+
 Examples
 --------
 

--- a/doc/user/guide/operator.rst
+++ b/doc/user/guide/operator.rst
@@ -125,10 +125,20 @@ The behavior of ``lst`` is controlled by :class:`LSTOptions <sequant::mbpt::LSTO
 .. code-block:: cpp
 
    struct LSTOptions {
+     SEQUANT_DESIGNATED_INIT_ONLY;  // see below
      bool unitary = false;
      bool use_connected_form = false;
      bool skip_clone = false;
    };
+
+``LSTOptions`` must be written with C++20 designated initializers --
+``LSTOptions{.unitary = true}``, or ``{}`` for all defaults. Positional
+initialization, ``LSTOptions{true, false}``, is rejected at compile time by the
+``SEQUANT_DESIGNATED_INIT_ONLY`` member. This is deliberate: fields have been
+reordered and repurposed before (``use_connected_form`` took the position of
+the older ``use_commutators`` and inverted its meaning), and a positional call
+site would have kept compiling with its meaning silently changed. Naming the
+fields makes any such change a compile error instead.
 
 - ``unitary``: if true, :math:`\hat{B}` is replaced by :math:`\hat{B} - \hat{B}^\dagger`, i.e. the method returns :math:`e^{-(\hat{B} - \hat{B}^\dagger)} \hat{A} e^{\hat{B} - \hat{B}^\dagger}`. Use this for unitary ansätze.
 

--- a/doc/user/guide/operator.rst
+++ b/doc/user/guide/operator.rst
@@ -107,6 +107,46 @@ Custom operators can be registered to extend SeQuant's vocabulary. Once register
 
 The registry is stored in the :class:`mbpt::Context <sequant::mbpt::Context>`. See the unit test cases for further manipulations with :class:`mbpt::Context <sequant::mbpt::Context>` and :class:`mbpt::OpRegistry <sequant::mbpt::OpRegistry>`.
 
+.. _mbpt-lst:
+
+Lie Similarity Transformation
+-----------------------------
+
+.. code-block:: cpp
+
+   ExprPtr lst(ExprPtr A, ExprPtr B, size_t r, LSTOptions options = {});
+
+Returns Lie similarity transformation, :math:`\bar{A} = e^{-\hat{B}} \hat{A} e^{\hat{B}}`, as a series of nested commutators, :math:`[\hat{A},\hat{B}]`, :math:`[[\hat{A},\hat{B}],\hat{B}]`, etc., up to order ``r``.
+
+The method ``lst`` is declared in ``<SeQuant/domain/mbpt/utils.hpp>``. The :class:`CC <sequant::mbpt::CC>` class uses it to construct the similarity-transformed Hamiltonian, but it is a standalone utility and can be used on any expression built from ``mbpt::Operator``.
+
+The behavior of ``lst`` is controlled by :class:`LSTOptions <sequant::mbpt::LSTOptions>`:
+
+.. code-block:: cpp
+
+   struct LSTOptions {
+     bool unitary = false;
+     bool use_connected_form = false;
+     bool skip_clone = false;
+   };
+
+- ``unitary``: if true, :math:`\hat{B}` is replaced by :math:`\hat{B} - \hat{B}^\dagger`, i.e. the method returns :math:`e^{-(\hat{B} - \hat{B}^\dagger)} \hat{A} e^{\hat{B} - \hat{B}^\dagger}`. Use this for unitary ansätze.
+
+- ``use_connected_form``: selects how each commutator is written, see below.
+
+- ``skip_clone``: if true, ``A`` is transformed in place instead of being cloned first. Set it only if nothing else holds a reference to ``A``.
+
+Commutators or connected products
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each commutator can be written in two ways, and ``use_connected_form`` selects between them:
+
+- ``false`` (the default) writes it explicitly, :math:`[\hat{A},\hat{B}] = \hat{A}\hat{B} - \hat{B}\hat{A}`.
+
+- ``true`` writes it as a connected product, :math:`(\hat{A}\hat{B})_c`. This gives fewer terms, but only reproduces the commutator once the same operators are connected downstream when taking the expectation value, using ``OpConnections``.
+
+Both forms give the same equations, given the right connectivity. They differ in *where* the disconnected terms are removed: the commutator removes them algebraically, the connected product relies on the connectivity you supply to ``vac_av``/``ref_av`` (which connect the Hamiltonian with the cluster operator by default, see below).
+
 Examples
 --------
 

--- a/doc/user/guide/operator.rst
+++ b/doc/user/guide/operator.rst
@@ -145,7 +145,9 @@ Each commutator can be written in two ways, and ``use_connected_form`` selects b
 
 - ``true`` writes it as a connected product, :math:`(\hat{A}\hat{B})_c`. This gives fewer terms, but only reproduces the commutator once the same operators are connected downstream when taking the expectation value, using ``OpConnections``.
 
-Both forms give the same equations, given the right connectivity. They differ in *where* the disconnected terms are removed: the commutator removes them algebraically, the connected product relies on the connectivity you supply to ``vac_av``/``ref_av`` (which connect the Hamiltonian with the cluster operator by default).
+Both forms give the same equations, given the right connectivity. They differ in *where* the disconnected terms are removed: the commutator removes them algebraically, the connected product relies on the connectivity you supply to ``vac_av``/``ref_av``.
+
+Mind which overload you reach: the operator-level ``op::vac_av``/``op::ref_av`` default to ``default_op_connections()``, which connects the Hamiltonian (``h``, ``f``, ``f̃``, ``g``) with the cluster operator ``t``. Their tensor-level counterparts, ``op::tensor::vac_av``/``op::tensor::ref_av``, default to *empty* connections. Pairing ``use_connected_form = true`` with empty connectivity silently keeps the disconnected terms the commutator would have cancelled, so the result is wrong rather than merely more verbose.
 
 Examples
 --------

--- a/doc/user/guide/operator.rst
+++ b/doc/user/guide/operator.rst
@@ -145,7 +145,7 @@ Each commutator can be written in two ways, and ``use_connected_form`` selects b
 
 - ``true`` writes it as a connected product, :math:`(\hat{A}\hat{B})_c`. This gives fewer terms, but only reproduces the commutator once the same operators are connected downstream when taking the expectation value, using ``OpConnections``.
 
-Both forms give the same equations, given the right connectivity. They differ in *where* the disconnected terms are removed: the commutator removes them algebraically, the connected product relies on the connectivity you supply to ``vac_av``/``ref_av`` (which connect the Hamiltonian with the cluster operator by default, see below).
+Both forms give the same equations, given the right connectivity. They differ in *where* the disconnected terms are removed: the commutator removes them algebraically, the connected product relies on the connectivity you supply to ``vac_av``/``ref_av`` (which connect the Hamiltonian with the cluster operator by default).
 
 Examples
 --------

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -617,6 +617,11 @@ TEST_CASE("mbpt", "[mbpt][valgrind_skip]") {
               commutator(commutator(commutator(H(), t(2)), t(2)), t(2));
       REQUIRE(simplify(expr2 - expected2) == ex<Constant>(0));
 
+      // the default LSTOptions must produce the explicit commutator form, i.e.
+      // lst() must never assume the caller supplies operator connectivity
+      REQUIRE(simplify(lst(H(), t(2), 3) - expected2) == ex<Constant>(0));
+      REQUIRE(simplify(lst(H(), t(2), 3, {}) - expected2) == ex<Constant>(0));
+
       // unitary, rank 2
       using sequant::adjoint;
       auto expr3 =
@@ -635,6 +640,11 @@ TEST_CASE("mbpt", "[mbpt][valgrind_skip]") {
           ex<Constant>(rational{1, 2}) * (commutator(generator, t(2)) -
                                           commutator(generator, adjoint(t(2))));
       REQUIRE(simplify(expr4 - expected4) == ex<Constant>(0));
+
+      // `unitary` must no longer select the commutator representation: it only
+      // swaps B for B - B^+, leaving use_connected_form at its default
+      REQUIRE(simplify(lst(H(), t(2), 2, {.unitary = true}) - expected4) ==
+              ex<Constant>(0));
     }  // SECTION("lst")
 
     SECTION("predefined") {

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -571,7 +571,8 @@ TEST_CASE("mbpt", "[mbpt][valgrind_skip]") {
       REQUIRE(to_latex(vev2_op) == to_latex(vev2_t));
 
       // Test screen_vac_av
-      auto hbar = mbpt::lst(H(), t(2), 4);  // CCD Hbar
+      // CCD Hbar in connected-product form
+      auto hbar = mbpt::lst(H(), t(2), 4, {.use_connected_form = true});
       auto screened_hbar = screen_vac_av(hbar);
       auto expected = h(2) * t(2);
       REQUIRE(simplify(screened_hbar - expected) == ex<Constant>(0));
@@ -599,7 +600,7 @@ TEST_CASE("mbpt", "[mbpt][valgrind_skip]") {
 
       // non-unitary, rank 3
       auto expr1 =
-          lst(H(), t(2), 3, {.unitary = false, .use_commutators = false});
+          lst(H(), t(2), 3, {.unitary = false, .use_connected_form = true});
       auto expected1 =
           H() *
           (ex<Constant>(1) + t(2) + ex<Constant>(rational{1, 2}) * t(2) * t(2) +
@@ -607,7 +608,7 @@ TEST_CASE("mbpt", "[mbpt][valgrind_skip]") {
       REQUIRE(simplify(expr1 - expected1) == ex<Constant>(0));
 
       auto expr2 =
-          lst(H(), t(2), 3, {.unitary = false, .use_commutators = true});
+          lst(H(), t(2), 3, {.unitary = false, .use_connected_form = false});
       auto expected2 =
           H() + commutator(H(), t(2)) +
           ex<Constant>(rational{1, 2}) *
@@ -619,7 +620,7 @@ TEST_CASE("mbpt", "[mbpt][valgrind_skip]") {
       // unitary, rank 2
       using sequant::adjoint;
       auto expr3 =
-          lst(H(), t(2), 2, {.unitary = true, .use_commutators = false});
+          lst(H(), t(2), 2, {.unitary = true, .use_connected_form = true});
       auto expected3 =
           H() + H() * t(2) + adjoint(t(2)) * H() + adjoint(t(2)) * H() * t(2) +
           H() * ex<Constant>(rational{1, 2}) * t(2) * t(2) +
@@ -627,7 +628,7 @@ TEST_CASE("mbpt", "[mbpt][valgrind_skip]") {
       REQUIRE(simplify(expr3 - expected3) == ex<Constant>(0));
 
       auto expr4 =
-          lst(H(), t(2), 2, {.unitary = true, .use_commutators = true});
+          lst(H(), t(2), 2, {.unitary = true, .use_connected_form = false});
       auto generator = commutator(H(), t(2)) - commutator(H(), adjoint(t(2)));
       auto expected4 =
           H() + generator +
@@ -1240,10 +1241,11 @@ SECTION("manuscript-examples") {
   /// When order > 0, returns sim. transformed perturbation operator or given
   /// order.
   auto H̅ = [](size_t order = 0) {
-    auto hbar0 = lst(op::H(), T(2), 4);
+    auto hbar0 = lst(op::H(), T(2), 4, {.use_connected_form = true});
     if (order == 0) return hbar0;
     // only one-body perturbation operator
-    auto hbar_pt = lst(op::Hʼ(/*rank*/ 1, {.order = order}), T(2), 2);
+    auto hbar_pt = lst(op::Hʼ(/*rank*/ 1, {.order = order}), T(2), 2,
+                       {.use_connected_form = true});
     return hbar_pt;
   };
 
@@ -1272,7 +1274,7 @@ SECTION("manuscript-examples") {
   SECTION("CC LR Function") {
     const int N = 2;  // CC rank
 
-    auto θ̅ = lst(θ(1), T(N), 2);
+    auto θ̅ = lst(θ(1), T(N), 2, {.use_connected_form = true});
     auto expr = (1 + Λ(N)) * θ̅ * Tʼ(N) + Λʼ(N) * θ̅;
     auto result = ref_av(expr, {.connect = {{L"θ", L"t"}, {L"θ", L"t¹"}}});
     // number of terms is verified against MPQC4 implementation


### PR DESCRIPTION
`mbpt::lst`'s default assumed the caller knew about operator connectivity:
- `mbpt::lst` now uses explicit commutators, [A,B] = AB - BA by default. Can be switched to the cheaper connected form with an option in `LSTOptions`

The `CC` class is unaffected: it passes its connectivity and its lst form explicitly.

### The change:
Keep the old behavior by asking for it:
```cpp
auto hbar = lst(H(), T(2), 4, {.use_connected_form = true});
auto eqs = ref_av(P(2) * hbar, {.connect = default_op_connections()});
```
**Compatibility**: any out-of-tree caller relying on `lst()`'s previous default (no `LSTOptions` passed) moves from the connected-product form to explicit commutators. See https://github.com/ValeevGroup/mpqc4/pull/795. 

**Note**: initially I had planned to change the default behavior of `ref_av`/`vac_av` calls, but turned out to be bad idea. So only `lst` is changed and git history is cleaned. 

Documentation on `mbpt::lst` is moved out of the `CC` class file and `LSTOptions` are now documented.
