### PR TITLE
tests/mbpt: spell out Hermiticity in the custom-operators example

### DIFF
--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -77,6 +77,37 @@ TEST_CASE("mbpt", "[mbpt][valgrind_skip]") {
       REQUIRE(registry.to_class(L"F") == OpClass::Gen);
     }
 
+    SECTION("add-operators-with-hermiticity") {
+      using sequant::Hermiticity;
+
+      OpRegistry registry;
+      // no explicit Hermiticity => default_hermiticity(class)
+      registry.add(L"T", OpClass::Ex);
+      registry.add(L"F", OpClass::Gen);
+      REQUIRE(registry.hermiticity(L"T") == Hermiticity::NonHermitian);
+      REQUIRE(registry.hermiticity(L"F") == Hermiticity::Hermitian);
+
+      // explicit Hermiticity overrides the class default
+      registry.add(L"Z", OpClass::Ex, Hermiticity::Hermitian);
+      registry.add(L"G", OpClass::Gen, Hermiticity::NonHermitian);
+      REQUIRE(registry.to_class(L"Z") == OpClass::Ex);
+      REQUIRE(registry.to_class(L"G") == OpClass::Gen);
+      REQUIRE(registry.hermiticity(L"Z") == Hermiticity::Hermitian);
+      REQUIRE(registry.hermiticity(L"G") == Hermiticity::NonHermitian);
+
+      // set_hermiticity overrides after the fact, in both directions
+      registry.set_hermiticity(L"T", Hermiticity::Hermitian);
+      registry.set_hermiticity(L"Z", Hermiticity::NonHermitian);
+      REQUIRE(registry.hermiticity(L"T") == Hermiticity::Hermitian);
+      REQUIRE(registry.hermiticity(L"Z") == Hermiticity::NonHermitian);
+
+      // overrides survive cloning
+      auto cloned = registry.clone();
+      REQUIRE(cloned.hermiticity(L"Z") == Hermiticity::NonHermitian);
+      REQUIRE(cloned.hermiticity(L"G") == Hermiticity::NonHermitian);
+      REQUIRE(cloned.hermiticity(L"F") == Hermiticity::Hermitian);
+    }
+
     SECTION("remove-operators") {
       OpRegistry registry;
       registry.add(L"T", OpClass::Ex);

--- a/tests/unit/test_mbpt.cpp
+++ b/tests/unit/test_mbpt.cpp
@@ -1364,14 +1364,11 @@ SECTION("manuscript-examples") {
     const auto& ann_space = get_hole_space(Spin::any);
 
     OpRegistry registry;
-    // amplitudes pinned Hermitian so the reference equations below (generated
-    // under the legacy conjugate-symmetric assumption) stay valid under the
-    // hermiticity model (see scoped_hermitian_amplitudes)
-    registry.add(L"f", OpClass::Gen)
-        .add(L"g", OpClass::Gen)
-        .add(L"t", OpClass::Ex, Hermiticity::Hermitian)
-        .add(L"x", OpClass::Ex, Hermiticity::Hermitian)
-        .add(L"y", OpClass::Ex, Hermiticity::Hermitian);
+    registry.add(L"f", OpClass::Gen, Hermiticity::Hermitian)
+        .add(L"g", OpClass::Gen, Hermiticity::Hermitian)
+        .add(L"t", OpClass::Ex, Hermiticity::NonHermitian)
+        .add(L"x", OpClass::Ex, Hermiticity::NonHermitian)
+        .add(L"y", OpClass::Ex, Hermiticity::NonHermitian);
 
     // set MBPT context
     auto ctx_resetter = set_scoped_default_mbpt_context(
@@ -1388,9 +1385,9 @@ SECTION("manuscript-examples") {
     REQUIRE_THAT(
         simplify(expr),
         EquivalentTo(
-            L"1/8 f{p1;p2}:A-C-S x{a1,a2;i1,i2}:A-C-S y{a3,a4;i3}:A-C-S "
+            L"1/8 f{p1;p2}:A-C-S x{a1,a2;i1,i2}:A-N-S y{a3,a4;i3}:A-N-S "
             L"ã{p2;p1} ã{i1,i2;a1,a2} ã{i3;a3,a4} + 1/32 g{p3,p4;p1,p2}:A-C-S "
-            L"x{a1,a2;i1,i2}:A-C-S y{a3,a4;i3}:A-C-S ã{p1,p2;p3,p4} "
+            L"x{a1,a2;i1,i2}:A-N-S y{a3,a4;i3}:A-N-S ã{p1,p2;p3,p4} "
             L"ã{i1,i2;a1,a2} ã{i3;a3,a4}"));
   }
 }  // SECTION("manuscript-examples")


### PR DESCRIPTION
Mirror the manuscript's Listing 3: pass `Hermiticity` explicitly for every registered operator, using the values the `OpClass` already implies (Gen -> Hermitian, Ex -> NonHermitian), rather than pinning the amplitudes Hermitian to preserve pre-existing reference equations.

x and y are therefore bra-ket nonsymmetric, so the expected expression carries A-N-S for them; f and g stay A-C-S. Term structure and coefficients are unchanged.