### PR TITLE
Require designated initializers for all Options-style aggregates

### DIFF
--- a/SeQuant/core/batch_policy.hpp
+++ b/SeQuant/core/batch_policy.hpp
@@ -1,6 +1,8 @@
 #ifndef SEQUANT_CORE_BATCH_POLICY_HPP
 #define SEQUANT_CORE_BATCH_POLICY_HPP
 
+#include <SeQuant/core/utility/aggregate.hpp>
+
 #include <cstddef>
 #include <functional>
 
@@ -12,6 +14,7 @@ class Tensor;
 /// One batchability policy shared by the single-term optimizer and the runtime
 /// batched evaluator (make_evaluator, Task A3). All predicates default empty.
 struct BatchPolicy {
+  SEQUANT_DESIGNATED_INIT_ONLY;
   std::function<bool(Index const&)> is_batchable_index = {};
   /// Per-index per-batch slice size (in elements) for a batchable index -- an
   /// UPPER BOUND, not a goal. Both the single-term optimizer and the runtime

--- a/SeQuant/core/context.hpp
+++ b/SeQuant/core/context.hpp
@@ -4,6 +4,7 @@
 #include <SeQuant/core/attr.hpp>
 #include <SeQuant/core/index_space_registry.hpp>
 #include <SeQuant/core/options.hpp>
+#include <SeQuant/core/utility/aggregate.hpp>
 #include <SeQuant/core/utility/context.hpp>
 
 namespace sequant {
@@ -64,6 +65,7 @@ class Context {
 
   /// see the Context documentation for detailed description
   struct Options {
+    SEQUANT_DESIGNATED_INIT_ONLY;
       /// a shared_ptr to an IndexSpaceRegistry object
       std::shared_ptr<IndexSpaceRegistry> index_space_registry_shared_ptr = nullptr;
       /// an IndexSpaceRegistry object; used if index_space_registry_shared_ptr is null and it is nonnull

--- a/SeQuant/core/eval/eval_expr.hpp
+++ b/SeQuant/core/eval/eval_expr.hpp
@@ -6,6 +6,7 @@
 #include <SeQuant/core/eval/fwd.hpp>
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>
+#include <SeQuant/core/utility/aggregate.hpp>
 #include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/external/bliss/graph.hh>
 
@@ -292,6 +293,7 @@ struct EvalOpSetter {
 };
 
 struct BinarizationOptions {
+  SEQUANT_DESIGNATED_INIT_ONLY;
   /// Whether to merge indices of intermediate tensors into a single list
   /// (stored as aux indices) instead of retaining the bra, ket and aux
   /// separation

--- a/SeQuant/core/expressions/sum.hpp
+++ b/SeQuant/core/expressions/sum.hpp
@@ -8,6 +8,7 @@
 #include <SeQuant/core/expressions/product.hpp>
 #include <SeQuant/core/meta.hpp>
 #include <SeQuant/core/runtime.hpp>
+#include <SeQuant/core/utility/aggregate.hpp>
 #include <SeQuant/core/utility/macros.hpp>
 
 #include <range/v3/range/access.hpp>
@@ -385,6 +386,7 @@ class HashingAccumulator {
 };
 
 struct TransformSumExprOptions {
+  SEQUANT_DESIGNATED_INIT_ONLY;
   bool canonicalize = true;
   bool flatten = true;
 };

--- a/SeQuant/core/io/serialization/serialization.hpp
+++ b/SeQuant/core/io/serialization/serialization.hpp
@@ -5,6 +5,7 @@
 #include <SeQuant/core/expr_fwd.hpp>
 #include <SeQuant/core/index.hpp>
 #include <SeQuant/core/op.hpp>
+#include <SeQuant/core/utility/aggregate.hpp>
 #include <SeQuant/core/utility/exception.hpp>
 
 #include <optional>
@@ -38,6 +39,7 @@ enum class SerializationSyntax {
 };
 
 struct DeserializationOptions {
+  SEQUANT_DESIGNATED_INIT_ONLY;
   /// The Symmetry (within bra and ket) to use, if none is specified in the
   /// input explicitly. The Context is queried in case this is not provided
   /// explicitly.
@@ -54,6 +56,7 @@ struct DeserializationOptions {
 };
 
 struct SerializationOptions {
+  SEQUANT_DESIGNATED_INIT_ONLY;
   /// Whether to explicitly annotate tensor symmetries
   bool annot_symm = true;
   /// The syntax version of the produced output

--- a/SeQuant/core/optimize/common_subexpression_elimination.hpp
+++ b/SeQuant/core/optimize/common_subexpression_elimination.hpp
@@ -7,6 +7,7 @@
 #include <SeQuant/core/eval/eval_node.hpp>
 #include <SeQuant/core/eval/eval_node_compare.hpp>
 #include <SeQuant/core/expr.hpp>
+#include <SeQuant/core/utility/aggregate.hpp>
 #include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/core/utility/string.hpp>
 
@@ -227,6 +228,7 @@ class SubexpressionReplacer {
 
 template <typename TreeNode>
 struct CSEOptions {
+  SEQUANT_DESIGNATED_INIT_ONLY;
   // TODO: provide predicate that computes the FLOPs required to compute the CSE
   // and compares that with the expected speed for reading the CSE from disk.
   // Use typical FLOPs/s and I/O rates from e.g. https://ssd.userbenchmark.com/

--- a/SeQuant/core/optimize/optimize.cpp
+++ b/SeQuant/core/optimize/optimize.cpp
@@ -87,13 +87,14 @@ void log_chosen_factorization(ExprPtr const& result,
 /// Optimize a Product that contains only Tensor and scalar factors.
 ExprPtr opt_pure_product(Product const& prod, OptimizeOptions const& opts) {
   bool const subnet_cse = opts.CSE.subnet;
-  CostParams const cost{opts.batch_policy.is_volatile_leaf,
-                        opts.volatile_weight,
-                        opts.footprint_weight,
-                        opts.peak_flops_tolerance,
-                        opts.roofline,
-                        opts.batch_policy.accumulation_factor,
-                        opts.prune_outer_products};
+  CostParams const cost{
+      .is_volatile_leaf = opts.batch_policy.is_volatile_leaf,
+      .volatile_weight = opts.volatile_weight,
+      .footprint_weight = opts.footprint_weight,
+      .peak_flops_tolerance = opts.peak_flops_tolerance,
+      .roofline = opts.roofline,
+      .accumulation_factor = opts.batch_policy.accumulation_factor,
+      .prune_outer_products = opts.prune_outer_products};
   auto run = [&]() -> ExprPtr {
     if (opts.objective_function == ObjectiveFunction::DenseFLOPs)
       return opt::single_term_opt<ObjectiveFunction::DenseFLOPs>(

--- a/SeQuant/core/optimize/options.hpp
+++ b/SeQuant/core/optimize/options.hpp
@@ -2,6 +2,7 @@
 #define SEQUANT_CORE_OPTIMIZE_OPTIONS_HPP
 
 #include <SeQuant/core/batch_policy.hpp>
+#include <SeQuant/core/utility/aggregate.hpp>
 
 #include <cstddef>
 #include <functional>
@@ -54,6 +55,7 @@ enum class ReorderSum { Reorder, NoReorder };
 /// an evaluation order, trading extra search time for potentially lower op
 /// counts. (Room to grow, e.g. a maximum subnet size to consider.)
 struct CSEOptions {
+  SEQUANT_DESIGNATED_INIT_ONLY;
   bool subnet = false;
 };
 
@@ -68,6 +70,7 @@ struct CSEOptions {
 /// is inert in the dense case. \c machine_balance == 0 (default) recovers the
 /// pure-flop tie-break. See doc/dev/specs/2026-06-23-roofline-tiebreak-cost.md.
 struct RooflineParams {
+  SEQUANT_DESIGNATED_INIT_ONLY;
   /// Machine balance beta = 8*F/B in FLOPs per element of traffic. 0 = off.
   double machine_balance = 0.0;
   /// Capacity M of the binding fast memory level, in elements (e.g. LLC/8).
@@ -86,6 +89,7 @@ struct RooflineParams {
 /// weighting, and \c roofline.machine_balance == 0 keeps the pure-flop
 /// tie-break.
 struct CostParams {
+  SEQUANT_DESIGNATED_INIT_ONLY;
   /// Marks a LEAF tensor as volatile (amplitude-dependent), so the contraction
   /// forming any subset that contains it is replayed every iteration. Empty =>
   /// nothing volatile (replay weighting off).
@@ -120,6 +124,7 @@ using index_to_extent_t = std::function<std::size_t(Index const&)>;
 
 /// Options that control behavior of \ref sequant::optimize.
 struct OptimizeOptions {
+  SEQUANT_DESIGNATED_INIT_ONLY;
   /// Objective function to minimize.
   ObjectiveFunction objective_function = ObjectiveFunction::DenseFLOPs;
 

--- a/SeQuant/core/options.hpp
+++ b/SeQuant/core/options.hpp
@@ -6,6 +6,7 @@
 #define SEQUANT_CORE_OPTIONS_HPP
 
 #include <SeQuant/core/index.hpp>
+#include <SeQuant/core/utility/aggregate.hpp>
 
 #include <optional>
 #include <string>
@@ -42,6 +43,7 @@ std::wstring to_wstring(CanonicalizationMethod m);
 
 /// @brief options that control behavior of `canonicalize()`
 struct CanonicalizeOptions {
+  SEQUANT_DESIGNATED_INIT_ONLY;
   enum class IgnoreNamedIndexLabel : bool { Yes = true, No = false };
 
   /// TN canonicalization method

--- a/SeQuant/core/tensor_network/v1.hpp
+++ b/SeQuant/core/tensor_network/v1.hpp
@@ -12,6 +12,7 @@
 #include <SeQuant/core/tensor_network/canonicals.hpp>
 #include <SeQuant/core/tensor_network/slot.hpp>
 #include <SeQuant/core/tensor_network/vertex.hpp>
+#include <SeQuant/core/utility/aggregate.hpp>
 #include <SeQuant/core/utility/macros.hpp>
 
 #include <range/v3/view/indirect.hpp>
@@ -463,6 +464,7 @@ class TensorNetworkV1 {
 
   /// options for generating bliss Graph
   struct BlissGraphOptions {
+    SEQUANT_DESIGNATED_INIT_ONLY;
     /// pointer to the set of named indices (ordinarily,
     /// this includes all external indices);
     ///            default is nullptr, which means use all external indices for

--- a/SeQuant/core/tensor_network/v2.hpp
+++ b/SeQuant/core/tensor_network/v2.hpp
@@ -12,6 +12,7 @@
 #include <SeQuant/core/tensor_network/slot.hpp>
 #include <SeQuant/core/tensor_network/utils.hpp>
 #include <SeQuant/core/tensor_network/vertex.hpp>
+#include <SeQuant/core/utility/aggregate.hpp>
 #include <SeQuant/core/utility/macros.hpp>
 
 #include <range/v3/range/traits.hpp>
@@ -346,6 +347,7 @@ class TensorNetworkV2 {
 
   /// options for generating Graph from an object of this type
   struct CreateGraphOptions {
+    SEQUANT_DESIGNATED_INIT_ONLY;
     /// pointer to the set of named indices (ordinarily,
     /// this includes all external indices);
     /// default is nullptr, which means use all external indices for

--- a/SeQuant/core/tensor_network/v3.hpp
+++ b/SeQuant/core/tensor_network/v3.hpp
@@ -11,6 +11,7 @@
 #include <SeQuant/core/tensor_network/canonicals.hpp>
 #include <SeQuant/core/tensor_network/slot.hpp>
 #include <SeQuant/core/tensor_network/vertex.hpp>
+#include <SeQuant/core/utility/aggregate.hpp>
 #include <SeQuant/core/utility/macros.hpp>
 
 #include <range/v3/algorithm/for_each.hpp>
@@ -332,6 +333,7 @@ class TensorNetworkV3 {
 
   /// options for generating Graph from an object of this type
   struct CreateGraphOptions {
+    SEQUANT_DESIGNATED_INIT_ONLY;
     /// pointer to the set of named indices (ordinarily,
     /// this includes all external indices);
     /// default is nullptr, which means use all external indices for

--- a/SeQuant/core/utility/aggregate.hpp
+++ b/SeQuant/core/utility/aggregate.hpp
@@ -5,6 +5,7 @@
 #ifndef SEQUANT_CORE_UTILITY_AGGREGATE_HPP
 #define SEQUANT_CORE_UTILITY_AGGREGATE_HPP
 
+#include <compare>
 #include <type_traits>
 
 namespace sequant::detail {
@@ -24,6 +25,17 @@ class designated_init_only {
   constexpr designated_init_only& operator=(
       const designated_init_only&) noexcept = default;
   static constexpr designated_init_only make() noexcept { return {}; }
+
+  /// all tags compare equal, so that a guarded aggregate can still default its
+  /// comparison operators
+  friend constexpr bool operator==(designated_init_only,
+                                   designated_init_only) noexcept {
+    return true;
+  }
+  friend constexpr std::strong_ordering operator<=>(
+      designated_init_only, designated_init_only) noexcept {
+    return std::strong_ordering::equal;
+  }
 
  private:
   constexpr designated_init_only() noexcept = default;

--- a/SeQuant/domain/mbpt/context.hpp
+++ b/SeQuant/domain/mbpt/context.hpp
@@ -4,6 +4,7 @@
 
 #include <SeQuant/domain/mbpt/fwd.hpp>
 
+#include <SeQuant/core/utility/aggregate.hpp>
 #include <SeQuant/core/utility/context.hpp>
 #include <SeQuant/domain/mbpt/op_registry.hpp>
 
@@ -34,6 +35,7 @@ class Context {
   };
 
   struct Options {
+    SEQUANT_DESIGNATED_INIT_ONLY;
     /// whether to use cluster-specific virtuals
     CSV csv = Defaults::csv;
     /// shared pointer to operator registry

--- a/SeQuant/domain/mbpt/models/cc.hpp
+++ b/SeQuant/domain/mbpt/models/cc.hpp
@@ -2,6 +2,7 @@
 #define SEQUANT_DOMAIN_MBPT_MODELS_CC_HPP
 
 #include <SeQuant/core/op.hpp>
+#include <SeQuant/core/utility/aggregate.hpp>
 #include <SeQuant/domain/mbpt/op.hpp>
 #include <SeQuant/domain/mbpt/utils.hpp>
 #include <SeQuant/domain/mbpt/vac_av.hpp>
@@ -33,6 +34,7 @@ class CC {
 
   /// Configuration options for CC class
   struct Options {
+    SEQUANT_DESIGNATED_INIT_ONLY;
     /// type of CC ansatz. see CC::Ansatz
     Ansatz ansatz = Ansatz::T;
     /// if true, singles amplitudes are excluded from \f$ \hat{T} \f$ and \f$

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -21,6 +21,7 @@
 #include <SeQuant/core/op.hpp>
 #include <SeQuant/core/rational.hpp>
 #include <SeQuant/core/space.hpp>
+#include <SeQuant/core/utility/aggregate.hpp>
 #include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/core/utility/strong.hpp>
 
@@ -95,6 +96,7 @@ inline IndexSpace make_space(const IndexSpace::Type& type) {
 ///
 /// Used with `mbpt::OpMaker` and `mbpt::Operator` classes
 struct OpParams {
+  SEQUANT_DESIGNATED_INIT_ONLY;
   std::size_t order = 0;  ///< perturbation order, limited to range [0,9]
   std::optional<size_t> nbatch = std::nullopt;  ///< number of batching indices
   container::svector<std::size_t> batch_ordinals{};
@@ -525,6 +527,7 @@ using OpConnections = std::vector<std::pair<T, T>>;
 /// parameters in here which are only meaningful at the operator level.
 template <typename T>
 struct EVOptions {
+  SEQUANT_DESIGNATED_INIT_ONLY;
   /// List of pairs of operator labels to be connected; connections are defined
   /// left-to-right, i.e., pair `{opL,opR}` declares that `opL` and `opR` are to
   /// be connected when `opR` precedes `opL`, i.e. `opL` is to the left of `opR`

--- a/SeQuant/domain/mbpt/spin.hpp
+++ b/SeQuant/domain/mbpt/spin.hpp
@@ -12,6 +12,7 @@
 #include <SeQuant/core/container.hpp>
 #include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/index.hpp>
+#include <SeQuant/core/utility/aggregate.hpp>
 #include <SeQuant/core/utility/indices.hpp>
 #include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/core/utility/overloads.hpp>
@@ -257,6 +258,7 @@ enum class BiorthogonalizationMethod {
 
 /// controls behavior of biorthogonal closed-shell spin-tracing
 struct ClosedShellCCSpintraceOptions {
+  SEQUANT_DESIGNATED_INIT_ONLY;
   BiorthogonalizationMethod method = BiorthogonalizationMethod::V2;
   /// set to true to use sequant::spintrace which does not assume closed-shell
   /// (spin-free) basis and thus has an exponential cost;

--- a/tests/unit/test_optimize.cpp
+++ b/tests/unit/test_optimize.cpp
@@ -1365,8 +1365,11 @@ TEST_CASE("OSV early-contraction reproducer", "[optimize][osv]") {
   auto show = [&](auto metric, std::wstring name,
                   std::function<double(Index const&, std::size_t)> ip = {}) {
     auto res = opt::single_term_opt<decltype(metric)::value>(
-        prod, idxsz, /*subnet_cse=*/false, CostParams{{}, 1.0, 0.0}, {}, {},
-        ip);
+        prod, idxsz, /*subnet_cse=*/false,
+        CostParams{.is_volatile_leaf = {},
+                   .volatile_weight = 1.0,
+                   .footprint_weight = 0.0},
+        {}, {}, ip);
     std::wcout << name << L":  " << render_tree(res) << L"\n";
   };
   std::wcout
@@ -1434,17 +1437,29 @@ TEST_CASE("OSV early-contraction reproducer (full term #1)",
 
   {
     auto res = opt::single_term_opt<ObjectiveFunction::DenseFLOPs>(
-        prod, idxsz, false, CostParams{{}, 1.0, 0.0}, {}, {}, ip);
+        prod, idxsz, false,
+        CostParams{.is_volatile_leaf = {},
+                   .volatile_weight = 1.0,
+                   .footprint_weight = 0.0},
+        {}, {}, ip);
     std::wcout << L"FLOPs:        " << render_tree(res) << L"\n";
   }
   {
     auto res = opt::single_term_opt<ObjectiveFunction::DensePeakSize>(
-        prod, idxsz, false, CostParams{{}, 1.0, 0.0}, {}, {}, ip);
+        prod, idxsz, false,
+        CostParams{.is_volatile_leaf = {},
+                   .volatile_weight = 1.0,
+                   .footprint_weight = 0.0},
+        {}, {}, ip);
     std::wcout << L"PeakSize:     " << render_tree(res) << L"\n";
   }
   {
     auto res = opt::single_term_opt<ObjectiveFunction::DensePeakSizeBatched>(
-        prod, idxsz, false, CostParams{{}, 1.0, 0.0}, is_batch, bts, ip);
+        prod, idxsz, false,
+        CostParams{.is_volatile_leaf = {},
+                   .volatile_weight = 1.0,
+                   .footprint_weight = 0.0},
+        is_batch, bts, ip);
     std::wcout << L"PeakBatched:  " << render_tree(res) << L"\n";
   }
   std::wcout << L"\n  >>> looking for (C{a_4<i_1>;μ̃_1216} * t{a_4<i_1>;i_1}) "
@@ -1598,38 +1613,63 @@ TEST_CASE("OSV deferral reproducer (tetramer term 3)", "[optimize][osv]") {
                << render_tree(res) << L"\n";
     return mx;
   };
-  double flops_mx =
-      report(L"FLOPs:        ",
-             opt::single_term_opt<ObjectiveFunction::DenseFLOPs>(
-                 prod, idxsz, false, CostParams{{}, 1.0, 0.0}, {}, {}, ip));
-  double peak_mx =
-      report(L"PeakSize:     ",
-             opt::single_term_opt<ObjectiveFunction::DensePeakSize>(
-                 prod, idxsz, false, CostParams{{}, 1.0, 0.0}, {}, {}, ip));
-  double pbat_mx = report(
-      L"PeakBatched:  ",
-      opt::single_term_opt<ObjectiveFunction::DensePeakSizeBatched>(
-          prod, idxsz, false, CostParams{{}, 1.0, 0.0}, is_batch, bts, ip));
+  double flops_mx = report(L"FLOPs:        ",
+                           opt::single_term_opt<ObjectiveFunction::DenseFLOPs>(
+                               prod, idxsz, false,
+                               CostParams{.is_volatile_leaf = {},
+                                          .volatile_weight = 1.0,
+                                          .footprint_weight = 0.0},
+                               {}, {}, ip));
+  double peak_mx = report(
+      L"PeakSize:     ", opt::single_term_opt<ObjectiveFunction::DensePeakSize>(
+                             prod, idxsz, false,
+                             CostParams{.is_volatile_leaf = {},
+                                        .volatile_weight = 1.0,
+                                        .footprint_weight = 0.0},
+                             {}, {}, ip));
+  double pbat_mx =
+      report(L"PeakBatched:  ",
+             opt::single_term_opt<ObjectiveFunction::DensePeakSizeBatched>(
+                 prod, idxsz, false,
+                 CostParams{.is_volatile_leaf = {},
+                            .volatile_weight = 1.0,
+                            .footprint_weight = 0.0},
+                 is_batch, bts, ip));
   // Real MPQC config: t is volatile, volatile_weight=100. The tie-break weights
   // volatile (replayed) flops, so it must STILL eliminate the OSV early.
   auto is_t = [](Tensor const& t) { return t.label() == L"t"; };
   // isolate volatile_weight: hold is_volatile_leaf=is_t FIXED, vary only vw.
-  double peak_v =
-      report(L"PeakSize/is_t,vw1:   ",
-             opt::single_term_opt<ObjectiveFunction::DensePeakSize>(
-                 prod, idxsz, false, CostParams{is_t, 1.0, 0.0}, {}, {}, ip));
+  double peak_v = report(L"PeakSize/is_t,vw1:   ",
+                         opt::single_term_opt<ObjectiveFunction::DensePeakSize>(
+                             prod, idxsz, false,
+                             CostParams{.is_volatile_leaf = is_t,
+                                        .volatile_weight = 1.0,
+                                        .footprint_weight = 0.0},
+                             {}, {}, ip));
   double peak_v100 =
       report(L"PeakSize/is_t,vw100: ",
              opt::single_term_opt<ObjectiveFunction::DensePeakSize>(
-                 prod, idxsz, false, CostParams{is_t, 100.0, 0.0}, {}, {}, ip));
-  double pbat_v = report(
-      L"PeakBatch/is_t,vw1:  ",
-      opt::single_term_opt<ObjectiveFunction::DensePeakSizeBatched>(
-          prod, idxsz, false, CostParams{is_t, 1.0, 0.0}, is_batch, bts, ip));
-  double pbat_v100 = report(
-      L"PeakBatch/is_t,vw100:",
-      opt::single_term_opt<ObjectiveFunction::DensePeakSizeBatched>(
-          prod, idxsz, false, CostParams{is_t, 100.0, 0.0}, is_batch, bts, ip));
+                 prod, idxsz, false,
+                 CostParams{.is_volatile_leaf = is_t,
+                            .volatile_weight = 100.0,
+                            .footprint_weight = 0.0},
+                 {}, {}, ip));
+  double pbat_v =
+      report(L"PeakBatch/is_t,vw1:  ",
+             opt::single_term_opt<ObjectiveFunction::DensePeakSizeBatched>(
+                 prod, idxsz, false,
+                 CostParams{.is_volatile_leaf = is_t,
+                            .volatile_weight = 1.0,
+                            .footprint_weight = 0.0},
+                 is_batch, bts, ip));
+  double pbat_v100 =
+      report(L"PeakBatch/is_t,vw100:",
+             opt::single_term_opt<ObjectiveFunction::DensePeakSizeBatched>(
+                 prod, idxsz, false,
+                 CostParams{.is_volatile_leaf = is_t,
+                            .volatile_weight = 100.0,
+                            .footprint_weight = 0.0},
+                 is_batch, bts, ip));
   (void)peak_v100;
   (void)pbat_v100;
   std::wcout << L"\n";
@@ -1664,11 +1704,15 @@ TEST_CASE("OSV deferral reproducer (tetramer term 3)", "[optimize][osv]") {
   //     batch_persistent_only restores the old behavior (volatile subtrees not
   //     sliced -> the batched model reverts to deferring the OSV outer
   //     product).
-  double pbat_po = report(
-      L"PeakBatch/persistent_only:",
-      opt::single_term_opt<ObjectiveFunction::DensePeakSizeBatched>(
-          prod, idxsz, false, CostParams{is_t, 100.0, 0.0}, is_batch, bts, ip,
-          /*batch_persistent_only=*/true));
+  double pbat_po =
+      report(L"PeakBatch/persistent_only:",
+             opt::single_term_opt<ObjectiveFunction::DensePeakSizeBatched>(
+                 prod, idxsz, false,
+                 CostParams{.is_volatile_leaf = is_t,
+                            .volatile_weight = 100.0,
+                            .footprint_weight = 0.0},
+                 is_batch, bts, ip,
+                 /*batch_persistent_only=*/true));
   CHECK(pbat_po >= osv_outer_product);  // gate restored -> OSV deferred again
 }
 
@@ -1761,18 +1805,28 @@ TEST_CASE("PPL: form 4-PNO W vs fold-t (peak-neutral, flop tie-break)",
   // so it is slightly LARGER in peak than fold-t; only the peak_flops_tolerance
   // (default 0.10) lets the peak objectives accept that within-tolerance peak
   // bump in exchange for the large volatile-flop win, i.e. form W like FLOPs.
-  double flops_w =
-      rep(L"FLOPs/vw100:  ",
-          opt::single_term_opt<ObjectiveFunction::DenseFLOPs>(
-              prod, idxsz, false, CostParams{is_t, 100.0, 0.0}, {}, {}, ip));
-  double peak_w =
-      rep(L"PeakSize/vw100:",
-          opt::single_term_opt<ObjectiveFunction::DensePeakSize>(
-              prod, idxsz, false, CostParams{is_t, 100.0, 0.0}, {}, {}, ip));
-  double pbat_w = rep(
-      L"PeakB/vw100:  ",
-      opt::single_term_opt<ObjectiveFunction::DensePeakSizeBatched>(
-          prod, idxsz, false, CostParams{is_t, 100.0, 0.0}, is_batch, bts, ip));
+  double flops_w = rep(L"FLOPs/vw100:  ",
+                       opt::single_term_opt<ObjectiveFunction::DenseFLOPs>(
+                           prod, idxsz, false,
+                           CostParams{.is_volatile_leaf = is_t,
+                                      .volatile_weight = 100.0,
+                                      .footprint_weight = 0.0},
+                           {}, {}, ip));
+  double peak_w = rep(L"PeakSize/vw100:",
+                      opt::single_term_opt<ObjectiveFunction::DensePeakSize>(
+                          prod, idxsz, false,
+                          CostParams{.is_volatile_leaf = is_t,
+                                     .volatile_weight = 100.0,
+                                     .footprint_weight = 0.0},
+                          {}, {}, ip));
+  double pbat_w =
+      rep(L"PeakB/vw100:  ",
+          opt::single_term_opt<ObjectiveFunction::DensePeakSizeBatched>(
+              prod, idxsz, false,
+              CostParams{.is_volatile_leaf = is_t,
+                         .volatile_weight = 100.0,
+                         .footprint_weight = 0.0},
+              is_batch, bts, ip));
   std::wcout << L"\n";
   // The epsilon-tolerant Pareto selection makes both peak objectives form W,
   // matching the flop-optimal volatile-weighted flop count.
@@ -1784,8 +1838,11 @@ TEST_CASE("PPL: form 4-PNO W vs fold-t (peak-neutral, flop tie-break)",
       rep(L"PeakSize/strict:",
           opt::single_term_opt<ObjectiveFunction::DensePeakSize>(
               prod, idxsz, false,
-              CostParams{is_t, 100.0, 0.0, /*peak_flops_tolerance=*/0.0}, {},
-              {}, ip));
+              CostParams{.is_volatile_leaf = is_t,
+                         .volatile_weight = 100.0,
+                         .footprint_weight = 0.0,
+                         .peak_flops_tolerance = 0.0},
+              {}, {}, ip));
   CHECK(peak_w_strict > flops_w);
   // At volatile_weight=1 (the caching-off regime, where persistent
   // intermediates cannot be amortized across replays) the persistent 4-PNO W is
@@ -1795,10 +1852,14 @@ TEST_CASE("PPL: form 4-PNO W vs fold-t (peak-neutral, flop tie-break)",
   // forming/caching W. (mpqc's SeQuantEngine pins volatile_weight to 1 when
   // eval:cache is off for exactly this reason.) A form-W tree would reproduce
   // flops_w; fold-t does not.
-  double pbat_w_vw1 = rep(
-      L"PeakB/vw1:    ",
-      opt::single_term_opt<ObjectiveFunction::DensePeakSizeBatched>(
-          prod, idxsz, false, CostParams{is_t, 1.0, 0.0}, is_batch, bts, ip));
+  double pbat_w_vw1 =
+      rep(L"PeakB/vw1:    ",
+          opt::single_term_opt<ObjectiveFunction::DensePeakSizeBatched>(
+              prod, idxsz, false,
+              CostParams{.is_volatile_leaf = is_t,
+                         .volatile_weight = 1.0,
+                         .footprint_weight = 0.0},
+              is_batch, bts, ip));
   CHECK(pbat_w_vw1 > flops_w);
 }
 
@@ -1963,8 +2024,14 @@ TEST_CASE("quadratic bubble: early-K integral vs late-K t·(gC)",
     //              peak_flops_tolerance, roofline, accumulation_factor}.
     // peak_flops_tolerance = 0 => strict peak-min (no tolerance band).
     auto res = opt::single_term_opt<ObjectiveFunction::DensePeakSizeBatched>(
-        prod, idxsz, false, CostParams{{}, 1.0, 0.0, 0.0, {}, lambda}, is_batch,
-        bts, ip);
+        prod, idxsz, false,
+        CostParams{.is_volatile_leaf = {},
+                   .volatile_weight = 1.0,
+                   .footprint_weight = 0.0,
+                   .peak_flops_tolerance = 0.0,
+                   .roofline = {},
+                   .accumulation_factor = lambda},
+        is_batch, bts, ip);
     bool integral = forms_integral(res);
     double gb = batched_peak(res, Kb) * 8.0 / 1e9;
     std::wcout << L"  K_b=" << Kb << L"\tlambda=" << lambda
@@ -1996,7 +2063,13 @@ TEST_CASE("quadratic bubble: early-K integral vs late-K t·(gC)",
       return Kb;
     };
     auto res = opt::single_term_opt<ObjectiveFunction::DensePeakSizeBatched>(
-        prod, idxsz, false, CostParams{is_t, 100.0, 0.0, 0.10, {}, 0.0},
+        prod, idxsz, false,
+        CostParams{.is_volatile_leaf = is_t,
+                   .volatile_weight = 100.0,
+                   .footprint_weight = 0.0,
+                   .peak_flops_tolerance = 0.10,
+                   .roofline = {},
+                   .accumulation_factor = 0.0},
         is_batch, bts, ip);
     return forms_integral(res);
   };


### PR DESCRIPTION
Stacked on #584 — **base is `ajay/flip-lst-defaults`**, since `SEQUANT_DESIGNATED_INIT_ONLY` is introduced there. Retarget to `master` once #584 merges; review only the top commit.

## Why

#584 flipped `LSTOptions`' second field from `use_commutators` to `use_connected_form` — same position, inverted polarity. Designated-initializer callers got a compile error; positional callers (`LSTOptions{true, false}`) silently changed meaning. That prompted the guard in #584.

Every other options aggregate in SeQuant has the same failure mode. This applies the guard to all 20 of them, so the "reorder a field, silently reinterpret a caller" hazard is gone project-wide rather than fixed once for the struct that happened to hit it.

## What

`CanonicalizeOptions`, `Context::Options`, `BinarizationOptions`, `TransformSumExprOptions`, `De/SerializationOptions`, both `CSEOptions`, `OptimizeOptions`, `RooflineParams`, `CostParams`, `BatchPolicy`, `BlissGraphOptions`, `CreateGraphOptions` (v2, v3), `mbpt::Context::Options`, `CC::Options`, `OpParams`, `EVOptions`, `ClosedShellCCSpintraceOptions`.

**Excluded, deliberately:** `SimplifyOptions` has a user-provided constructor, so it is not an aggregate and designated init never applied; `OpInfo` and `Context::Defaults` are not options bundles; `external/bliss` is vendored.

## One addition to the guard

The tag gets `==` and `<=>` so a guarded aggregate can still default its own comparison operators.

(A second defect — the tag's user-declared copy constructor deprecating the *implicit* copy assignment, an error under `-Werror -Wdeprecated-copy` — was found while building this PR but fixed in #584 instead, since it is reachable from `LSTOptions` alone.)

## Call sites the guard rejected

- `optimize.cpp`: `CostParams` was built from `OptimizeOptions` with **seven positional fields** — correct only while two independently-editable structs keep the same field order. This is the hazard, in library code.
- `test_optimize.cpp`: 19 sites. One had already grown a `/*peak_flops_tolerance=*/` comment, which designated initializers now make real.

## Compatibility

Positional initialization of any of these types stops compiling — deliberately, and it is a hard error with a clear message, never a silent behavior change. Downstream (mpqc4) may need the same mechanical conversion.

## Verification

Clean build and **226/226 ctest** with AppleClang 17 at C++20. Guard behavior verified on clang and g++-13/15 under C++20 and C++23: `{a, b}` and `{{}, a, b}` rejected; `{}`, `{.field = a}`, copy, copy-assign, defaulted parameters, and constant expressions all fine.