### PR TITLE
ExprContainer with value semantics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,8 @@ set(SeQuant_symb_src
         SeQuant/core/expressions/expr.hpp
         SeQuant/core/expressions/expr_algorithms.cpp
         SeQuant/core/expressions/expr_algorithms.hpp
+        SeQuant/core/expressions/expr_container.cpp
+        SeQuant/core/expressions/expr_container.hpp
         SeQuant/core/expressions/expr_operators.hpp
         SeQuant/core/expressions/expr_ptr.cpp
         SeQuant/core/expressions/expr_ptr.hpp

--- a/SeQuant/core/export/export.hpp
+++ b/SeQuant/core/export/export.hpp
@@ -539,10 +539,10 @@ void track_usage(const EvalNode<T> &node, PreprocessResult &result) {
     handle_variable(expr.as<Variable>());
   } else if (expr.is<Power>()) {
     const Power &power = expr.as<Power>();
-    if (power.base().is<Tensor>()) {
-      handle_tensor(power.base().as<Tensor>());
-    } else if (power.base().is<Variable>()) {
-      handle_variable(power.base().as<Variable>());
+    if (power.base()->is<Tensor>()) {
+      handle_tensor(power.base()->as<Tensor>());
+    } else if (power.base()->is<Variable>()) {
+      handle_variable(power.base()->as<Variable>());
     }
   }
 }
@@ -762,10 +762,10 @@ class PreprocessVisitor {
       handle_variable(node.left()->as_variable());
     } else if (node.left()->is_power()) {
       const Power &power = node.left()->as_power();
-      if (power.base().is<Tensor>()) {
-        handle_tensor(power.base().as<Tensor>());
-      } else if (power.base().is<Variable>()) {
-        handle_variable(power.base().as<Variable>());
+      if (power.base()->is<Tensor>()) {
+        handle_tensor(power.base()->as<Tensor>());
+      } else if (power.base()->is<Variable>()) {
+        handle_variable(power.base()->as<Variable>());
       }
     }
 
@@ -775,10 +775,10 @@ class PreprocessVisitor {
       handle_variable(node.right()->as_variable());
     } else if (node.right()->is_power()) {
       const Power &power = node.right()->as_power();
-      if (power.base().is<Tensor>()) {
-        handle_tensor(power.base().as<Tensor>());
-      } else if (power.base().is<Variable>()) {
-        handle_variable(power.base().as<Variable>());
+      if (power.base()->is<Tensor>()) {
+        handle_tensor(power.base()->as<Tensor>());
+      } else if (power.base()->is<Variable>()) {
+        handle_variable(power.base()->as<Variable>());
       }
     }
   }

--- a/SeQuant/core/export/itf.hpp
+++ b/SeQuant/core/export/itf.hpp
@@ -215,7 +215,7 @@ class ItfGenerator : public Generator<Context> {
   }
 
   std::string represent(const Power &power, const Context &ctx) const override {
-    const ExprPtr &base = power.base();
+    const ExprContainer &base = power.base();
     // ITF can only express powers of Constants
     if (!base->is<Constant>()) {
       throw Exception(

--- a/SeQuant/core/export/julia_tensor_operations.hpp
+++ b/SeQuant/core/export/julia_tensor_operations.hpp
@@ -130,7 +130,7 @@ class JuliaTensorOperationsGenerator : public Generator<Context> {
   }
 
   std::string represent(const Power &power, const Context &ctx) const override {
-    const ExprPtr &base = power.base();
+    const ExprContainer &base = power.base();
     std::string base_str = to_julia_expr(*base, ctx);
     if (base->is<Variable>() && base->as<Variable>().conjugated()) {
       base_str = wrap_conj(std::move(base_str));

--- a/SeQuant/core/export/python_einsum.hpp
+++ b/SeQuant/core/export/python_einsum.hpp
@@ -198,7 +198,7 @@ class PythonEinsumGeneratorBase : public Generator<Context> {
   }
 
   std::string represent(const Power &power, const Context &ctx) const override {
-    const ExprPtr &base = power.base();
+    const ExprContainer &base = power.base();
     std::string base_str = stringify_scalar(*base, ctx);
     if (base->is<Variable>() && base->as<Variable>().conjugated()) {
       base_str = wrap_conj(std::move(base_str));

--- a/SeQuant/core/export/text_generator.hpp
+++ b/SeQuant/core/export/text_generator.hpp
@@ -121,7 +121,7 @@ class TextGenerator : public Generator<Context> {
   }
 
   std::string represent(const Power &power, const Context &ctx) const override {
-    const ExprPtr &base = power.base();
+    const ExprContainer &base = power.base();
     std::string base_str = stringify(*base, ctx);
     if (base->is<Variable>() && base->as<Variable>().conjugated()) {
       base_str = wrap_conj(std::move(base_str));

--- a/SeQuant/core/export/utils.cpp
+++ b/SeQuant/core/export/utils.cpp
@@ -4,8 +4,7 @@
 
 #include <SeQuant/core/export/utils.hpp>
 
-#include <SeQuant/core/expressions/constant.hpp>
-#include <SeQuant/core/expressions/expr.hpp>
+#include <SeQuant/core/expr.hpp>
 #include <SeQuant/core/rational.hpp>
 
 #include <sstream>
@@ -30,7 +29,7 @@ std::string format_power_exponent(const Power::exponent_type &exponent,
   return ss.str();
 }
 
-std::string format_power_base(const ExprPtr &base, std::string base_str) {
+std::string format_power_base(const ExprContainer &base, std::string base_str) {
   if (base->is<Constant>()) {
     const auto &v = base->as<Constant>().value();
     if (v.imag() == 0 &&

--- a/SeQuant/core/export/utils.hpp
+++ b/SeQuant/core/export/utils.hpp
@@ -5,9 +5,7 @@
 #ifndef SEQUANT_CORE_EXPORT_UTILS_HPP
 #define SEQUANT_CORE_EXPORT_UTILS_HPP
 
-#include <SeQuant/core/expr_fwd.hpp>
-#include <SeQuant/core/expressions/expr_ptr.hpp>
-#include <SeQuant/core/expressions/power.hpp>
+#include <SeQuant/core/expr.hpp>
 
 #include <string>
 
@@ -27,7 +25,7 @@ std::string format_power_exponent(const Power::exponent_type &exponent,
 /// @param base_str @p base already rendered to a string by the caller
 /// @return @p base_str, wrapped in parens iff @p base is a Constant whose
 ///         value is a non-integer or negative real
-std::string format_power_base(const ExprPtr &base, std::string base_str);
+std::string format_power_base(const ExprContainer &base, std::string base_str);
 
 }  // namespace sequant::detail
 

--- a/SeQuant/core/expr.hpp
+++ b/SeQuant/core/expr.hpp
@@ -9,6 +9,7 @@
 #include <SeQuant/core/expressions/constant.hpp>
 #include <SeQuant/core/expressions/expr.hpp>
 #include <SeQuant/core/expressions/expr_algorithms.hpp>
+#include <SeQuant/core/expressions/expr_container.hpp>
 #include <SeQuant/core/expressions/expr_iterator.hpp>
 #include <SeQuant/core/expressions/expr_operators.hpp>
 #include <SeQuant/core/expressions/expr_ptr.hpp>

--- a/SeQuant/core/expr_fwd.hpp
+++ b/SeQuant/core/expr_fwd.hpp
@@ -12,6 +12,7 @@ namespace sequant {
 class Expr;
 class ResultExpr;
 class ExprPtr;
+class ExprContainer;
 
 class Labeled;
 class Constant;

--- a/SeQuant/core/expressions/constant.cpp
+++ b/SeQuant/core/expressions/constant.cpp
@@ -22,12 +22,24 @@ void Constant::adjoint() {
   reset_hash_value();
 }
 
+Constant &Constant::operator*=(const Constant &that) {
+  value_ *= that.value();
+
+  reset_hash_value();
+
+  return *this;
+}
+
 Constant &Constant::operator*=(const Expr &that) {
-  if (that.is<Constant>()) {
-    value_ *= that.as<Constant>().value();
-  } else {
+  if (!that.is<Constant>()) {
     throw Exception("Constant::operator*=(that): not valid for that");
   }
+
+  return *this *= that.as<Constant>();
+}
+
+Constant &Constant::operator+=(const Constant &that) {
+  value_ += that.value();
 
   reset_hash_value();
 
@@ -35,11 +47,15 @@ Constant &Constant::operator*=(const Expr &that) {
 }
 
 Constant &Constant::operator+=(const Expr &that) {
-  if (that.is<Constant>()) {
-    value_ += that.as<Constant>().value();
-  } else {
+  if (!that.is<Constant>()) {
     throw Exception("Constant::operator+=(that): not valid for that");
   }
+
+  return *this += that.as<Constant>();
+}
+
+Constant &Constant::operator-=(const Constant &that) {
+  value_ -= that.value();
 
   reset_hash_value();
 
@@ -47,15 +63,11 @@ Constant &Constant::operator+=(const Expr &that) {
 }
 
 Constant &Constant::operator-=(const Expr &that) {
-  if (that.is<Constant>()) {
-    value_ -= that.as<Constant>().value();
-  } else {
+  if (!that.is<Constant>()) {
     throw Exception("Constant::operator-=(that): not valid for that");
   }
 
-  reset_hash_value();
-
-  return *this;
+  return *this -= that.as<Constant>();
 }
 
 bool Constant::is_zero(scalar_type v) { return v.is_zero(); }
@@ -77,6 +89,30 @@ Expr::hash_type Constant::memoizing_hash() const {
 
 bool Constant::static_equal(const Expr &that) const {
   return value() == static_cast<const Constant &>(that).value();
+}
+
+Constant operator*(const Constant &lhs, const Constant &rhs) {
+  Constant result(lhs);
+
+  result *= rhs;
+
+  return result;
+}
+
+Constant operator+(const Constant &lhs, const Constant &rhs) {
+  Constant result(lhs);
+
+  result += rhs;
+
+  return result;
+}
+
+Constant operator-(const Constant &lhs, const Constant &rhs) {
+  Constant result(lhs);
+
+  result -= rhs;
+
+  return result;
 }
 
 }  // namespace sequant

--- a/SeQuant/core/expressions/constant.cpp
+++ b/SeQuant/core/expressions/constant.cpp
@@ -5,6 +5,8 @@
 #include <SeQuant/core/utility/exception.hpp>
 #include <SeQuant/core/utility/macros.hpp>
 
+#include <memory>
+
 namespace sequant {
 
 std::wstring Constant::to_latex() const {
@@ -14,8 +16,6 @@ std::wstring Constant::to_latex() const {
 Expr::type_id_type Constant::type_id() const { return get_type_id<Constant>(); }
 
 bool Constant::is_scalar() const { return true; }
-
-ExprPtr Constant::clone() const { return ex<Constant>(this->value()); }
 
 void Constant::adjoint() {
   value_ = conj(value_);
@@ -61,6 +61,10 @@ Constant &Constant::operator-=(const Expr &that) {
 bool Constant::is_zero(scalar_type v) { return v.is_zero(); }
 
 bool Constant::is_zero() const { return is_zero(this->value()); }
+
+std::unique_ptr<Expr> Constant::unique_copy() const {
+  return std::make_unique<Constant>(this->value());
+}
 
 Expr::hash_type Constant::memoizing_hash() const {
   if (!hash_value_) {

--- a/SeQuant/core/expressions/constant.hpp
+++ b/SeQuant/core/expressions/constant.hpp
@@ -8,6 +8,7 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
+#include <memory>
 #include <string>
 
 namespace sequant {
@@ -73,8 +74,6 @@ class Constant : public Expr {
 
   bool is_scalar() const override;
 
-  ExprPtr clone() const override;
-
   /// @brief adjoint of a Constant is its complex conjugate
   virtual void adjoint() override;
 
@@ -90,6 +89,9 @@ class Constant : public Expr {
 
   /// @return `Constant::is_zero(this->value())`
   bool is_zero() const final;
+
+ protected:
+  std::unique_ptr<Expr> unique_copy() const override;
 
  private:
   scalar_type value_;

--- a/SeQuant/core/expressions/constant.hpp
+++ b/SeQuant/core/expressions/constant.hpp
@@ -77,10 +77,13 @@ class Constant : public Expr {
   /// @brief adjoint of a Constant is its complex conjugate
   virtual void adjoint() override;
 
+  Constant &operator*=(const Constant &that);
   Constant &operator*=(const Expr &that);
 
+  Constant &operator+=(const Constant &that);
   Constant &operator+=(const Expr &that);
 
+  Constant &operator-=(const Constant &that);
   Constant &operator-=(const Expr &that);
 
   /// @param[in] v a scalar
@@ -101,6 +104,10 @@ class Constant : public Expr {
   bool static_equal(const Expr &that) const override;
 
 };  // class Constant
+
+Constant operator*(const Constant &lhs, const Constant &rhs);
+Constant operator+(const Constant &lhs, const Constant &rhs);
+Constant operator-(const Constant &lhs, const Constant &rhs);
 
 }  // namespace sequant
 

--- a/SeQuant/core/expressions/expr.cpp
+++ b/SeQuant/core/expressions/expr.cpp
@@ -75,6 +75,8 @@ std::wstring Expr::to_latex() const {
   throw Exception("to_latex not implemented for " + type_name());
 }
 
+ExprPtr Expr::clone() const { return unique_copy(); }
+
 bool proportional_to::operator()(const ExprPtr &expr1,
                                  const ExprPtr &expr2) const {
   if (expr1->type_id() !=

--- a/SeQuant/core/expressions/expr.cpp
+++ b/SeQuant/core/expressions/expr.cpp
@@ -8,6 +8,7 @@
 #include <SeQuant/core/expressions/expr_ptr.hpp>
 #include <SeQuant/core/expressions/product.hpp>
 
+#include <memory>
 #include <sstream>
 
 namespace sequant {
@@ -76,6 +77,22 @@ std::wstring Expr::to_latex() const {
 }
 
 ExprPtr Expr::clone() const { return unique_copy(); }
+
+std::shared_ptr<Expr> Expr::shared_from_this() {
+  return std::enable_shared_from_this<Expr>::shared_from_this();
+}
+
+std::shared_ptr<const Expr> Expr::shared_from_this() const {
+  return std::enable_shared_from_this<Expr>::shared_from_this();
+}
+
+std::weak_ptr<Expr> Expr::weak_from_this() {
+  return std::enable_shared_from_this<Expr>::weak_from_this();
+}
+
+std::weak_ptr<const Expr> Expr::weak_from_this() const {
+  return std::enable_shared_from_this<Expr>::weak_from_this();
+}
 
 bool proportional_to::operator()(const ExprPtr &expr1,
                                  const ExprPtr &expr2) const {

--- a/SeQuant/core/expressions/expr.cpp
+++ b/SeQuant/core/expressions/expr.cpp
@@ -94,17 +94,16 @@ std::weak_ptr<const Expr> Expr::weak_from_this() const {
   return std::enable_shared_from_this<Expr>::weak_from_this();
 }
 
-bool proportional_to::operator()(const ExprPtr &expr1,
-                                 const ExprPtr &expr2) const {
-  if (expr1->type_id() !=
-      expr2->type_id()) {  // if expr1 is a Product with single factor == expr2,
-                           // or vice versa
+bool proportional_to::operator()(const Expr &expr1, const Expr &expr2) const {
+  if (expr1.type_id() != expr2.type_id()) {
+    // if expr1 is a Product with single factor == expr2,
+    // or vice versa
     if (expr1.is<Product>()) {
       return expr1.as<Product>().factors().size() == 1 &&
-             expr1.as<Product>().factors().front() == expr2;
+             *expr1.as<Product>().factors().front() == expr2;
     } else if (expr2.is<Product>()) {
       return expr2.as<Product>().factors().size() == 1 &&
-             expr2.as<Product>().factors().front() == expr1;
+             *expr2.as<Product>().factors().front() == expr1;
     } else
       return false;
   }
@@ -115,10 +114,15 @@ bool proportional_to::operator()(const ExprPtr &expr1,
     return true;
   }
   if (expr1.is<Product>()) {
-    return expr1->hash_value() == expr2->hash_value() &&
+    return expr1.hash_value() == expr2.hash_value() &&
            expr1.as<Product>().factors() == expr2.as<Product>().factors();
   }
   return expr1 == expr2;
+}
+
+bool proportional_to::operator()(const ExprPtr &expr1,
+                                 const ExprPtr &expr2) const {
+  return (*this)(*expr1, *expr2);
 }
 
 }  // namespace sequant

--- a/SeQuant/core/expressions/expr.hpp
+++ b/SeQuant/core/expressions/expr.hpp
@@ -59,6 +59,8 @@ static const wchar_t adjoint_label = L'\u207A';
 /// @endcode
 class Expr : public std::enable_shared_from_this<Expr> {
  public:
+  friend class ExprContainer;
+
   using hash_type = std::size_t;
   using type_id_type = int;  // to speed up comparisons
 

--- a/SeQuant/core/expressions/expr.hpp
+++ b/SeQuant/core/expressions/expr.hpp
@@ -75,7 +75,7 @@ class Expr : public std::enable_shared_from_this<Expr> {
   virtual std::wstring to_latex() const;
 
   /// @return a clone of this object, i.e. an object that is equal to @c this
-  virtual ExprPtr clone() const = 0;
+  ExprPtr clone() const;
 
   /// like Expr::shared_from_this, but returns ExprPtr
   /// @return a shared_ptr to this object wrapped into ExprPtr, if this object
@@ -431,6 +431,8 @@ class Expr : public std::enable_shared_from_this<Expr> {
   virtual bool commutes_with_atom([[maybe_unused]] const Expr &that) const {
     return true;
   }
+
+  virtual std::unique_ptr<Expr> unique_copy() const = 0;
 
  private:
   /// @return returns next type id in the grand class list

--- a/SeQuant/core/expressions/expr.hpp
+++ b/SeQuant/core/expressions/expr.hpp
@@ -516,6 +516,7 @@ struct proportional_to {
   /// @param[in] expr1
   /// @param[in] expr2
   /// @return true if @p expr1 is proportional to @p expr2
+  bool operator()(const Expr &expr1, const Expr &expr2) const;
   bool operator()(const ExprPtr &expr1, const ExprPtr &expr2) const;
 };
 

--- a/SeQuant/core/expressions/expr.hpp
+++ b/SeQuant/core/expressions/expr.hpp
@@ -77,11 +77,25 @@ class Expr : public std::enable_shared_from_this<Expr> {
   /// @return a clone of this object, i.e. an object that is equal to @c this
   ExprPtr clone() const;
 
+  [[deprecated("Expr objects may no longer be managed by shared_ptr")]] std::
+      shared_ptr<Expr>
+      shared_from_this();
+  [[deprecated("Expr objects may no longer be managed by shared_ptr")]] std::
+      shared_ptr<const Expr>
+      shared_from_this() const;
+  [[deprecated("Expr objects may no longer be managed by shared_ptr")]] std::
+      weak_ptr<Expr>
+      weak_from_this();
+  [[deprecated("Expr objects may no longer be managed by shared_ptr")]] std::
+      weak_ptr<const Expr>
+      weak_from_this() const;
+
   /// like Expr::shared_from_this, but returns ExprPtr
   /// @return a shared_ptr to this object wrapped into ExprPtr, if this object
   /// is already managed by a shared_ptr, else returns a shared_ptr to a clone
   /// of this object wrapped into ExprPtr
-  ExprPtr exprptr_from_this() {
+  [[deprecated("Expr objects may no longer be managed by shared_ptr")]] ExprPtr
+  exprptr_from_this() {
     if (weak_from_this().use_count() == 0)
       return this->clone();
     else
@@ -92,7 +106,8 @@ class Expr : public std::enable_shared_from_this<Expr> {
   /// @return a shared_ptr to this object wrapped into ExprPtr, if this object
   /// is already managed by a shared_ptr, else returns a shared_ptr to a clone
   /// of this object wrapped into ExprPtr
-  ExprPtr exprptr_from_this() const {
+  [[deprecated("Expr objects may no longer be managed by shared_ptr")]] ExprPtr
+  exprptr_from_this() const {
     if (weak_from_this().use_count() == 0)
       return this->clone();
     else
@@ -237,9 +252,16 @@ class Expr : public std::enable_shared_from_this<Expr> {
   /// Expr::memoizing_hash
   /// @return the hash value for this Expr
   hash_type hash_value(
-      std::function<hash_type(const std::shared_ptr<const Expr> &)> hasher = {})
-      const {
-    return hasher ? hasher(shared_from_this()) : memoizing_hash();
+      std::function<hash_type(const Expr &)> hasher = {}) const {
+    return hasher ? hasher(*this) : memoizing_hash();
+  }
+
+  [[deprecated(
+      "Use a hashing function that takes a const Expr & instead of "
+      "shared_ptr")]] hash_type
+  hash_value(std::function<hash_type(const std::shared_ptr<const Expr> &)>
+                 hasher) const {
+    return hasher ? hasher(this->clone()) : memoizing_hash();
   }
 
   /// Computes and returns the derived type identifier
@@ -365,9 +387,10 @@ class Expr : public std::enable_shared_from_this<Expr> {
       typename E, typename Visitor,
       typename = std::enable_if_t<std::is_same_v<std::remove_cvref_t<E>, Expr>>>
   static bool visit_impl(E &&expr, Visitor &&visitor, const bool atoms_only) {
-    if (expr.weak_from_this().use_count() == 0)
-      throw Exception(
-          "Expr::visit: cannot visit expressions not managed by shared_ptr");
+    constexpr bool visitor_uses_exprptr =
+        std::is_invocable_r_v<void, std::remove_reference_t<Visitor>,
+                              ExprPtr &>;
+
     for (auto &subexpr_ptr : expr.expr()) {
       const auto subexpr_is_an_atom = subexpr_ptr->is_atom();
       const auto need_to_visit_subexpr = !atoms_only || subexpr_is_an_atom;
@@ -376,18 +399,32 @@ class Expr : public std::enable_shared_from_this<Expr> {
         visited = visit_impl(*subexpr_ptr, std::forward<Visitor>(visitor),
                              atoms_only);
       // call on the subexpression itself, if not yet done so
-      if (need_to_visit_subexpr && !visited) visitor(subexpr_ptr);
+      if (need_to_visit_subexpr && !visited) {
+        if constexpr (visitor_uses_exprptr) {
+          visitor(subexpr_ptr);
+        } else {
+          visitor(*subexpr_ptr);
+        }
+      }
     }
+
     // N.B. can only visit itself if visitor is nonmutating!
     bool this_visited = false;
     if constexpr (std::is_invocable_r_v<void, std::remove_reference_t<Visitor>,
                                         const ExprPtr &>) {
       if (!atoms_only || expr.is_atom()) {
-        const ExprPtr this_exprptr = expr.exprptr_from_this();
-        visitor(this_exprptr);
+        visitor(expr.clone());
+        this_visited = true;
+      }
+    } else if constexpr (std::is_invocable_r_v<void,
+                                               std::remove_reference_t<Visitor>,
+                                               const Expr &>) {
+      if (!atoms_only || expr.is_atom()) {
+        visitor(std::as_const(expr));
         this_visited = true;
       }
     }
+
     return this_visited;
   }
 

--- a/SeQuant/core/expressions/expr.hpp
+++ b/SeQuant/core/expressions/expr.hpp
@@ -98,10 +98,12 @@ class Expr : public std::enable_shared_from_this<Expr> {
   /// of this object wrapped into ExprPtr
   [[deprecated("Expr objects may no longer be managed by shared_ptr")]] ExprPtr
   exprptr_from_this() {
+    SEQUANT_PRAGMA_IGNORE_DEPRECATED_BEGIN
     if (weak_from_this().use_count() == 0)
       return this->clone();
     else
       return static_cast<ExprPtr>(this->shared_from_this());
+    SEQUANT_PRAGMA_IGNORE_DEPRECATED_END
   }
 
   /// like Expr::shared_from_this, but returns ExprPtr
@@ -110,11 +112,13 @@ class Expr : public std::enable_shared_from_this<Expr> {
   /// of this object wrapped into ExprPtr
   [[deprecated("Expr objects may no longer be managed by shared_ptr")]] ExprPtr
   exprptr_from_this() const {
+    SEQUANT_PRAGMA_IGNORE_DEPRECATED_BEGIN
     if (weak_from_this().use_count() == 0)
       return this->clone();
     else
       return static_cast<const ExprPtr>(
           std::const_pointer_cast<Expr>(this->shared_from_this()));
+    SEQUANT_PRAGMA_IGNORE_DEPRECATED_END
   }
 
   /// Canonicalizes @c this and returns the byproduct of canonicalization (e.g.

--- a/SeQuant/core/expressions/expr_algorithms.cpp
+++ b/SeQuant/core/expressions/expr_algorithms.cpp
@@ -19,10 +19,10 @@
 
 namespace sequant {
 
-std::wstring to_latex_align(const ExprPtr& exprptr, size_t max_lines_per_align,
+std::wstring to_latex_align(const Expr& expr, size_t max_lines_per_align,
                             size_t max_terms_per_line) {
-  std::wstring result = io::latex::to_string(exprptr);
-  if (exprptr->is<Sum>()) {
+  std::wstring result = io::latex::to_string(expr);
+  if (expr.is<Sum>()) {
     result.erase(0, 7);  // remove leading  "{ \bigl"
     result.replace(result.size() - 8, 8,
                    L")");  // replace trailing "\bigr) }" with ")"
@@ -77,6 +77,10 @@ std::wstring to_latex_align(const ExprPtr& exprptr, size_t max_lines_per_align,
   }
   result += L"\n\\end{align}";
   return result;
+}
+std::wstring to_latex_align(const ExprPtr& exprptr, size_t max_lines_per_align,
+                            size_t max_terms_per_line) {
+  return to_latex_align(*exprptr, max_lines_per_align, max_terms_per_line);
 }
 
 std::size_t size(const Expr& expr) { return ranges::size(expr); }

--- a/SeQuant/core/expressions/expr_algorithms.hpp
+++ b/SeQuant/core/expressions/expr_algorithms.hpp
@@ -22,6 +22,8 @@ namespace sequant {
 /// @param max_lines_per_align the maximum number of lines in the align before
 /// starting new align block (if zero, will produce single align block)
 /// @param max_terms_per_line the maximum number of terms per line
+std::wstring to_latex_align(const Expr& expr, size_t max_lines_per_align = 0,
+                            size_t max_terms_per_line = 1);
 std::wstring to_latex_align(const ExprPtr& exprptr,
                             size_t max_lines_per_align = 0,
                             size_t max_terms_per_line = 1);

--- a/SeQuant/core/expressions/expr_container.cpp
+++ b/SeQuant/core/expressions/expr_container.cpp
@@ -1,0 +1,133 @@
+#include <SeQuant/core/expressions/constant.hpp>
+#include <SeQuant/core/expressions/expr.hpp>
+#include <SeQuant/core/expressions/expr_container.hpp>
+#include <SeQuant/core/expressions/expr_ptr.hpp>
+#include <SeQuant/core/expressions/product.hpp>
+#include <SeQuant/core/expressions/sum.hpp>
+#include <SeQuant/core/utility/macros.hpp>
+
+#include <algorithm>
+#include <memory>
+
+namespace sequant {
+
+ExprPtr to_expr_ptr(ExprContainer &&container) {
+  return std::shared_ptr<Expr>(std::move(container.expr_));
+}
+
+ExprContainer::ExprContainer(const ExprContainer &container)
+    : ExprContainer(container->unique_copy()) {}
+
+ExprContainer::ExprContainer(std::unique_ptr<Expr> expr)
+    : expr_(std::move(expr)) {}
+
+ExprContainer::ExprContainer(const Expr &expr)
+    : ExprContainer(expr.unique_copy()) {}
+
+ExprContainer::ExprContainer(Expr &&expr)
+    : ExprContainer(std::move(expr).unique_copy()) {}
+
+ExprContainer &ExprContainer::operator=(const ExprContainer &container) {
+  // Copy-and-swap
+  ExprContainer copy(container);
+
+  swap(*this, copy);
+
+  return *this;
+}
+
+ExprContainer &ExprContainer::operator=(const Expr &expr) {
+  // Copy-and-swap
+  ExprContainer copy(expr);
+
+  swap(*this, copy);
+
+  return *this;
+}
+
+ExprContainer &ExprContainer::operator=(Expr &&expr) {
+  // Copy-and-swap
+  ExprContainer copy(std::move(expr));
+
+  swap(*this, copy);
+
+  return *this;
+}
+
+ExprContainer ExprContainer::copy() const { return expr_->unique_copy(); }
+
+ExprContainer::operator const Expr &() const { return *expr_; }
+
+ExprContainer::operator Expr &() & { return *expr_; }
+ExprContainer::operator Expr &&() && { return std::move(*expr_); }
+
+const Expr &ExprContainer::operator*() const { return *expr_; }
+
+Expr &ExprContainer::operator*() { return *expr_; }
+
+const Expr *ExprContainer::operator->() const { return expr_.get(); }
+
+Expr *ExprContainer::operator->() { return expr_.get(); }
+
+ExprContainer &ExprContainer::operator+=(const Expr &expr) {
+  if (expr_->is<Sum>()) {
+    expr_->as<Sum>() += expr;
+  } else if (expr_->is<Constant>() && expr.is<Constant>()) {
+    *this = expr_->as<Constant>() + expr.as<Constant>();
+  } else {
+    *this = Sum(ExprPtrList{to_expr_ptr(std::move(*this)), expr.clone()});
+  }
+
+  return *this;
+}
+
+ExprContainer &ExprContainer::operator-=(const Expr &expr) {
+  if (expr_->is<Sum>()) {
+    expr_->as<Sum>() -= expr;
+  } else if (expr_->is<Constant>() && expr.is<Constant>()) {
+    *this = expr_->as<Constant>() - expr.as<Constant>();
+  } else {
+    *this = Sum(ExprPtrList{to_expr_ptr(std::move(*this)),
+                            ex<Product>(-1, ExprPtrList{expr.clone()})});
+  }
+
+  return *this;
+}
+
+ExprContainer &ExprContainer::operator*=(const Expr &expr) {
+  if (expr_->is<Product>()) {
+    expr_->as<Product>() *= expr;
+  } else if (expr_->is<Constant>() && expr.is<Constant>()) {
+    *this = expr_->as<Constant>() * expr.as<Constant>();
+  } else {
+    *this = Product(ExprPtrList{to_expr_ptr(std::move(*this)), expr.clone()});
+  }
+  return *this;
+}
+
+void swap(ExprContainer &lhs, ExprContainer &rhs) {
+  std::swap(lhs.expr_, rhs.expr_);
+}
+
+ExprContainer operator+(const Expr &lhs, const Expr &rhs) {
+  ExprContainer cont(lhs);
+  cont += rhs;
+
+  return cont;
+}
+
+ExprContainer operator-(const Expr &lhs, const Expr &rhs) {
+  ExprContainer cont(lhs);
+  cont -= rhs;
+
+  return cont;
+}
+
+ExprContainer operator*(const Expr &lhs, const Expr &rhs) {
+  ExprContainer cont(lhs);
+  cont *= rhs;
+
+  return cont;
+}
+
+}  // namespace sequant

--- a/SeQuant/core/expressions/expr_container.cpp
+++ b/SeQuant/core/expressions/expr_container.cpp
@@ -105,6 +105,24 @@ ExprContainer &ExprContainer::operator*=(const Expr &expr) {
   return *this;
 }
 
+ExprContainer &ExprContainer::operator^=(const Expr &other) {
+  auto this_is_product = expr_->is<Product>();
+  auto other_is_product = other.is<Product>();
+  if (!this_is_product && !other_is_product) {
+    *this =
+        NCProduct(ExprPtrList{to_expr_ptr(std::move(*this)), other.clone()});
+  } else if (this_is_product) {
+    *this = NCProduct(std::move(expr_->as<Product>()));
+    expr_->as<NCProduct>().append(1, other.clone());
+  } else {  // other_is_product
+    NCProduct result(other.clone().as<Product>());
+    result.prepend(1, to_expr_ptr(std::move(*this)));
+    *this = std::move(result);
+  }
+
+  return *this;
+}
+
 void swap(ExprContainer &lhs, ExprContainer &rhs) {
   std::swap(lhs.expr_, rhs.expr_);
 }
@@ -126,6 +144,13 @@ ExprContainer operator-(const Expr &lhs, const Expr &rhs) {
 ExprContainer operator*(const Expr &lhs, const Expr &rhs) {
   ExprContainer cont(lhs);
   cont *= rhs;
+
+  return cont;
+}
+
+ExprContainer operator^(const Expr &lhs, const Expr &rhs) {
+  ExprContainer cont(lhs);
+  cont ^= rhs;
 
   return cont;
 }

--- a/SeQuant/core/expressions/expr_container.cpp
+++ b/SeQuant/core/expressions/expr_container.cpp
@@ -27,6 +27,9 @@ ExprContainer::ExprContainer(const Expr &expr)
 ExprContainer::ExprContainer(Expr &&expr)
     : ExprContainer(std::move(expr).unique_copy()) {}
 
+ExprContainer::ExprContainer(const ExprPtr &ptr)
+    : ExprContainer(ptr->unique_copy()) {}
+
 ExprContainer &ExprContainer::operator=(const ExprContainer &container) {
   // Copy-and-swap
   ExprContainer copy(container);

--- a/SeQuant/core/expressions/expr_container.cpp
+++ b/SeQuant/core/expressions/expr_container.cpp
@@ -2,6 +2,7 @@
 #include <SeQuant/core/expressions/expr.hpp>
 #include <SeQuant/core/expressions/expr_algorithms.hpp>
 #include <SeQuant/core/expressions/expr_container.hpp>
+#include <SeQuant/core/expressions/expr_iterator.hpp>
 #include <SeQuant/core/expressions/expr_ptr.hpp>
 #include <SeQuant/core/expressions/product.hpp>
 #include <SeQuant/core/expressions/sum.hpp>
@@ -63,6 +64,30 @@ ExprContainer &ExprContainer::operator=(Expr &&expr) {
 ExprContainer ExprContainer::copy() const { return expr_->unique_copy(); }
 
 std::unique_ptr<Expr> ExprContainer::take_expr() && { return std::move(expr_); }
+
+ExprIterator ExprContainer::begin() {
+  SEQUANT_ASSERT(expr_);
+  return expr_->begin();
+}
+
+ExprIterator ExprContainer::end() {
+  SEQUANT_ASSERT(expr_);
+  return expr_->end();
+}
+
+ConstExprIterator ExprContainer::begin() const {
+  SEQUANT_ASSERT(expr_);
+  return std::as_const(*expr_).begin();
+}
+
+ConstExprIterator ExprContainer::end() const {
+  SEQUANT_ASSERT(expr_);
+  return std::as_const(*expr_).end();
+}
+
+ConstExprIterator ExprContainer::cbegin() const { return begin(); }
+
+ConstExprIterator ExprContainer::cend() const { return end(); }
 
 ExprContainer::operator const Expr &() const { return *expr_; }
 

--- a/SeQuant/core/expressions/expr_container.cpp
+++ b/SeQuant/core/expressions/expr_container.cpp
@@ -12,7 +12,7 @@
 namespace sequant {
 
 ExprPtr to_expr_ptr(ExprContainer &&container) {
-  return std::shared_ptr<Expr>(std::move(container.expr_));
+  return std::move(container).take_expr();
 }
 
 ExprContainer::ExprContainer(const ExprContainer &container)
@@ -55,6 +55,8 @@ ExprContainer &ExprContainer::operator=(Expr &&expr) {
 }
 
 ExprContainer ExprContainer::copy() const { return expr_->unique_copy(); }
+
+std::unique_ptr<Expr> ExprContainer::take_expr() && { return std::move(expr_); }
 
 ExprContainer::operator const Expr &() const { return *expr_; }
 

--- a/SeQuant/core/expressions/expr_container.cpp
+++ b/SeQuant/core/expressions/expr_container.cpp
@@ -1,5 +1,6 @@
 #include <SeQuant/core/expressions/constant.hpp>
 #include <SeQuant/core/expressions/expr.hpp>
+#include <SeQuant/core/expressions/expr_algorithms.hpp>
 #include <SeQuant/core/expressions/expr_container.hpp>
 #include <SeQuant/core/expressions/expr_ptr.hpp>
 #include <SeQuant/core/expressions/product.hpp>

--- a/SeQuant/core/expressions/expr_container.cpp
+++ b/SeQuant/core/expressions/expr_container.cpp
@@ -195,4 +195,12 @@ ExprContainer operator^(const Expr &lhs, const ExprContainer &rhs) {
   return lhs ^ static_cast<const Expr &>(rhs);
 }
 
+bool operator==(const ExprContainer &lhs, const ExprPtr &rhs) {
+  return *lhs == *rhs;
+}
+
+bool operator==(const ExprPtr &lhs, const ExprContainer &rhs) {
+  return *lhs == *rhs;
+}
+
 }  // namespace sequant

--- a/SeQuant/core/expressions/expr_container.cpp
+++ b/SeQuant/core/expressions/expr_container.cpp
@@ -20,7 +20,9 @@ ExprContainer::ExprContainer(const ExprContainer &container)
     : ExprContainer(container->unique_copy()) {}
 
 ExprContainer::ExprContainer(std::unique_ptr<Expr> expr)
-    : expr_(std::move(expr)) {}
+    : expr_(std::move(expr)) {
+  SEQUANT_ASSERT(expr_ != nullptr);
+}
 
 ExprContainer::ExprContainer(const Expr &expr)
     : ExprContainer(expr.unique_copy()) {}

--- a/SeQuant/core/expressions/expr_container.cpp
+++ b/SeQuant/core/expressions/expr_container.cpp
@@ -63,9 +63,11 @@ ExprContainer::operator const Expr &() const { return *expr_; }
 ExprContainer::operator Expr &() & { return *expr_; }
 ExprContainer::operator Expr &&() && { return std::move(*expr_); }
 
-const Expr &ExprContainer::operator*() const { return *expr_; }
+const Expr &ExprContainer::operator*() const & { return *expr_; }
 
-Expr &ExprContainer::operator*() { return *expr_; }
+Expr &ExprContainer::operator*() & { return *expr_; }
+
+Expr &&ExprContainer::operator*() && { return std::move(*expr_); }
 
 const Expr *ExprContainer::operator->() const { return expr_.get(); }
 

--- a/SeQuant/core/expressions/expr_container.cpp
+++ b/SeQuant/core/expressions/expr_container.cpp
@@ -138,11 +138,27 @@ ExprContainer operator+(const Expr &lhs, const Expr &rhs) {
   return cont;
 }
 
+ExprContainer operator+(const ExprContainer &lhs, const Expr &rhs) {
+  return static_cast<const Expr &>(lhs) + rhs;
+}
+
+ExprContainer operator+(const Expr &lhs, const ExprContainer &rhs) {
+  return lhs + static_cast<const Expr &>(rhs);
+}
+
 ExprContainer operator-(const Expr &lhs, const Expr &rhs) {
   ExprContainer cont(lhs);
   cont -= rhs;
 
   return cont;
+}
+
+ExprContainer operator-(const ExprContainer &lhs, const Expr &rhs) {
+  return static_cast<const Expr &>(lhs) - rhs;
+}
+
+ExprContainer operator-(const Expr &lhs, const ExprContainer &rhs) {
+  return lhs - static_cast<const Expr &>(rhs);
 }
 
 ExprContainer operator*(const Expr &lhs, const Expr &rhs) {
@@ -152,11 +168,27 @@ ExprContainer operator*(const Expr &lhs, const Expr &rhs) {
   return cont;
 }
 
+ExprContainer operator*(const ExprContainer &lhs, const Expr &rhs) {
+  return static_cast<const Expr &>(lhs) * rhs;
+}
+
+ExprContainer operator*(const Expr &lhs, const ExprContainer &rhs) {
+  return lhs * static_cast<const Expr &>(rhs);
+}
+
 ExprContainer operator^(const Expr &lhs, const Expr &rhs) {
   ExprContainer cont(lhs);
   cont ^= rhs;
 
   return cont;
+}
+
+ExprContainer operator^(const ExprContainer &lhs, const Expr &rhs) {
+  return static_cast<const Expr &>(lhs) ^ rhs;
+}
+
+ExprContainer operator^(const Expr &lhs, const ExprContainer &rhs) {
+  return lhs ^ static_cast<const Expr &>(rhs);
 }
 
 }  // namespace sequant

--- a/SeQuant/core/expressions/expr_container.cpp
+++ b/SeQuant/core/expressions/expr_container.cpp
@@ -230,4 +230,10 @@ bool operator==(const ExprPtr &lhs, const ExprContainer &rhs) {
   return *lhs == *rhs;
 }
 
+ExprContainer adjoint(const ExprContainer &cont) {
+  ExprContainer copy = cont.copy();
+  copy->adjoint();
+  return copy;
+}
+
 }  // namespace sequant

--- a/SeQuant/core/expressions/expr_container.hpp
+++ b/SeQuant/core/expressions/expr_container.hpp
@@ -59,9 +59,20 @@ class ExprContainer {
 };
 
 ExprContainer operator+(const Expr &lhs, const Expr &rhs);
+ExprContainer operator+(const ExprContainer &lhs, const Expr &rhs);
+ExprContainer operator+(const Expr &lhs, const ExprContainer &rhs);
+
 ExprContainer operator-(const Expr &lhs, const Expr &rhs);
+ExprContainer operator-(const ExprContainer &lhs, const Expr &rhs);
+ExprContainer operator-(const Expr &lhs, const ExprContainer &rhs);
+
 ExprContainer operator*(const Expr &lhs, const Expr &rhs);
+ExprContainer operator*(const ExprContainer &lhs, const ExprContainer &rhs);
+ExprContainer operator*(const Expr &lhs, const Expr &rhs);
+
 ExprContainer operator^(const Expr &lhs, const Expr &rhs);
+ExprContainer operator^(const ExprContainer &lhs, const Expr &rhs);
+ExprContainer operator^(const Expr &lhs, const ExprContainer &rhs);
 
 }  // namespace sequant
 

--- a/SeQuant/core/expressions/expr_container.hpp
+++ b/SeQuant/core/expressions/expr_container.hpp
@@ -38,6 +38,7 @@ class ExprContainer {
   ExprContainer &operator+=(const Expr &expr);
   ExprContainer &operator-=(const Expr &expr);
   ExprContainer &operator*=(const Expr &expr);
+  ExprContainer &operator^=(const Expr &expr);
 
   friend void swap(ExprContainer &, ExprContainer &);
 
@@ -52,6 +53,7 @@ class ExprContainer {
 ExprContainer operator+(const Expr &lhs, const Expr &rhs);
 ExprContainer operator-(const Expr &lhs, const Expr &rhs);
 ExprContainer operator*(const Expr &lhs, const Expr &rhs);
+ExprContainer operator^(const Expr &lhs, const Expr &rhs);
 
 }  // namespace sequant
 

--- a/SeQuant/core/expressions/expr_container.hpp
+++ b/SeQuant/core/expressions/expr_container.hpp
@@ -7,6 +7,8 @@
 
 namespace sequant {
 
+class ExprPtr;
+
 class ExprContainer {
  public:
   explicit ExprContainer(const ExprContainer &container);
@@ -14,6 +16,8 @@ class ExprContainer {
 
   explicit ExprContainer(const Expr &expr);
   ExprContainer(Expr &&expr);
+
+  explicit ExprContainer(const ExprPtr &ptr);
 
   ExprContainer &operator=(const ExprContainer &container);
   ExprContainer &operator=(ExprContainer &&container) = default;

--- a/SeQuant/core/expressions/expr_container.hpp
+++ b/SeQuant/core/expressions/expr_container.hpp
@@ -1,0 +1,58 @@
+#ifndef SEQUANT_EXPRESSIONS_EXPR_CONTAINER_HPP
+#define SEQUANT_EXPRESSIONS_EXPR_CONTAINER_HPP
+
+#include <SeQuant/core/expressions/expr.hpp>
+
+#include <memory>
+
+namespace sequant {
+
+class ExprContainer {
+ public:
+  explicit ExprContainer(const ExprContainer &container);
+  ExprContainer(ExprContainer &&container) = default;
+
+  explicit ExprContainer(const Expr &expr);
+  ExprContainer(Expr &&expr);
+
+  ExprContainer &operator=(const ExprContainer &container);
+  ExprContainer &operator=(ExprContainer &&container) = default;
+
+  ExprContainer &operator=(const Expr &expr);
+  ExprContainer &operator=(Expr &&expr);
+
+  ~ExprContainer() = default;
+
+  ExprContainer copy() const;
+
+  operator const Expr &() const;
+  operator Expr &() &;
+  operator Expr &&() &&;
+
+  const Expr &operator*() const;
+  Expr &operator*();
+
+  const Expr *operator->() const;
+  Expr *operator->();
+
+  ExprContainer &operator+=(const Expr &expr);
+  ExprContainer &operator-=(const Expr &expr);
+  ExprContainer &operator*=(const Expr &expr);
+
+  friend void swap(ExprContainer &, ExprContainer &);
+
+ private:
+  std::unique_ptr<Expr> expr_;
+
+  ExprContainer(std::unique_ptr<Expr> expr);
+
+  friend ExprPtr to_expr_ptr(ExprContainer &&container);
+};
+
+ExprContainer operator+(const Expr &lhs, const Expr &rhs);
+ExprContainer operator-(const Expr &lhs, const Expr &rhs);
+ExprContainer operator*(const Expr &lhs, const Expr &rhs);
+
+}  // namespace sequant
+
+#endif  // SEQUANT_EXPRESSIONS_EXPR_CONTAINER_HPP

--- a/SeQuant/core/expressions/expr_container.hpp
+++ b/SeQuant/core/expressions/expr_container.hpp
@@ -2,6 +2,7 @@
 #define SEQUANT_EXPRESSIONS_EXPR_CONTAINER_HPP
 
 #include <SeQuant/core/expressions/expr.hpp>
+#include <SeQuant/core/expressions/expr_iterator.hpp>
 
 #include <memory>
 
@@ -31,12 +32,12 @@ class ExprContainer {
 
   std::unique_ptr<Expr> take_expr() &&;
 
-  auto begin() { return expr_->begin(); }
-  auto end() { return expr_->begin(); }
-  auto begin() const { return expr_->begin(); }
-  auto end() const { return expr_->begin(); }
-  auto cbegin() const { return expr_->begin(); }
-  auto cend() const { return expr_->begin(); }
+  ExprIterator begin();
+  ExprIterator end();
+  ConstExprIterator begin() const;
+  ConstExprIterator end() const;
+  ConstExprIterator cbegin() const;
+  ConstExprIterator cend() const;
 
   operator const Expr &() const;
   operator Expr &() &;

--- a/SeQuant/core/expressions/expr_container.hpp
+++ b/SeQuant/core/expressions/expr_container.hpp
@@ -3,6 +3,7 @@
 
 #include <SeQuant/core/expressions/expr_iterator.hpp>
 
+#include <initializer_list>
 #include <memory>
 
 namespace sequant {
@@ -62,6 +63,8 @@ class ExprContainer {
 
   ExprContainer(std::unique_ptr<Expr> expr);
 };
+
+using ExprContainerList = std::initializer_list<ExprContainer>;
 
 ExprContainer operator+(const Expr &lhs, const Expr &rhs);
 ExprContainer operator+(const ExprContainer &lhs, const Expr &rhs);

--- a/SeQuant/core/expressions/expr_container.hpp
+++ b/SeQuant/core/expressions/expr_container.hpp
@@ -85,6 +85,8 @@ ExprContainer operator^(const Expr &lhs, const ExprContainer &rhs);
 bool operator==(const ExprContainer &lhs, const ExprPtr &rhs);
 bool operator==(const ExprPtr &lhs, const ExprContainer &rhs);
 
+ExprContainer adjoint(const ExprContainer &expr);
+
 }  // namespace sequant
 
 #endif  // SEQUANT_EXPRESSIONS_EXPR_CONTAINER_HPP

--- a/SeQuant/core/expressions/expr_container.hpp
+++ b/SeQuant/core/expressions/expr_container.hpp
@@ -1,13 +1,13 @@
 #ifndef SEQUANT_EXPRESSIONS_EXPR_CONTAINER_HPP
 #define SEQUANT_EXPRESSIONS_EXPR_CONTAINER_HPP
 
-#include <SeQuant/core/expressions/expr.hpp>
 #include <SeQuant/core/expressions/expr_iterator.hpp>
 
 #include <memory>
 
 namespace sequant {
 
+class Expr;
 class ExprPtr;
 
 class ExprContainer {

--- a/SeQuant/core/expressions/expr_container.hpp
+++ b/SeQuant/core/expressions/expr_container.hpp
@@ -25,6 +25,8 @@ class ExprContainer {
 
   ExprContainer copy() const;
 
+  std::unique_ptr<Expr> take_expr() &&;
+
   operator const Expr &() const;
   operator Expr &() &;
   operator Expr &&() &&;
@@ -46,8 +48,6 @@ class ExprContainer {
   std::unique_ptr<Expr> expr_;
 
   ExprContainer(std::unique_ptr<Expr> expr);
-
-  friend ExprPtr to_expr_ptr(ExprContainer &&container);
 };
 
 ExprContainer operator+(const Expr &lhs, const Expr &rhs);

--- a/SeQuant/core/expressions/expr_container.hpp
+++ b/SeQuant/core/expressions/expr_container.hpp
@@ -27,6 +27,13 @@ class ExprContainer {
 
   std::unique_ptr<Expr> take_expr() &&;
 
+  auto begin() { return expr_->begin(); }
+  auto end() { return expr_->begin(); }
+  auto begin() const { return expr_->begin(); }
+  auto end() const { return expr_->begin(); }
+  auto cbegin() const { return expr_->begin(); }
+  auto cend() const { return expr_->begin(); }
+
   operator const Expr &() const;
   operator Expr &() &;
   operator Expr &&() &&;

--- a/SeQuant/core/expressions/expr_container.hpp
+++ b/SeQuant/core/expressions/expr_container.hpp
@@ -78,6 +78,9 @@ ExprContainer operator^(const Expr &lhs, const Expr &rhs);
 ExprContainer operator^(const ExprContainer &lhs, const Expr &rhs);
 ExprContainer operator^(const Expr &lhs, const ExprContainer &rhs);
 
+bool operator==(const ExprContainer &lhs, const ExprPtr &rhs);
+bool operator==(const ExprPtr &lhs, const ExprContainer &rhs);
+
 }  // namespace sequant
 
 #endif  // SEQUANT_EXPRESSIONS_EXPR_CONTAINER_HPP

--- a/SeQuant/core/expressions/expr_container.hpp
+++ b/SeQuant/core/expressions/expr_container.hpp
@@ -31,8 +31,9 @@ class ExprContainer {
   operator Expr &() &;
   operator Expr &&() &&;
 
-  const Expr &operator*() const;
-  Expr &operator*();
+  const Expr &operator*() const &;
+  Expr &operator*() &;
+  Expr &&operator*() &&;
 
   const Expr *operator->() const;
   Expr *operator->();

--- a/SeQuant/core/expressions/expr_operators.hpp
+++ b/SeQuant/core/expressions/expr_operators.hpp
@@ -19,83 +19,84 @@ namespace sequant {
 
 template <typename T>
   requires(std::constructible_from<Constant, T>)
-ExprPtr operator+(const ExprPtr &lhs, T &&rhs) {
+ExprPtr operator+(const std::same_as<ExprPtr> auto &lhs, T &&rhs) {
   return lhs + ex<Constant>(std::forward<T>(rhs));
 }
 
 template <typename T>
   requires(std::constructible_from<Constant, T>)
-ExprPtr operator+(T &&lhs, const ExprPtr &rhs) {
+ExprPtr operator+(T &&lhs, const std::same_as<ExprPtr> auto &rhs) {
   return ex<Constant>(std::forward<T>(lhs)) + rhs;
 }
 
 template <typename T>
   requires(std::constructible_from<Constant, T>)
-ExprPtr operator-(const ExprPtr &lhs, T &&rhs) {
+ExprPtr operator-(const std::same_as<ExprPtr> auto &lhs, T &&rhs) {
   return lhs - ex<Constant>(std::forward<T>(rhs));
 }
 
 template <typename T>
   requires(std::constructible_from<Constant, T>)
-ExprPtr operator-(T &&lhs, const ExprPtr &rhs) {
+ExprPtr operator-(T &&lhs, const std::same_as<ExprPtr> auto &rhs) {
   return ex<Constant>(std::forward<T>(lhs)) - rhs;
 }
 
 template <typename T>
   requires(std::constructible_from<Constant, T>)
-ExprPtr operator*(const ExprPtr &lhs, T &&rhs) {
+ExprPtr operator*(const std::same_as<ExprPtr> auto &lhs, T &&rhs) {
   return lhs * ex<Constant>(std::forward<T>(rhs));
 }
 
 template <typename T>
   requires(std::constructible_from<Constant, T>)
-ExprPtr operator*(T &&lhs, const ExprPtr &rhs) {
+ExprPtr operator*(T &&lhs, const std::same_as<ExprPtr> auto &rhs) {
   return ex<Constant>(std::forward<T>(lhs)) * rhs;
 }
 
 template <typename T>
   requires(std::is_arithmetic_v<T>)
-ExprPtr operator/(const ExprPtr &lhs, T &&rhs) {
+ExprPtr operator/(const std::same_as<ExprPtr> auto &lhs, T &&rhs) {
   return lhs * ex<Constant>(rational(1, std::forward<T>(rhs)));
 }
 
-inline ExprPtr operator/(const ExprPtr &lhs, const Constant &rhs) {
+inline ExprPtr operator/(const std::same_as<ExprPtr> auto &lhs,
+                         const Constant &rhs) {
   return lhs * ex<Constant>(1.0 / rhs.value());
 }
 
 template <typename T>
   requires(std::constructible_from<Variable, T>)
-ExprPtr operator+(T &&lhs, const ExprPtr &rhs) {
+ExprPtr operator+(T &&lhs, const std::same_as<ExprPtr> auto &rhs) {
   return ex<Variable>(std::forward<T>(lhs)) + rhs;
 }
 
 template <typename T>
   requires(std::constructible_from<Variable, T>)
-ExprPtr operator+(const ExprPtr &lhs, T &&rhs) {
+ExprPtr operator+(const std::same_as<ExprPtr> auto &lhs, T &&rhs) {
   return lhs + ex<Variable>(std::forward<T>(rhs));
 }
 
 template <typename T>
   requires(std::constructible_from<Variable, T>)
-ExprPtr operator-(T &&lhs, const ExprPtr &rhs) {
+ExprPtr operator-(T &&lhs, const std::same_as<ExprPtr> auto &rhs) {
   return ex<Variable>(std::forward<T>(lhs)) - rhs;
 }
 
 template <typename T>
   requires(std::constructible_from<Variable, T>)
-ExprPtr operator-(const ExprPtr &lhs, T &&rhs) {
+ExprPtr operator-(const std::same_as<ExprPtr> auto &lhs, T &&rhs) {
   return lhs - ex<Variable>(std::forward<T>(rhs));
 }
 
 template <typename T>
   requires(std::constructible_from<Variable, T>)
-ExprPtr operator*(T &&lhs, const ExprPtr &rhs) {
+ExprPtr operator*(T &&lhs, const std::same_as<ExprPtr> auto &rhs) {
   return ex<Variable>(std::forward<T>(lhs)) * rhs;
 }
 
 template <typename T>
   requires(std::constructible_from<Variable, T>)
-ExprPtr operator*(const ExprPtr &lhs, T &&rhs) {
+ExprPtr operator*(const std::same_as<ExprPtr> auto &lhs, T &&rhs) {
   return lhs * ex<Variable>(std::forward<T>(rhs));
 }
 

--- a/SeQuant/core/expressions/expr_ptr.cpp
+++ b/SeQuant/core/expressions/expr_ptr.cpp
@@ -1,6 +1,7 @@
 #include <SeQuant/core/expressions/constant.hpp>
 #include <SeQuant/core/expressions/expr.hpp>
 #include <SeQuant/core/expressions/expr_algorithms.hpp>
+#include <SeQuant/core/expressions/expr_container.hpp>
 #include <SeQuant/core/expressions/expr_operators.hpp>
 #include <SeQuant/core/expressions/expr_ptr.hpp>
 #include <SeQuant/core/expressions/product.hpp>
@@ -10,6 +11,11 @@
 #include <memory>
 
 namespace sequant {
+
+ExprPtr::ExprPtr(const ExprContainer &container) : ExprPtr(container.copy()) {}
+
+ExprPtr::ExprPtr(ExprContainer &&container)
+    : ExprPtr(std::move(container).take_expr()) {}
 
 ExprPtr ExprPtr::clone() const & {
   if (!*this) return {};

--- a/SeQuant/core/expressions/expr_ptr.hpp
+++ b/SeQuant/core/expressions/expr_ptr.hpp
@@ -10,6 +10,8 @@
 
 namespace sequant {
 
+class ExprContainer;
+
 /// @brief ExprPtr is a multiple-owner smart pointer to Expr
 
 /// It can be used mostly interchangeably with `std::shared_ptr<Expr>`, but
@@ -23,6 +25,8 @@ class ExprPtr : public std::shared_ptr<Expr> {
   ExprPtr() = default;
   ExprPtr(const ExprPtr &) = default;
   ExprPtr(ExprPtr &&) = default;
+  explicit ExprPtr(const ExprContainer &container);
+  ExprPtr(ExprContainer &&container);
   template <typename E, typename = std::enable_if_t<
                             std::is_same_v<std::remove_const_t<E>, Expr> ||
                             std::is_base_of_v<Expr, std::remove_const_t<E>>>>

--- a/SeQuant/core/expressions/power.cpp
+++ b/SeQuant/core/expressions/power.cpp
@@ -1,3 +1,4 @@
+#include <SeQuant/core/expressions/expr_container.hpp>
 #include <SeQuant/core/expressions/expr_ptr.hpp>
 #include <SeQuant/core/expressions/power.hpp>
 #include <SeQuant/core/hash.hpp>
@@ -9,19 +10,18 @@
 
 namespace sequant {
 
-Power::Power(ExprPtr base, exponent_type exponent)
-    : base_{}, exponent_{std::move(exponent)} {
-  SEQUANT_ASSERT(base);
-  SEQUANT_ASSERT(base->is<Constant>() || base->is<Variable>());
-  // clone on construction so that external
-  // mutations of the input cannot invalidate our memoized hash
-  base_ = base->clone();
+Power::Power(const ExprPtr& base, exponent_type exponent)
+    : Power(ExprContainer(base), std::move(exponent)) {}
+
+Power::Power(ExprContainer base, exponent_type exponent)
+    : base_{std::move(base)}, exponent_{std::move(exponent)} {
+  SEQUANT_ASSERT(base_->is<Constant>() || base_->is<Variable>());
   // 0^n is defined only for n >= 0 (0^0 = 1 by convention)
   SEQUANT_ASSERT(!base_->is<Constant>() || !base_->as<Constant>().is_zero() ||
                  exponent_ >= 0);
 }
 
-const ExprPtr& Power::base() const { return base_; }
+const ExprContainer& Power::base() const { return base_; }
 
 const Power::exponent_type& Power::exponent() const { return exponent_; }
 
@@ -37,30 +37,38 @@ bool Power::is_zero() const {
          base_->as<Constant>().is_zero();
 }
 
-void Power::flatten(ExprPtr& expr) {
-  if (!expr || !expr->is<Power>()) return;
-  const auto& pw = expr->as<Power>();
+template <expr_holder E>
+void flatt_impl(E& expr) {
+  auto create_constant = [](const auto& val) {
+    if constexpr (std::same_as<std::remove_cvref_t<E>, ExprContainer>) {
+      return Constant(val);
+    } else {
+      return ex<Constant>(val);
+    }
+  };
+
+  const auto& pw = expr->template as<Power>();
 
   // b^1 = b and conjugate if needed
-  if (pw.exponent_ == 1) {
-    auto lifted = pw.base_->clone();
-    if (pw.conjugated_) lifted->adjoint();
+  if (pw.exponent() == 1) {
+    auto lifted = pw.base().copy();
+    if (pw.conjugated()) lifted->adjoint();
     expr = std::move(lifted);
     return;
   }
   // b^0 = 1 for any base (the ctor rejects 0^(negative)
-  if (pw.exponent_ == 0) {
-    expr = ex<Constant>(Constant::scalar_type{1});
+  if (pw.exponent() == 0) {
+    expr = create_constant(Constant::scalar_type{1});
     return;
   }
-  if (!pw.base_->is<Constant>()) return;
+  if (!pw.base()->template is<Constant>()) return;
 
   using scalar_type = Constant::scalar_type;
-  const auto& base_val = pw.base_->as<Constant>().value();
+  const auto& base_val = pw.base()->template as<Constant>().value();
 
   // 1^k = 1 for any rational k.
   if (base_val == scalar_type{1}) {
-    expr = ex<Constant>(scalar_type{1});
+    expr = create_constant(scalar_type{1});
     return;
   }
 
@@ -78,11 +86,11 @@ void Power::flatten(ExprPtr& expr) {
 
   // initialize the base
   scalar_type base{0};
-  auto exp_nr = numerator(pw.exponent_);  // numerator of exponent
+  auto exp_nr = numerator(pw.exponent());
 
-  if (denominator(pw.exponent_) == 1) {
+  if (denominator(pw.exponent()) == 1) {
     base = base_val;
-  } else if (denominator(pw.exponent_) == 2 && base_val.imag() == 0 &&
+  } else if (denominator(pw.exponent()) == 2 && base_val.imag() == 0 &&
              base_val.real() >= 0) {
     intmax_t p = numerator(base_val.real());
     intmax_t q = denominator(base_val.real());  // > 0 by Boost's convention,
@@ -112,8 +120,20 @@ void Power::flatten(ExprPtr& expr) {
   }
   if (negate) value = scalar_type{1} / value;
 
-  if (pw.conjugated_) value = conj(value);
-  expr = ex<Constant>(std::move(value));
+  if (pw.conjugated()) value = conj(value);
+  expr = create_constant(std::move(value));
+}
+
+void Power::flatten(ExprPtr& expr) {
+  if (!expr || !expr->is<Power>()) return;
+
+  flatt_impl(expr);
+}
+
+void Power::flatten(ExprContainer& expr) {
+  if (!expr->is<Power>()) return;
+
+  flatt_impl(expr);
 }
 
 Expr::type_id_type Power::type_id() const { return get_type_id<Power>(); }
@@ -155,9 +175,9 @@ Power& Power::operator*=(const Expr& that) {
 }
 
 std::unique_ptr<Expr> Power::unique_copy() const {
-  auto cloned = std::make_unique<Power>(base_, exponent_);
-  if (conjugated_) cloned->as<Power>().conjugate();
-  return cloned;
+  auto copy = std::make_unique<Power>(base_.copy(), exponent_);
+  if (conjugated_) copy->as<Power>().conjugate();
+  return copy;
 }
 
 Expr::hash_type Power::memoizing_hash() const {

--- a/SeQuant/core/expressions/power.cpp
+++ b/SeQuant/core/expressions/power.cpp
@@ -5,6 +5,8 @@
 #include <SeQuant/core/utility/exception.hpp>
 #include <SeQuant/core/utility/macros.hpp>
 
+#include <memory>
+
 namespace sequant {
 
 Power::Power(ExprPtr base, exponent_type exponent)
@@ -118,12 +120,6 @@ Expr::type_id_type Power::type_id() const { return get_type_id<Power>(); }
 
 bool Power::is_scalar() const { return true; }
 
-ExprPtr Power::clone() const {
-  auto cloned = ex<Power>(base_, exponent_);
-  if (conjugated_) cloned->as<Power>().conjugate();
-  return cloned;
-}
-
 void Power::adjoint() { conjugate(); }
 
 Power& Power::operator*=(const Expr& that) {
@@ -156,6 +152,12 @@ Power& Power::operator*=(const Expr& that) {
     return *this;
   }
   throw Exception("Power::operator*=(that): not valid for that");
+}
+
+std::unique_ptr<Expr> Power::unique_copy() const {
+  auto cloned = std::make_unique<Power>(base_, exponent_);
+  if (conjugated_) cloned->as<Power>().conjugate();
+  return cloned;
 }
 
 Expr::hash_type Power::memoizing_hash() const {

--- a/SeQuant/core/expressions/power.hpp
+++ b/SeQuant/core/expressions/power.hpp
@@ -7,6 +7,9 @@
 #include <SeQuant/core/expressions/variable.hpp>
 #include <SeQuant/core/rational.hpp>
 
+#include <memory>
+#include <string>
+
 namespace sequant {
 
 /// @brief Represents base^exponent where base is a scalar (Constant or
@@ -80,8 +83,6 @@ class Power : public Expr {
 
   bool is_scalar() const override;
 
-  ExprPtr clone() const override;
-
   /// @brief adjoint of Power: flips the conjugation flag.
   void adjoint() override;
 
@@ -94,6 +95,9 @@ class Power : public Expr {
   ///      only the fully unconjugated case combines.
   /// @throw Exception if @p that is not combinable.
   Power& operator*=(const Expr& that);
+
+ protected:
+  std::unique_ptr<Expr> unique_copy() const override;
 
  private:
   ExprPtr base_;

--- a/SeQuant/core/expressions/power.hpp
+++ b/SeQuant/core/expressions/power.hpp
@@ -3,7 +3,9 @@
 
 #include <SeQuant/core/expressions/constant.hpp>
 #include <SeQuant/core/expressions/expr.hpp>
+#include <SeQuant/core/expressions/expr_container.hpp>
 #include <SeQuant/core/expressions/expr_ptr.hpp>
+#include <SeQuant/core/expressions/traits.hpp>
 #include <SeQuant/core/expressions/variable.hpp>
 #include <SeQuant/core/rational.hpp>
 
@@ -27,25 +29,24 @@ class Power : public Expr {
 
   /// @param[in] base the base expression; must be a Constant or Variable.
   /// @param[in] exponent rational exponent
-  Power(ExprPtr base, exponent_type exponent);
+  Power(const ExprPtr& base, exponent_type exponent);
+  Power(ExprContainer base, exponent_type exponent);
 
   /// @overload constructs a `Variable` base from @p label
   template <typename L>
-    requires std::constructible_from<std::wstring, L> &&
-             (!std::convertible_to<L, ExprPtr>)
+    requires(std::constructible_from<std::wstring, L> && !expr_holder<L>)
   Power(L&& label, exponent_type exponent)
       : Power(ex<Variable>(std::forward<L>(label)), std::move(exponent)) {}
 
   /// @overload constructs a `Constant` base from scalar @p value
   template <typename V>
-    requires(!std::constructible_from<std::wstring, V> &&
-             !std::convertible_to<V, ExprPtr> &&
+    requires(!std::constructible_from<std::wstring, V> && !expr_holder<V> &&
              std::constructible_from<Constant::scalar_type, V>)
   Power(V&& value, exponent_type exponent)
       : Power(ex<Constant>(std::forward<V>(value)), std::move(exponent)) {}
 
   /// @return the base expression
-  const ExprPtr& base() const;
+  const ExprContainer& base() const;
 
   /// @return the rational exponent
   const exponent_type& exponent() const;
@@ -78,6 +79,7 @@ class Power : public Expr {
   /// case needed in practice right now). Extending to general n-th roots only
   /// requires replacing the integer-square-root step with an integer n-th-root.
   static void flatten(ExprPtr& expr);
+  static void flatten(ExprContainer& expr);
 
   type_id_type type_id() const override;
 
@@ -100,7 +102,7 @@ class Power : public Expr {
   std::unique_ptr<Expr> unique_copy() const override;
 
  private:
-  ExprPtr base_;
+  ExprContainer base_;
   exponent_type exponent_;
   bool conjugated_ = false;
 

--- a/SeQuant/core/expressions/product.cpp
+++ b/SeQuant/core/expressions/product.cpp
@@ -290,7 +290,7 @@ Product Product::deep_copy() const {
 
 Product &Product::operator*=(const Expr &that) {
   if (!that.is<Constant>()) {
-    this->append(1, const_cast<Expr &>(that).shared_from_this());
+    this->append(1, that.clone());
   } else {
     scalar_ *= that.as<Constant>().value();
   }

--- a/SeQuant/core/expressions/product.cpp
+++ b/SeQuant/core/expressions/product.cpp
@@ -242,6 +242,10 @@ ExprPtr Product::rapid_canonicalize(CanonicalizeOptions opt) {
 
 bool Product::static_commutativity() const { return false; }
 
+std::unique_ptr<Expr> Product::unique_copy() const {
+  return std::make_unique<Product>(deep_copy());
+}
+
 std::wstring Product::to_latex() const { return to_latex(false); }
 
 std::wstring Product::to_latex(bool negate) const {
@@ -271,11 +275,6 @@ std::wstring Product::to_latex(bool negate) const {
 Product::type_id_type Product::type_id() const {
   return get_type_id<Product>();
 }
-
-/// @return an identical clone of this Product (a deep copy allocated on the
-///         heap)
-/// @note this does not flatten the product
-ExprPtr Product::clone() const { return ex<Product>(this->deep_copy()); }
 
 Product Product::deep_copy() const {
   auto cloned_factors =
@@ -393,7 +392,9 @@ CProduct::CProduct(Product &&other) : Product(std::move(other)) {}
 
 bool CProduct::is_commutative() const { return true; }
 
-ExprPtr CProduct::clone() const { return ex<CProduct>(this->deep_copy()); }
+std::unique_ptr<Expr> CProduct::unique_copy() const {
+  return std::make_unique<CProduct>(this->deep_copy());
+}
 
 void CProduct::adjoint() {
   auto adj_scalar = conj(scalar());
@@ -413,7 +414,9 @@ NCProduct::NCProduct(Product &&other) : Product(std::move(other)) {}
 
 bool NCProduct::is_commutative() const { return false; }
 
-ExprPtr NCProduct::clone() const { return ex<NCProduct>(this->deep_copy()); }
+std::unique_ptr<Expr> NCProduct::unique_copy() const {
+  return std::make_unique<NCProduct>(this->deep_copy());
+}
 
 void NCProduct::adjoint() {
   auto adj_scalar = conj(scalar());

--- a/SeQuant/core/expressions/product.hpp
+++ b/SeQuant/core/expressions/product.hpp
@@ -11,6 +11,7 @@
 
 #include <range/v3/view/filter.hpp>
 
+#include <memory>
 #include <string>
 #include <type_traits>
 
@@ -306,11 +307,6 @@ class Product : public Expr {
 
   type_id_type type_id() const override;
 
-  /// @return an identical clone of this Product (a deep copy allocated on the
-  ///         heap)
-  /// @note this does not flatten the product
-  ExprPtr clone() const override;
-
   Product deep_copy() const;
 
   Product &operator*=(const Expr &that);
@@ -337,6 +333,9 @@ class Product : public Expr {
       CanonicalizeOptions opts =
           CanonicalizeOptions::default_options().copy_and_set(
               CanonicalizationMethod::Rapid)) override;
+
+ protected:
+  std::unique_ptr<Expr> unique_copy() const override;
 
  private:
   scalar_type scalar_ = {1, 0};
@@ -366,16 +365,17 @@ class CProduct : public Product {
 
   bool is_commutative() const override;
 
-  /// @return an identical clone of this CProduct
-  /// @note without this override Product::clone() would slice this down to a
-  ///       plain Product, whose adjoint() reverses the factors and whose
-  ///       commutativity is only decided by a recursive pairwise check
-  ExprPtr clone() const override;
-
   /// @brief adjoint of a CProduct is a product of adjoints of its factors, with
   /// complex-conjugated scalar
   /// @note factors are not reversed since the factors commute
   virtual void adjoint() override;
+
+ protected:
+  /// @return an identical clone of this CProduct
+  /// @note without this override Product::clone() would slice this down to a
+  ///       plain Product, whose adjoint() reverses the factors and whose
+  ///       commutativity is only decided by a recursive pairwise check
+  std::unique_ptr<Expr> unique_copy() const override;
 
  private:
   bool static_commutativity() const override;
@@ -389,15 +389,16 @@ class NCProduct : public Product {
 
   bool is_commutative() const override;
 
+  /// @brief adjoint of a NCProduct is a reversed product of adjoints of its
+  /// factors, with complex-conjugated scalar
+  virtual void adjoint() override;
+
+ protected:
   /// @return an identical clone of this NCProduct
   /// @note without this override Product::clone() would slice this down to a
   ///       plain Product, which is no longer unconditionally non-commutative
   ///       and hence may have its factors reordered by canonicalization
-  ExprPtr clone() const override;
-
-  /// @brief adjoint of a NCProduct is a reversed product of adjoints of its
-  /// factors, with complex-conjugated scalar
-  virtual void adjoint() override;
+  std::unique_ptr<Expr> unique_copy() const override;
 
  private:
   bool static_commutativity() const override;

--- a/SeQuant/core/expressions/product.hpp
+++ b/SeQuant/core/expressions/product.hpp
@@ -61,7 +61,7 @@ class Product : public Expr {
     if constexpr (rng_is_expr || rng_is_exprptr) {
       ExprPtr rng_as_exprptr;
       if constexpr (rng_is_expr) {
-        rng_as_exprptr = rng.exprptr_from_this();
+        rng_as_exprptr = rng.clone();
       } else {
         rng_as_exprptr = rng;
       }
@@ -180,10 +180,10 @@ class Product : public Expr {
             typename = std::enable_if_t<is_an_expr_v<Factor>>>
   Product &append(T scalar, Factor &&factor,
                   Flatten flatten_tag = Flatten::Yes) {
-    return this->append(scalar,
-                        std::static_pointer_cast<Expr>(
-                            std::forward<Factor>(factor).shared_from_this()),
-                        flatten_tag);
+    return this->append(
+        scalar,
+        std::static_pointer_cast<Expr>(std::forward<Factor>(factor).clone()),
+        flatten_tag);
   }
 
   /// (post-)multiplies the product by@c factor
@@ -199,9 +199,9 @@ class Product : public Expr {
   /// @warning if @p factor is a Product, it is flattened recursively
   template <typename Factor, typename = std::enable_if_t<is_an_expr_v<Factor>>>
   Product &append(Factor &&factor, Flatten flatten_tag = Flatten::Yes) {
-    return this->append(std::static_pointer_cast<Expr>(
-                            std::forward<Factor>(factor).shared_from_this()),
-                        flatten_tag);
+    return this->append(
+        std::static_pointer_cast<Expr>(std::forward<Factor>(factor).clone()),
+        flatten_tag);
   }
 
   /// (pre-)multiplies the product by @c scalar times @c factor
@@ -252,10 +252,10 @@ class Product : public Expr {
             typename = std::enable_if_t<is_an_expr_v<Factor>>>
   Product &prepend(T scalar, Factor &&factor,
                    Flatten flatten_tag = Flatten::Yes) {
-    return this->prepend(scalar,
-                         std::static_pointer_cast<Expr>(
-                             std::forward<Factor>(factor).shared_from_this()),
-                         flatten_tag);
+    return this->prepend(
+        scalar,
+        std::static_pointer_cast<Expr>(std::forward<Factor>(factor).clone()),
+        flatten_tag);
   }
 
   const scalar_type &scalar() const;

--- a/SeQuant/core/expressions/sum.cpp
+++ b/SeQuant/core/expressions/sum.cpp
@@ -5,6 +5,8 @@
 #include <SeQuant/core/logger.hpp>
 #include <SeQuant/core/utility/macros.hpp>
 
+#include <memory>
+
 namespace sequant {
 
 Sum::Sum(ExprPtrList summands) {
@@ -145,13 +147,6 @@ std::wstring Sum::to_latex() const {
 
 Expr::type_id_type Sum::type_id() const { return Expr::get_type_id<Sum>(); }
 
-ExprPtr Sum::clone() const {
-  auto cloned_summands =
-      summands() |
-      ranges::views::transform([](const ExprPtr &ptr) { return ptr->clone(); });
-  return ex<Sum>(ranges::begin(cloned_summands), ranges::end(cloned_summands));
-}
-
 void Sum::adjoint() {
   using namespace ranges;
   auto adj_summands = summands() | views::transform([](auto &&expr) {
@@ -260,6 +255,14 @@ ConstExprIterator Sum::begin_subexpr() const {
 
 ConstExprIterator Sum::end_subexpr() const {
   return ConstExprIterator{summands_.data() + summands_.size()};
+}
+
+std::unique_ptr<Expr> Sum::unique_copy() const {
+  auto cloned_summands =
+      summands() |
+      ranges::views::transform([](const ExprPtr &ptr) { return ptr->clone(); });
+  return std::make_unique<Sum>(ranges::begin(cloned_summands),
+                               ranges::end(cloned_summands));
 }
 
 Expr::hash_type Sum::memoizing_hash() const {

--- a/SeQuant/core/expressions/sum.cpp
+++ b/SeQuant/core/expressions/sum.cpp
@@ -157,8 +157,8 @@ void Sum::adjoint() {
 
 ExprPtr Sum::canonicalize_impl(bool multipass, CanonicalizeOptions opts) {
   if (Logger::instance().canonicalize)
-    std::wcout << "Sum::canonicalize_impl: input = "
-               << to_latex_align(shared_from_this()) << std::endl;
+    std::wcout << "Sum::canonicalize_impl: input = " << to_latex_align(*this)
+               << std::endl;
 
   const auto npasses = multipass ? 2 : 1;
   for (auto pass = 0; pass != npasses; ++pass) {
@@ -192,7 +192,7 @@ ExprPtr Sum::canonicalize_impl(bool multipass, CanonicalizeOptions opts) {
     if (Logger::instance().canonicalize)
       std::wcout << "Sum::canonicalize_impl (pass=" << pass
                  << "): after canonicalizing summands = "
-                 << to_latex_align(shared_from_this()) << std::endl;
+                 << to_latex_align(*this) << std::endl;
 
     HashingAccumulator acc;
     for (auto &summand : summands_) {
@@ -209,15 +209,15 @@ ExprPtr Sum::canonicalize_impl(bool multipass, CanonicalizeOptions opts) {
 
     if (Logger::instance().canonicalize)
       std::wcout << "Sum::canonicalize_impl (pass=" << pass
-                 << "): after reducing summands = "
-                 << to_latex_align(shared_from_this()) << std::endl;
+                 << "): after reducing summands = " << to_latex_align(*this)
+                 << std::endl;
   }
 
   return {};  // side effects are absorbed into summands
 }
 
 Sum &Sum::operator+=(const Expr &that) {
-  this->append(const_cast<Expr &>(that).shared_from_this());
+  this->append(that.clone());
   return *this;
 }
 
@@ -225,8 +225,7 @@ Sum &Sum::operator-=(const Expr &that) {
   if (that.is<Constant>())
     this->append(ex<Constant>(-that.as<Constant>().value()));
   else
-    this->append(ex<Product>(
-        -1, ExprPtrList{const_cast<Expr &>(that).shared_from_this()}));
+    this->append(ex<Product>(-1, ExprPtrList{that.clone()}));
   return *this;
 }
 

--- a/SeQuant/core/expressions/sum.hpp
+++ b/SeQuant/core/expressions/sum.hpp
@@ -66,7 +66,7 @@ class Sum : public Expr {
     if constexpr (rng_is_expr || rng_is_exprptr) {
       ExprPtr rng_as_exprptr;
       if constexpr (rng_is_expr) {
-        rng_as_exprptr = rng.exprptr_from_this();
+        rng_as_exprptr = rng.clone();
       } else {
         rng_as_exprptr = rng;
       }

--- a/SeQuant/core/expressions/sum.hpp
+++ b/SeQuant/core/expressions/sum.hpp
@@ -17,6 +17,7 @@
 #include <range/v3/view/filter.hpp>
 #include <range/v3/view/transform.hpp>
 
+#include <memory>
 #include <optional>
 #include <type_traits>
 
@@ -127,8 +128,6 @@ class Sum : public Expr {
 
   Expr::type_id_type type_id() const override;
 
-  ExprPtr clone() const override;
-
   /// @brief adjoint of a Sum is a sum of adjoints of its factors
   virtual void adjoint() override;
 
@@ -143,6 +142,9 @@ class Sum : public Expr {
   ConstExprIterator begin_subexpr() const override;
 
   ConstExprIterator end_subexpr() const override;
+
+ protected:
+  std::unique_ptr<Expr> unique_copy() const override;
 
  private:
   summands_type summands_{};

--- a/SeQuant/core/expressions/sum.hpp
+++ b/SeQuant/core/expressions/sum.hpp
@@ -4,6 +4,7 @@
 #include <SeQuant/core/container.hpp>
 #include <SeQuant/core/expressions/constant.hpp>
 #include <SeQuant/core/expressions/expr.hpp>
+#include <SeQuant/core/expressions/expr_container.hpp>
 #include <SeQuant/core/expressions/expr_iterator.hpp>
 #include <SeQuant/core/expressions/expr_ptr.hpp>
 #include <SeQuant/core/expressions/product.hpp>
@@ -110,13 +111,13 @@ class Sum : public Expr {
   /// offset
   ExprPtr take_n(size_t offset, size_t count) const;
 
-  /// @tparam Filter a boolean predicate type, such `Filter(const ExprPtr&)`
-  /// evaluates to true
-  /// @param f an object of Filter type
-  /// Selects elements {`e`} for which `f(e)` is true
-  template <typename Filter>
+  /// @param f Boolean predicate
+  /// @returns A sum containing only the summands for which f was true.
+  template <std::predicate<const Expr &> Filter>
   ExprPtr filter(Filter &&f) const {
-    return ex<Sum>(summands_ | ranges::views::filter(f));
+    return ex<Sum>(summands_ |
+                   ranges::views::transform([](const auto &e) { return *e; }) |
+                   ranges::views::filter(f));
   }
 
   /// @return true if the number of factors is zero

--- a/SeQuant/core/expressions/sum.hpp
+++ b/SeQuant/core/expressions/sum.hpp
@@ -17,8 +17,10 @@
 #include <range/v3/view/filter.hpp>
 #include <range/v3/view/transform.hpp>
 
+#include <concepts>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <type_traits>
 
 namespace sequant {
@@ -54,15 +56,14 @@ class Sum : public Expr {
 
   /// construct a Sum out of a range of summands
   /// @param rng a range
-  template <typename Range>
-    requires(meta::is_range_v<std::remove_cvref_t<Range>> &&
-             !meta::is_same_v<std::remove_cvref_t<Range>, ExprPtrList>)
+  template <std::ranges::range Range>
+    requires(!std::same_as<std::remove_cvref_t<Range>, ExprPtrList>)
   explicit Sum(Range &&rng) {
     // N.B. use append to flatten out Sum summands
-    constexpr auto rng_is_expr =
-        meta::is_base_of_v<Expr, std::remove_cvref_t<Range>>;
+    constexpr auto rng_is_expr = is_an_expr_v<std::remove_cvref_t<Range>>;
     constexpr auto rng_is_exprptr =
-        meta::is_same_v<ExprPtr, std::remove_cvref_t<Range>>;
+        std::same_as<ExprPtr, std::remove_cvref_t<Range>>;
+
     if constexpr (rng_is_expr || rng_is_exprptr) {
       ExprPtr rng_as_exprptr;
       if constexpr (rng_is_expr) {

--- a/SeQuant/core/expressions/tensor.cpp
+++ b/SeQuant/core/expressions/tensor.cpp
@@ -45,4 +45,8 @@ ExprPtr Tensor::canonicalize(CanonicalizeOptions) {
   return canonicalizer_ptr ? canonicalizer_ptr->apply(*this) : ExprPtr{};
 }
 
+std::unique_ptr<Expr> Tensor::unique_copy() const {
+  return std::make_unique<Tensor>(*this);
+}
+
 }  // namespace sequant

--- a/SeQuant/core/expressions/tensor.hpp
+++ b/SeQuant/core/expressions/tensor.hpp
@@ -754,8 +754,6 @@ class Tensor : public Expr, public AbstractTensor, public MutatableLabeled {
 
   type_id_type type_id() const override { return get_type_id<Tensor>(); };
 
-  ExprPtr clone() const override { return ex<Tensor>(*this); }
-
   void reset_tags() const {
     ranges::for_each(slots(), [](const auto &idx) { idx.reset_tag(); });
   }
@@ -774,6 +772,9 @@ class Tensor : public Expr, public AbstractTensor, public MutatableLabeled {
     } else
       return false;  // TODO do we compare typeid? labels? probably the latter
   }
+
+ protected:
+  std::unique_ptr<Expr> unique_copy() const override;
 
  private:
   std::wstring label_{};

--- a/SeQuant/core/expressions/traits.hpp
+++ b/SeQuant/core/expressions/traits.hpp
@@ -4,6 +4,9 @@
 #include <SeQuant/core/expr_fwd.hpp>
 #include <SeQuant/core/meta.hpp>
 
+#include <concepts>
+#include <type_traits>
+
 namespace sequant {
 
 template <typename T>
@@ -35,6 +38,10 @@ template <typename T>
 constexpr bool is_a_power_v = meta::is_base_of_v<Power, T>;
 template <typename T>
 constexpr bool is_power_v = meta::is_same_v<Power, T>;
+
+template <typename T>
+concept expr_holder = std::same_as<std::remove_cvref_t<T>, ExprPtr> ||
+                      std::same_as<std::remove_cvref_t<T>, ExprContainer>;
 
 }  // namespace sequant
 

--- a/SeQuant/core/expressions/variable.cpp
+++ b/SeQuant/core/expressions/variable.cpp
@@ -4,6 +4,7 @@
 #include <SeQuant/core/utility/macros.hpp>
 #include <SeQuant/core/utility/string.hpp>
 
+#include <memory>
 #include <string>
 #include <string_view>
 
@@ -60,7 +61,9 @@ std::wstring Variable::to_latex() const {
   return result;
 }
 
-ExprPtr Variable::clone() const { return ex<Variable>(*this); }
+std::unique_ptr<Expr> Variable::unique_copy() const {
+  return std::make_unique<Variable>(*this);
+}
 
 void Variable::adjoint() { conjugate(); }
 

--- a/SeQuant/core/expressions/variable.hpp
+++ b/SeQuant/core/expressions/variable.hpp
@@ -5,6 +5,7 @@
 #include <SeQuant/core/expressions/labeled.hpp>
 #include <SeQuant/core/utility/macros.hpp>
 
+#include <memory>
 #include <string>
 #include <string_view>
 
@@ -50,10 +51,11 @@ class Variable : public Expr, public MutatableLabeled {
 
   bool is_scalar() const override;
 
-  ExprPtr clone() const override;
-
   /// @brief adjoint of a Variable is its complex conjugate
   virtual void adjoint() override;
+
+ protected:
+  std::unique_ptr<Expr> unique_copy() const override;
 
  private:
   std::wstring label_;

--- a/SeQuant/core/op.hpp
+++ b/SeQuant/core/op.hpp
@@ -389,7 +389,10 @@ class Operator : public container::svector<Op<S>>, public Expr {
 
   type_id_type type_id() const override { return get_type_id<Operator>(); };
 
-  ExprPtr clone() const override { return std::make_shared<Operator>(*this); }
+ protected:
+  std::unique_ptr<Expr> unique_copy() const override {
+    return std::make_unique<Operator>(*this);
+  }
 
  private:
   base_type make_ops(Action action, IndexList indices) {
@@ -711,10 +714,6 @@ class NormalOperator : public Operator<S>,
     return Expr::get_type_id<NormalOperator>();
   };
 
-  ExprPtr clone() const override {
-    return std::make_shared<NormalOperator>(*this);
-  }
-
   virtual void adjoint() override {
     // same as base adjoint(), but updates extra state
     Operator<S>::adjoint();
@@ -737,6 +736,11 @@ class NormalOperator : public Operator<S>,
     });
     if (mutated) this->reset_hash_value();
     return mutated;
+  }
+
+ protected:
+  std::unique_ptr<Expr> unique_copy() const override {
+    return std::make_unique<NormalOperator>(*this);
   }
 
  private:
@@ -1068,13 +1072,16 @@ class NormalOperatorSequence : public container::svector<NormalOperator<S>>,
     return Expr::get_type_id<NormalOperatorSequence>();
   };
 
-  ExprPtr clone() const override { return ex<NormalOperatorSequence>(*this); }
-
   friend bool operator==(const NormalOperatorSequence &nopseq1,
                          const NormalOperatorSequence &nopseq2) {
     return nopseq1.vacuum() == nopseq2.vacuum() &&
            static_cast<const base_type &>(nopseq1) ==
                static_cast<const base_type &>(nopseq2);
+  }
+
+ protected:
+  std::unique_ptr<Expr> unique_copy() const override {
+    return std::make_unique<NormalOperatorSequence>(*this);
   }
 
  private:

--- a/SeQuant/domain/mbpt/op.cpp
+++ b/SeQuant/domain/mbpt/op.cpp
@@ -580,14 +580,14 @@ ExprPtr OpMaker<S>::operator()(
   if (!dep && csv) {
     if (opclass == OpClass::Ex) {
       if constexpr (assert_enabled()) {
-        for (auto&& s : cre_spaces_) {
+        for ([[maybe_unused]] const auto& s : cre_spaces_) {
           SEQUANT_ASSERT(isr->contains_unoccupied(s));
         }
       }
       dep = UseDepIdx::Bra;
     } else if (opclass == OpClass::Deex) {
       if constexpr (assert_enabled()) {
-        for (auto&& s : ann_spaces_) {
+        for ([[maybe_unused]] const auto& s : ann_spaces_) {
           SEQUANT_ASSERT(isr->contains_unoccupied(s));
         }
       }

--- a/SeQuant/domain/mbpt/op.hpp
+++ b/SeQuant/domain/mbpt/op.hpp
@@ -43,7 +43,7 @@
 #include <functional>
 #include <initializer_list>
 #include <iterator>
-#include <map>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -950,6 +950,9 @@ class Operator : public Operator<void, S> {
   /// @brief returns the perturbation order of this operator
   [[nodiscard]] size_t order() const { return order_; }
 
+ protected:
+  std::unique_ptr<Expr> unique_copy() const override;
+
  private:
   std::function<void(QuantumNumbers&)> qn_action_;
 
@@ -962,8 +965,6 @@ class Operator : public Operator<void, S> {
   bool less_than_rank_of(const this_type& that) const;
 
   Expr::type_id_type type_id() const override;
-
-  ExprPtr clone() const override;
 
   std::wstring to_latex() const override;
 

--- a/SeQuant/domain/mbpt/op.ipp
+++ b/SeQuant/domain/mbpt/op.ipp
@@ -12,6 +12,8 @@
 #include <range/v3/algorithm/is_sorted.hpp>
 #include <range/v3/view/iota.hpp>
 
+#include <memory>
+
 namespace sequant {
 namespace mbpt {
 
@@ -192,8 +194,8 @@ Expr::type_id_type Operator<QuantumNumbers, S>::type_id() const {
 };
 
 template <typename QuantumNumbers, Statistics S>
-ExprPtr Operator<QuantumNumbers, S>::clone() const {
-  return ex<this_type>(*this);
+std::unique_ptr<Expr> Operator<QuantumNumbers, S>::unique_copy() const {
+  return std::make_unique<this_type>(*this);
 }
 
 // Expresses general operators in human interpretable form. for example:

--- a/tests/unit/test_expr.cpp
+++ b/tests/unit/test_expr.cpp
@@ -1008,10 +1008,14 @@ TEST_CASE("expr", "[elements]") {
 
     REQUIRE(hash_value(ex<Constant>(1)) == hash_value(ex<Constant>(1)));
 
-    auto hasher = [](const std::shared_ptr<const Expr> &) -> unsigned int {
+    auto hasher1 = [](const std::shared_ptr<const Expr> &) -> unsigned int {
       return 0;
     };
-    REQUIRE_NOTHROW(ex<Constant>(1)->hash_value(hasher) == 0);
+    auto hasher2 = [](const Expr &) -> unsigned int { return 2; };
+    SEQUANT_PRAGMA_IGNORE_DEPRECATED_BEGIN
+    REQUIRE_NOTHROW(ex<Constant>(1)->hash_value(hasher1) == 0);
+    SEQUANT_PRAGMA_IGNORE_DEPRECATED_END
+    REQUIRE_NOTHROW(ex<Constant>(1)->hash_value(hasher2) == 2);
 
     {  // Power
       const auto c2 = ex<Constant>(rational{1, 2});

--- a/tests/unit/test_expr.cpp
+++ b/tests/unit/test_expr.cpp
@@ -1359,6 +1359,24 @@ TEST_CASE("expr", "[elements]") {
 
       REQUIRE_THAT(res, EquivalentTo("(1 + A - B) * 3"));
     }
+    SECTION("Conversion to ExprPtr") {
+      ExprContainer cont = Constant(3);
+
+      ExprPtr ptr = std::move(cont);
+      REQUIRE(ptr->is<Constant>());
+      REQUIRE(ptr->as<Constant>().value() == 3);
+
+      cont = Variable("A");
+      // Copy-conversion-ctor is explicit
+      ptr = ExprPtr(cont);
+      REQUIRE(ptr->is<Variable>());
+      REQUIRE(ptr->as<Variable>().label() == L"A");
+
+      // Ensure that ptr actually points to a copy
+      ptr->as<Variable>().set_label(L"B");
+      REQUIRE(cont->as<Variable>().label() == L"A");
+      REQUIRE(ptr->as<Variable>().label() == L"B");
+    }
   }
 
   SECTION("ResultExpr") {

--- a/tests/unit/test_expr.cpp
+++ b/tests/unit/test_expr.cpp
@@ -370,9 +370,9 @@ TEST_CASE("expr", "[elements]") {
       // convenience ctors:
       REQUIRE(Power(L"x", 2) == Power(vx, rational{2}));
       REQUIRE(Power(L"x", rational{1, 2}) == Power(vx, rational{1, 2}));
-      REQUIRE(Power(2, 3) == Power(ex<Constant>(2), rational{3}));
+      REQUIRE(Power(2, 3) == Power(Constant(2), rational{3}));
       REQUIRE(Power(rational{2, 3}, 2) ==
-              Power(ex<Constant>(rational{2, 3}), rational{2}));
+              Power(Constant(rational{2, 3}), rational{2}));
       if constexpr (sequant::assert_behavior() ==
                     sequant::AssertBehavior::Throw) {
         // base must be a Constant or Variable; Power-of-Power is not allowed
@@ -380,20 +380,20 @@ TEST_CASE("expr", "[elements]") {
         REQUIRE_THROWS(Power(inner, rational{2, 3}));
 
         // 0^n is defined only for n >= 0
-        REQUIRE_THROWS(Power(ex<Constant>(0), rational{-1}));
+        REQUIRE_THROWS(Power(Constant(0), rational{-1}));
       }
     }
 
     {  // accessors
       Power p(c2, rational{1, 2});
-      REQUIRE(p.base() == ex<Constant>(rational{1, 2}));
+      REQUIRE(p.base() == Constant(rational{1, 2}));
       REQUIRE(p.exponent() == rational{1, 2});
 
       // is_zero: base == 0, exponent > 0
-      Power pz(ex<Constant>(0), rational{2});
+      Power pz(Constant(0), rational{2});
       REQUIRE(pz.is_zero());
       // 0^0 is not zero by our convention
-      Power pz2(ex<Constant>(0), rational{0});
+      Power pz2(Constant(0), rational{0});
       REQUIRE(!pz2.is_zero());
       REQUIRE(!p.is_zero());
     }
@@ -447,8 +447,8 @@ TEST_CASE("expr", "[elements]") {
       REQUIRE(pc_conj2.exponent() == rational{3, 2});
 
       // 2^{1/2} * 2^{1/2} = 2
-      Power pe(ex<Constant>(2), rational{1, 2});
-      Power pf(ex<Constant>(2), rational{1, 2});
+      Power pe(Constant(2), rational{1, 2});
+      Power pf(Constant(2), rational{1, 2});
       pe *= pf;
       REQUIRE(pe.exponent() == rational{1});
       REQUIRE(to_latex(pe) == Constant(2).to_latex());

--- a/tests/unit/test_expr.cpp
+++ b/tests/unit/test_expr.cpp
@@ -37,7 +37,9 @@ struct Dummy : public sequant::Expr {
   virtual ~Dummy() = default;
   std::wstring to_latex() const override { return L"{\\text{Dummy}}"; }
   type_id_type type_id() const override { return get_type_id<Dummy>(); };
-  sequant::ExprPtr clone() const override { return sequant::ex<Dummy>(); }
+  std::unique_ptr<sequant::Expr> unique_copy() const override {
+    return std::make_unique<Dummy>();
+  }
   void adjoint() override {}
   bool static_equal(const sequant::Expr &) const override { return true; }
 };
@@ -110,8 +112,8 @@ struct VecExpr : public std::vector<T>, public sequant::Expr {
            static_cast<const base_type &>(static_cast<const VecExpr &>(that));
   }
 
-  sequant::ExprPtr clone() const override {
-    return sequant::ex<VecExpr>(this->begin(), this->end());
+  std::unique_ptr<sequant::Expr> unique_copy() const override {
+    return std::make_unique<VecExpr>(this->begin(), this->end());
   }
 };
 
@@ -123,8 +125,8 @@ struct Adjointable : public sequant::Expr {
     return L"{\\text{Adjointable}{" + std::to_wstring(v) + L"}}";
   }
   type_id_type type_id() const override { return get_type_id<Adjointable>(); };
-  sequant::ExprPtr clone() const override {
-    return sequant::ex<Adjointable>(v);
+  std::unique_ptr<sequant::Expr> unique_copy() const override {
+    return std::make_unique<Adjointable>(v);
   }
   bool static_equal(const sequant::Expr &that) const override {
     return v == that.as<Adjointable>().v;

--- a/tests/unit/test_expr.cpp
+++ b/tests/unit/test_expr.cpp
@@ -1241,6 +1241,126 @@ TEST_CASE("expr", "[elements]") {
     }
   }
 
+  SECTION("ExprContainer") {
+    SECTION("Constructors") {
+      SECTION("from conrete") {
+        ExprContainer cont1(Constant(1));
+        REQUIRE(cont1->is<Constant>());
+        REQUIRE(cont1->as<Constant>() == Constant(1));
+
+        ExprContainer cont2(Variable("bla"));
+        REQUIRE(cont2->is<Variable>());
+        REQUIRE(cont2->as<Variable>() == Variable("bla"));
+
+        Product prod(ExprPtrList{ex<Variable>("bla"), ex<Constant>(2)});
+        ExprContainer cont3(prod);
+        REQUIRE(cont3->is<Product>());
+        REQUIRE(cont3->as<Product>() == prod);
+
+        Sum sum(ExprPtrList{ex<Variable>("bla"), ex<Constant>(2)});
+        ExprContainer cont4(sum);
+        REQUIRE(cont4->is<Sum>());
+        REQUIRE(cont4->as<Sum>() == sum);
+      }
+      SECTION("from  base") {
+        ExprPtr expr = ex<Constant>(42);
+
+        ExprContainer cont(*expr);
+        REQUIRE(cont->is<Constant>());
+        REQUIRE(cont->as<Constant>().value() == 42);
+      }
+      SECTION("conversion via 'assignment'") {
+        ExprContainer cont1 = Constant(1);
+        REQUIRE(cont1->is<Constant>());
+        REQUIRE(cont1->as<Constant>() == Constant(1));
+
+        ExprContainer cont2 = Variable("bla");
+        REQUIRE(cont2->is<Variable>());
+        REQUIRE(cont2->as<Variable>() == Variable("bla"));
+
+        // Note: copy-ctor is explicit so in order for this "assignment" to
+        // work, we need to assign rvalues
+        Product prod(ExprPtrList{ex<Variable>("bla"), ex<Constant>(2)});
+        ExprContainer cont3 = Product(prod);
+        REQUIRE(cont3->is<Product>());
+        REQUIRE(cont3->as<Product>() == prod);
+
+        Sum sum(ExprPtrList{ex<Variable>("bla"), ex<Constant>(2)});
+        ExprContainer cont4 = Sum(sum);
+        REQUIRE(cont4->is<Sum>());
+        REQUIRE(cont4->as<Sum>() == sum);
+      }
+    }
+    SECTION("Assignment") {
+      ExprContainer cont = Constant(1);
+      REQUIRE(cont->is<Constant>());
+      REQUIRE(cont->as<Constant>() == Constant(1));
+
+      cont = Variable("bla");
+      REQUIRE(cont->is<Variable>());
+      REQUIRE(cont->as<Variable>() == Variable("bla"));
+
+      Product prod(ExprPtrList{ex<Variable>("bla"), ex<Constant>(2)});
+      cont = Product(prod);
+      REQUIRE(cont->is<Product>());
+      REQUIRE(cont->as<Product>() == prod);
+
+      Sum sum(ExprPtrList{ex<Variable>("bla"), ex<Constant>(2)});
+      cont = Sum(sum);
+      REQUIRE(cont->is<Sum>());
+      REQUIRE(cont->as<Sum>() == sum);
+    }
+    SECTION("value semantics") {
+      ExprContainer cont = Constant(1);
+      ExprContainer copy(cont);
+      copy = Variable("test");
+
+      REQUIRE(copy->is<Variable>());
+      REQUIRE(cont->is<Constant>());
+    }
+    SECTION("conversion to Expr &") {
+      bool passed1 = false;
+
+      auto func1 = [&passed1](Expr &) { passed1 = true; };
+
+      ExprContainer expr = Constant(5);
+      func1(expr);
+
+      REQUIRE(passed1);
+
+      bool passed2 = false;
+      auto func2 = [&passed2](const Expr &) { passed2 = true; };
+
+      func2(std::as_const(expr));
+
+      REQUIRE(passed2);
+
+      bool passed3 = false;
+      auto func3 = [&passed3](Expr &&) { passed3 = true; };
+
+      func3(std::move(expr));
+
+      REQUIRE(passed3);
+    }
+    SECTION("freestanding Expr arithmetic") {
+      // This allows to use arithmetic directly on Expr & instances (instead of
+      // requiring ExprPtr or ExprContainer wrappers)
+      ExprContainer res = Constant(1) + Variable("One");
+      REQUIRE_THAT(res, EquivalentTo("1 + One"));
+
+      res = Variable("A") * Tensor("T", bra({"a1"}), ket()) - Constant(42);
+      REQUIRE_THAT(res, EquivalentTo("A * T{a1} - 42"));
+    }
+    SECTION("In-place ExprContainer arithmetic") {
+      ExprContainer res = Constant(1);
+      res += Variable("A");
+      res -= Variable("B");
+      res *= Constant(3);
+
+      REQUIRE_THAT(res, EquivalentTo("(1 + A - B) * 3"));
+    }
+  }
+
   SECTION("ResultExpr") {
     SECTION("accessors") {
       SECTION("as_variable") {

--- a/tests/unit/test_expr.cpp
+++ b/tests/unit/test_expr.cpp
@@ -1381,6 +1381,19 @@ TEST_CASE("expr", "[elements]") {
       REQUIRE(cont->as<Variable>().label() == L"A");
       REQUIRE(ptr->as<Variable>().label() == L"B");
     }
+    SECTION("Conversion from ExprPtr") {
+      // This conversion is always explicit as it always has to perform a copy.
+      // Even a moved-from ExpPtr might point to an object that is co-owned by
+      // another ExprPtr and thus "resource stealing" is not possible.
+      ExprPtr ptr = ex<Constant>(2);
+      ExprContainer cont(ptr);
+      REQUIRE(cont->is<Constant>());
+      REQUIRE(cont->as<Constant>().value() == 2);
+
+      ptr->as<Constant>() = Constant(3);
+      REQUIRE(ptr->as<Constant>().value() == 3);
+      REQUIRE(cont->as<Constant>().value() == 2);
+    }
   }
 
   SECTION("ResultExpr") {

--- a/tests/unit/test_expr.cpp
+++ b/tests/unit/test_expr.cpp
@@ -363,7 +363,7 @@ TEST_CASE("expr", "[elements]") {
     const auto c2 = ex<Constant>(rational{1, 2});
     const auto vx = ex<Variable>(L"x");
 
-    {  // constructors
+    SECTION("constructors") {
       REQUIRE_NOTHROW(Power(c2, rational{1, 2}));
       REQUIRE_NOTHROW(Power(vx, rational{3, 1}));
 
@@ -384,7 +384,7 @@ TEST_CASE("expr", "[elements]") {
       }
     }
 
-    {  // accessors
+    SECTION("accessors") {
       Power p(c2, rational{1, 2});
       REQUIRE(p.base() == Constant(rational{1, 2}));
       REQUIRE(p.exponent() == rational{1, 2});
@@ -398,7 +398,7 @@ TEST_CASE("expr", "[elements]") {
       REQUIRE(!p.is_zero());
     }
 
-    {  // comparison
+    SECTION("comparison") {
       Power p1(c2, rational{1, 2});
       Power p2(c2, rational{1, 2});
       REQUIRE(p1 == p2);
@@ -417,7 +417,7 @@ TEST_CASE("expr", "[elements]") {
       REQUIRE(!(plt_a < plt_c));
     }
 
-    {  // operator*=
+    SECTION("operator*=") {
       // b^e1 *= b^e2 -> b^(e1+e2)
       Power pa(vx, rational{1, 2});
       Power pb(vx, rational{1, 3});
@@ -454,7 +454,7 @@ TEST_CASE("expr", "[elements]") {
       REQUIRE(to_latex(pe) == Constant(2).to_latex());
     }
 
-    {  // Power should NOT be absorbed into Product::scalar_
+    SECTION("Don't absorb into Product::scalar") {
       auto p = ex<Power>(vx, rational{1, 2});
       auto prod = ex<Product>(Product{});
       prod->as<Product>().append(1, p, Product::Flatten::Yes);
@@ -499,12 +499,12 @@ TEST_CASE("expr", "[elements]") {
       REQUIRE_NOTHROW(e->adjoint());
       REQUIRE_NOTHROW(adjoint(e));  // check free-function adjoint
     }
-    {  // Constant
+    SECTION("Constant") {
       const auto e = std::make_shared<Constant>(Constant::scalar_type{1, 2});
       REQUIRE_NOTHROW(e->adjoint());
       REQUIRE(e->value() == Constant::scalar_type{1, -2});
     }
-    {  // Variable
+    SECTION("Variabkle") {
       const auto e = std::make_shared<Variable>(L"q");
       REQUIRE(e->conjugated() == false);
       REQUIRE_NOTHROW(e->adjoint());
@@ -513,7 +513,7 @@ TEST_CASE("expr", "[elements]") {
       REQUIRE_NOTHROW(e->adjoint());
       REQUIRE(e->conjugated() == false);
     }
-    {  // Product
+    SECTION("Product") {  // Product
       const auto e = std::make_shared<Product>();
       e->append(Constant::scalar_type{2, -1}, ex<Adjointable>());
       e->append(1, ex<Adjointable>(-2));
@@ -522,7 +522,7 @@ TEST_CASE("expr", "[elements]") {
       REQUIRE(e->factors()[0]->as<Adjointable>().v == 2);
       REQUIRE(e->factors()[1]->as<Adjointable>().v == -1);
     }
-    {  // CProduct
+    SECTION("CProduct") {
       const auto e = std::make_shared<CProduct>();
       e->append(Constant::scalar_type{2, -1}, ex<Adjointable>());
       e->append(1, ex<Adjointable>(-2));
@@ -531,7 +531,7 @@ TEST_CASE("expr", "[elements]") {
       REQUIRE(e->factors()[0]->as<Adjointable>().v == -1);
       REQUIRE(e->factors()[1]->as<Adjointable>().v == 2);
     }
-    {  // NCProduct
+    SECTION("NCProduct") {
       const auto e = std::make_shared<NCProduct>();
       e->append(Constant::scalar_type{2, -1}, ex<Adjointable>());
       e->append(1, ex<Adjointable>(-2));
@@ -540,7 +540,7 @@ TEST_CASE("expr", "[elements]") {
       REQUIRE(e->factors()[0]->as<Adjointable>().v == 2);
       REQUIRE(e->factors()[1]->as<Adjointable>().v == -1);
     }
-    {  // Sum
+    SECTION("Sum") {
       const auto e = std::make_shared<Sum>();
       e->append(ex<Adjointable>());
       e->append(ex<Adjointable>(-2));
@@ -548,7 +548,8 @@ TEST_CASE("expr", "[elements]") {
       REQUIRE(e->summands()[0]->as<Adjointable>().v == -1);
       REQUIRE(e->summands()[1]->as<Adjointable>().v == 2);
     }
-    {  // Power: adjoint flips the conjugation flag; base/exponent unchanged
+    SECTION("Power") {
+      // adjoint flips the conjugation flag; base/exponent unchanged
       Power pv(ex<Variable>(L"z"), rational{1, 2});
       REQUIRE(!pv.conjugated());
       pv.adjoint();


### PR DESCRIPTION
This is supposed to be an alternative (longer-term perhaps even replacement) for `ExprPtr`. It can be used to store expressions but contrary to `ExprPtr`, the new `ExprContainer` has value semantics. That is, copying the container actually copies the underlying expression. This makes things much easier to reason about and as a side-effect this fixes the `const` issue of `ExprPtr` which allows you to do
```cpp
void func(const ExprPtr &ptr) {
  auto copy = ptr; // only copies _pointer_
  expand(copy);
}
```
which ends up modifying the original expression `ptr` was is pointing to. Hence, with `ExprPtr` we don't have any way to avoid accidental modification.

----

Note: This PR is based on top of #589 