### PR TITLE
Turn Expr into a proper range instead of a view

### DIFF
--- a/SeQuant/core/expr.hpp
+++ b/SeQuant/core/expr.hpp
@@ -9,6 +9,7 @@
 #include <SeQuant/core/expressions/constant.hpp>
 #include <SeQuant/core/expressions/expr.hpp>
 #include <SeQuant/core/expressions/expr_algorithms.hpp>
+#include <SeQuant/core/expressions/expr_iterator.hpp>
 #include <SeQuant/core/expressions/expr_operators.hpp>
 #include <SeQuant/core/expressions/expr_ptr.hpp>
 #include <SeQuant/core/expressions/expr_range.hpp>

--- a/SeQuant/core/expressions/expr.cpp
+++ b/SeQuant/core/expressions/expr.cpp
@@ -31,25 +31,25 @@
 
 namespace sequant {
 
-ExprIterator Expr::begin() { return ExprIterator{}; }
+ExprIterator Expr::begin() { return begin_subexpr(); }
 
-ExprIterator Expr::end() { return ExprIterator{}; }
+ExprIterator Expr::end() { return end_subexpr(); }
 
-ConstExprIterator Expr::begin() const { return ConstExprIterator{}; }
+ConstExprIterator Expr::begin() const { return begin_subexpr(); }
 
-ConstExprIterator Expr::end() const { return ConstExprIterator{}; }
+ConstExprIterator Expr::end() const { return end_subexpr(); }
 
-ConstExprIterator Expr::cbegin() const { return begin(); }
+ConstExprIterator Expr::cbegin() const { return begin_subexpr(); }
 
-ConstExprIterator Expr::cend() const { return end(); }
+ConstExprIterator Expr::cend() const { return end_subexpr(); }
 
-ExprIterator Expr::begin_subexpr() { return begin(); }
+ExprIterator Expr::begin_subexpr() { return ExprIterator{}; }
 
-ExprIterator Expr::end_subexpr() { return end(); }
+ExprIterator Expr::end_subexpr() { return ExprIterator{}; }
 
-ConstExprIterator Expr::begin_subexpr() const { return begin(); }
+ConstExprIterator Expr::begin_subexpr() const { return ConstExprIterator{}; }
 
-ConstExprIterator Expr::end_subexpr() const { return end(); }
+ConstExprIterator Expr::end_subexpr() const { return ConstExprIterator{}; }
 
 std::size_t Expr::size() const { return end() - begin(); }
 

--- a/SeQuant/core/expressions/expr.cpp
+++ b/SeQuant/core/expressions/expr.cpp
@@ -6,6 +6,7 @@
 #include <SeQuant/core/expressions/abstract_tensor.hpp>
 #include <SeQuant/core/expressions/constant.hpp>
 #include <SeQuant/core/expressions/expr.hpp>
+#include <SeQuant/core/expressions/expr_iterator.hpp>
 #include <SeQuant/core/expressions/tensor.hpp>
 #include <SeQuant/core/io/latex/latex.hpp>
 #include <SeQuant/core/logger.hpp>
@@ -29,6 +30,52 @@
 #include <vector>
 
 namespace sequant {
+
+ExprIterator Expr::begin() { return ExprIterator{}; }
+
+ExprIterator Expr::end() { return ExprIterator{}; }
+
+ConstExprIterator Expr::begin() const { return ConstExprIterator{}; }
+
+ConstExprIterator Expr::end() const { return ConstExprIterator{}; }
+
+ConstExprIterator Expr::cbegin() const { return begin(); }
+
+ConstExprIterator Expr::cend() const { return end(); }
+
+ExprIterator Expr::begin_subexpr() { return begin(); }
+
+ExprIterator Expr::end_subexpr() { return end(); }
+
+ConstExprIterator Expr::begin_subexpr() const { return begin(); }
+
+ConstExprIterator Expr::end_subexpr() const { return end(); }
+
+std::size_t Expr::size() const { return end() - begin(); }
+
+bool Expr::empty() const { return size() == 0; }
+
+ExprPtr &Expr::operator[](std::size_t idx) {
+  SEQUANT_ASSERT(idx < size());
+  return begin()[idx];
+}
+
+const ExprPtr &Expr::operator[](std::size_t idx) const {
+  SEQUANT_ASSERT(idx < size());
+  return begin()[idx];
+}
+
+ExprPtr &Expr::at(std::size_t idx) { return (*this)[idx]; }
+
+const ExprPtr &Expr::at(std::size_t idx) const { return (*this)[idx]; }
+
+ExprPtr &Expr::front() { return at(0); }
+
+const ExprPtr &Expr::front() const { return at(0); }
+
+ExprPtr &Expr::back() { return at(size() - 1); }
+
+const ExprPtr &Expr::back() const { return at(size() - 1); }
 
 ExprPtr ExprPtr::clone() const & {
   if (!*this) return {};

--- a/SeQuant/core/expressions/expr.hpp
+++ b/SeQuant/core/expressions/expr.hpp
@@ -10,6 +10,7 @@
 #include <atomic>
 #include <memory>
 #include <optional>
+#include <ranges>
 
 #include <range/v3/range/primitives.hpp>
 #include <range/v3/view/facade.hpp>
@@ -530,6 +531,10 @@ class Expr : public std::enable_shared_from_this<Expr>,
   /// fn is missing from this type
   Exception not_implemented(const char *fn) const;
 };  // class Expr
+
+static_assert(std::ranges::sized_range<Expr>);
+static_assert(std::ranges::bidirectional_range<Expr>);
+static_assert(std::ranges::random_access_range<Expr>);
 
 template <>
 struct Expr::is_shared_ptr_of_expr<ExprPtr, void> : std::true_type {};

--- a/SeQuant/core/expressions/expr.hpp
+++ b/SeQuant/core/expressions/expr.hpp
@@ -1,6 +1,7 @@
 #ifndef SEQUANT_EXPRESSIONS_EXPR_HPP
 #define SEQUANT_EXPRESSIONS_EXPR_HPP
 
+#include <SeQuant/core/expressions/expr_iterator.hpp>
 #include <SeQuant/core/expressions/expr_ptr.hpp>
 #include <SeQuant/core/options.hpp>
 #include <SeQuant/core/utility/macros.hpp>
@@ -11,9 +12,6 @@
 #include <memory>
 #include <optional>
 #include <ranges>
-
-#include <range/v3/range/primitives.hpp>
-#include <range/v3/view/facade.hpp>
 
 namespace sequant {
 
@@ -59,10 +57,8 @@ static const wchar_t adjoint_label = L'\u207A';
 ///    for(const auto& e: c.expr()) {  // iterates over subexpressions
 ///    }
 /// @endcode
-class Expr : public std::enable_shared_from_this<Expr>,
-             public ranges::view_facade<Expr> {
+class Expr : public std::enable_shared_from_this<Expr> {
  public:
-  using range_type = ranges::view_facade<Expr>;
   using hash_type = std::size_t;
   using type_id_type = int;  // to speed up comparisons
 
@@ -70,7 +66,7 @@ class Expr : public std::enable_shared_from_this<Expr>,
   virtual ~Expr() = default;
 
   /// @return true if this is a leaf
-  bool is_atom() const { return ranges::empty(*this); }
+  bool is_atom() const { return empty(); }
 
   /// @return true if this is zero
   virtual bool is_zero() const { return false; }
@@ -150,14 +146,6 @@ class Expr : public std::enable_shared_from_this<Expr>,
     return visit_impl(*this, std::forward<Visitor>(visitor), atoms_only);
   }
 
-  auto begin_subexpr() { return range_type::begin(); }
-
-  auto end_subexpr() { return range_type::end(); }
-
-  auto begin_subexpr() const { return range_type::begin(); }
-
-  auto end_subexpr() const { return range_type::end(); }
-
   Expr &expr() { return *this; }
   const Expr &expr() const { return *this; }
 
@@ -181,7 +169,7 @@ class Expr : public std::enable_shared_from_this<Expr>,
   /// overridden for scalar leaf types.
   virtual bool is_scalar() const {
     if (is_atom()) return false;
-    for (auto it = begin_subexpr(); it != end_subexpr(); ++it) {
+    for (auto it = begin(); it != end(); ++it) {
       if (!(*it)->is_scalar()) return false;
     }
     return true;
@@ -200,7 +188,7 @@ class Expr : public std::enable_shared_from_this<Expr>,
       return true;
     else {
       bool result = true;
-      for (auto it = begin_subexpr(); result && it != end_subexpr(); ++it) {
+      for (auto it = begin(); result && it != end(); ++it) {
         result &= (*it)->is_cnumber();
       }
       return result;
@@ -227,14 +215,12 @@ class Expr : public std::enable_shared_from_this<Expr>,
           this->is_cnumber() || that.is_cnumber() || commutes_with_atom(that);
     } else if (this_is_atom) {
       if (!this->is_cnumber()) {
-        for (auto it = that.begin_subexpr(); result && it != that.end_subexpr();
-             ++it) {
+        for (auto it = that.begin(); result && it != that.end(); ++it) {
           result &= this->commutes_with(**it);
         }
       }
     } else {
-      for (auto it = this->begin_subexpr(); result && it != this->end_subexpr();
-           ++it) {
+      for (auto it = this->begin(); result && it != this->end(); ++it) {
         result &= (*it)->commutes_with(that);
       }
     }
@@ -376,9 +362,35 @@ class Expr : public std::enable_shared_from_this<Expr>,
 
   ///@}
 
- private:
-  friend ranges::range_access;
+  virtual ExprIterator begin();
+  virtual ExprIterator end();
+  virtual ConstExprIterator begin() const;
+  virtual ConstExprIterator end() const;
+  ConstExprIterator cbegin() const;
+  ConstExprIterator cend() const;
 
+  ExprIterator begin_subexpr();
+  ExprIterator end_subexpr();
+  ConstExprIterator begin_subexpr() const;
+  ConstExprIterator end_subexpr() const;
+
+  std::size_t size() const;
+
+  bool empty() const;
+
+  ExprPtr &operator[](std::size_t idx);
+  const ExprPtr &operator[](std::size_t idx) const;
+
+  ExprPtr &at(std::size_t idx);
+  const ExprPtr &at(std::size_t idx) const;
+
+  ExprPtr &front();
+  const ExprPtr &front() const;
+
+  ExprPtr &back();
+  const ExprPtr &back() const;
+
+ private:
   template <
       typename E, typename Visitor,
       typename = std::enable_if_t<std::is_same_v<std::remove_cvref_t<E>, Expr>>>
@@ -414,59 +426,6 @@ class Expr : public std::enable_shared_from_this<Expr>,
   Expr(const Expr &) = default;
   Expr &operator=(Expr &&) = default;
   Expr &operator=(const Expr &) = default;
-
-  struct cursor {
-    using value_type = ExprPtr;
-
-    cursor() = default;
-    constexpr explicit cursor(ExprPtr *subexpr_ptr) noexcept
-        : ptr_{subexpr_ptr} {}
-    /// when take const ptr note runtime const flag
-    constexpr explicit cursor(const ExprPtr *subexpr_ptr) noexcept
-        : ptr_{const_cast<ExprPtr *>(subexpr_ptr)}, const_{true} {}
-    bool equal(const cursor &that) const { return ptr_ == that.ptr_; }
-    void next() { ++ptr_; }
-    void prev() { --ptr_; }
-    // TODO figure out why can't return const here if want to be able to assign
-    // to *begin(Expr&)
-    ExprPtr &read() const {
-      RANGES_EXPECT(ptr_);
-      return *ptr_;
-    }
-    ExprPtr &read() {
-      RANGES_EXPECT(const_ == false);
-      RANGES_EXPECT(ptr_);
-      return *ptr_;
-    }
-    void assign(const ExprPtr &that_ptr) {
-      RANGES_EXPECT(ptr_);
-      *ptr_ = that_ptr;
-    }
-    std::ptrdiff_t distance_to(cursor const &that) const {
-      return that.ptr_ - ptr_;
-    }
-    void advance(std::ptrdiff_t n) { ptr_ += n; }
-
-   private:
-    ExprPtr *ptr_ =
-        nullptr;  // both begin and end will be represented by this, so Expr
-                  // without subexpressions begin() equals end() automatically
-    bool const_ = false;  // assert in nonconst ops
-  };
-
-  /// @return the cursor for the beginning of the range (must override in a
-  /// derived Expr that has subexpressions)
-  virtual cursor begin_cursor() { return cursor{}; }
-  /// @return the cursor for the end of the range (must override in a derived
-  /// Expr that has subexpressions)
-  virtual cursor end_cursor() { return cursor{}; }
-
-  /// @return the cursor for the beginning of the range (must override in a
-  /// derived Expr that has subexpressions)
-  virtual cursor begin_cursor() const { return cursor{}; }
-  /// @return the cursor for the end of the range (must override in a derived
-  /// Expr that has subexpressions)
-  virtual cursor end_cursor() const { return cursor{}; }
 
   mutable std::optional<hash_type> hash_value_;  // not initialized by default
   virtual hash_type memoizing_hash() const {

--- a/SeQuant/core/expressions/expr.hpp
+++ b/SeQuant/core/expressions/expr.hpp
@@ -362,17 +362,17 @@ class Expr : public std::enable_shared_from_this<Expr> {
 
   ///@}
 
-  virtual ExprIterator begin();
-  virtual ExprIterator end();
-  virtual ConstExprIterator begin() const;
-  virtual ConstExprIterator end() const;
+  ExprIterator begin();
+  ExprIterator end();
+  ConstExprIterator begin() const;
+  ConstExprIterator end() const;
   ConstExprIterator cbegin() const;
   ConstExprIterator cend() const;
 
-  ExprIterator begin_subexpr();
-  ExprIterator end_subexpr();
-  ConstExprIterator begin_subexpr() const;
-  ConstExprIterator end_subexpr() const;
+  virtual ExprIterator begin_subexpr();
+  virtual ExprIterator end_subexpr();
+  virtual ConstExprIterator begin_subexpr() const;
+  virtual ConstExprIterator end_subexpr() const;
 
   std::size_t size() const;
 

--- a/SeQuant/core/expressions/expr_iterator.hpp
+++ b/SeQuant/core/expressions/expr_iterator.hpp
@@ -1,0 +1,140 @@
+#ifndef SEQUANT_EXPRESSIONS_EXPR_ITERATOR_HPP
+#define SEQUANT_EXPRESSIONS_EXPR_ITERATOR_HPP
+
+#include <SeQuant/core/utility/macros.hpp>
+
+#include <compare>
+#include <iterator>
+#include <type_traits>
+
+namespace sequant {
+
+class ExprPtr;
+
+namespace detail {
+
+template <bool is_const>
+class ExprIteratorImpl {
+ public:
+  using value_type = ExprPtr;
+  using reference = std::add_lvalue_reference_t<
+      std::conditional_t<is_const, std::add_const_t<value_type>, value_type>>;
+  using const_reference =
+      std::add_lvalue_reference_t<std::add_const_t<value_type>>;
+  using pointer = std::add_pointer_t<
+      std::conditional_t<is_const, std::add_const_t<value_type>, value_type>>;
+  using difference_type = std::ptrdiff_t;
+
+  explicit ExprIteratorImpl(pointer ptr = nullptr) : ptr_(ptr) {}
+
+  ExprIteratorImpl &operator+=(difference_type val) {
+    ptr_ += val;
+    return *this;
+  }
+
+  friend ExprIteratorImpl operator+(const ExprIteratorImpl &it,
+                                    difference_type val) {
+    return ExprIteratorImpl(it.ptr_ + val);
+  }
+
+  friend ExprIteratorImpl operator+(difference_type val,
+                                    const ExprIteratorImpl &it) {
+    return ExprIteratorImpl(it.ptr_ + val);
+  }
+
+  ExprIteratorImpl &operator++() {
+    ++ptr_;
+    return *this;
+  }
+
+  ExprIteratorImpl operator++(int) {
+    ExprIteratorImpl copy = *this;
+
+    ++ptr_;
+
+    return copy;
+  }
+
+  ExprIteratorImpl &operator-=(difference_type val) {
+    ptr_ -= val;
+    return *this;
+  }
+
+  friend ExprIteratorImpl operator-(const ExprIteratorImpl &it,
+                                    difference_type val) {
+    return ExprIteratorImpl(it.ptr_ - val);
+  }
+
+  friend ExprIteratorImpl operator-(difference_type val,
+                                    const ExprIteratorImpl &it) {
+    return ExprIteratorImpl(it.ptr_ - val);
+  }
+
+  ExprIteratorImpl &operator--() {
+    --ptr_;
+    return *this;
+  }
+
+  ExprIteratorImpl operator--(int) {
+    ExprIteratorImpl copy = *this;
+
+    --ptr_;
+
+    return copy;
+  }
+
+  reference operator*() const {
+    SEQUANT_ASSERT(ptr_);
+    return *ptr_;
+  }
+
+  pointer operator->() const {
+    SEQUANT_ASSERT(ptr_);
+    return ptr_;
+  }
+
+  difference_type operator-(const ExprIteratorImpl<is_const> &other) const {
+    return ptr_ - other.ptr_;
+  }
+  difference_type operator-(const ExprIteratorImpl<!is_const> &other) const {
+    return ptr_ - other.ptr_;
+  }
+
+  bool operator==(const ExprIteratorImpl<is_const> &other) const {
+    return ptr_ == other.ptr_;
+  }
+  bool operator==(const ExprIteratorImpl<!is_const> &other) const {
+    return ptr_ == other.ptr_;
+  }
+
+  reference operator[](difference_type offset) const {
+    SEQUANT_ASSERT(ptr_);
+    return *(ptr_ + offset);
+  }
+
+  std::strong_ordering operator<=>(
+      const ExprIteratorImpl<is_const> &other) const {
+    return ptr_ <=> other.ptr_;
+  }
+  std::strong_ordering operator<=>(
+      const ExprIteratorImpl<!is_const> &other) const {
+    return ptr_ <=> other.ptr_;
+  }
+
+ private:
+  pointer ptr_ = nullptr;
+};
+
+}  // namespace detail
+
+using ExprIterator = detail::ExprIteratorImpl<false>;
+using ConstExprIterator = detail::ExprIteratorImpl<true>;
+
+static_assert(std::bidirectional_iterator<ExprIterator>);
+static_assert(std::random_access_iterator<ExprIterator>);
+static_assert(std::bidirectional_iterator<ConstExprIterator>);
+static_assert(std::random_access_iterator<ConstExprIterator>);
+
+}  // namespace sequant
+
+#endif  // SEQUANT_EXPRESSIONS_EXPR_ITERATOR_HPP

--- a/SeQuant/core/expressions/product.hpp
+++ b/SeQuant/core/expressions/product.hpp
@@ -5,6 +5,7 @@
 #include <SeQuant/core/expressions/constant.hpp>
 #include <SeQuant/core/expressions/expr.hpp>
 #include <SeQuant/core/expressions/expr_algorithms.hpp>
+#include <SeQuant/core/expressions/expr_iterator.hpp>
 #include <SeQuant/core/expressions/expr_ptr.hpp>
 #include <SeQuant/core/io/latex/latex.hpp>
 #include <SeQuant/core/meta.hpp>
@@ -388,34 +389,29 @@ class Product : public Expr {
     scalar_ += 1;
   }
 
+  ExprIterator begin() override {
+    if (!factors_.empty()) {
+      reset_hash_value();
+    }
+
+    return ExprIterator{factors_.data()};
+  }
+
+  ExprIterator end() override {
+    return ExprIterator{factors_.data() + factors_.size()};
+  }
+
+  ConstExprIterator begin() const override {
+    return ConstExprIterator{factors_.data()};
+  }
+
+  ConstExprIterator end() const override {
+    return ConstExprIterator{factors_.data() + factors_.size()};
+  }
+
  private:
   scalar_type scalar_ = {1, 0};
   container::svector<ExprPtr, 2> factors_{};
-
-  cursor begin_cursor() override {
-    if (factors_.empty()) {
-      return Expr::begin_cursor();
-    } else {
-      reset_hash_value();
-      return cursor{&factors_[0]};
-    }
-  };
-  cursor end_cursor() override {
-    if (factors_.empty()) {
-      return Expr::begin_cursor();
-    } else {
-      reset_hash_value();
-      return cursor{&factors_[0] + factors_.size()};
-    }
-  };
-
-  cursor begin_cursor() const override {
-    return factors_.empty() ? Expr::begin_cursor() : cursor{&factors_[0]};
-  };
-  cursor end_cursor() const override {
-    return factors_.empty() ? Expr::end_cursor()
-                            : cursor{&factors_[0] + factors_.size()};
-  };
 
   /// @return the hash of this object, by hashing only the factors,
   /// not the scalar to make possible rapid finding of Products that only

--- a/SeQuant/core/expressions/product.hpp
+++ b/SeQuant/core/expressions/product.hpp
@@ -389,7 +389,7 @@ class Product : public Expr {
     scalar_ += 1;
   }
 
-  ExprIterator begin() override {
+  ExprIterator begin_subexpr() override {
     if (!factors_.empty()) {
       reset_hash_value();
     }
@@ -397,15 +397,15 @@ class Product : public Expr {
     return ExprIterator{factors_.data()};
   }
 
-  ExprIterator end() override {
+  ExprIterator end_subexpr() override {
     return ExprIterator{factors_.data() + factors_.size()};
   }
 
-  ConstExprIterator begin() const override {
+  ConstExprIterator begin_subexpr() const override {
     return ConstExprIterator{factors_.data()};
   }
 
-  ConstExprIterator end() const override {
+  ConstExprIterator end_subexpr() const override {
     return ConstExprIterator{factors_.data() + factors_.size()};
   }
 

--- a/SeQuant/core/expressions/sum.hpp
+++ b/SeQuant/core/expressions/sum.hpp
@@ -4,6 +4,7 @@
 #include <SeQuant/core/container.hpp>
 #include <SeQuant/core/expressions/constant.hpp>
 #include <SeQuant/core/expressions/expr.hpp>
+#include <SeQuant/core/expressions/expr_iterator.hpp>
 #include <SeQuant/core/expressions/expr_ptr.hpp>
 #include <SeQuant/core/expressions/product.hpp>
 #include <SeQuant/core/meta.hpp>
@@ -274,26 +275,31 @@ class Sum : public Expr {
     return *this;
   }
 
+  ExprIterator begin() override {
+    if (!summands_.empty()) {
+      reset_hash_value();
+    }
+
+    return ExprIterator{summands_.data()};
+  }
+
+  ExprIterator end() override {
+    return ExprIterator{summands_.data() + summands_.size()};
+  }
+
+  ConstExprIterator begin() const override {
+    return ConstExprIterator{summands_.data()};
+  }
+
+  ConstExprIterator end() const override {
+    return ConstExprIterator{summands_.data() + summands_.size()};
+  }
+
  private:
   summands_type summands_{};
   std::optional<size_t>
       constant_summand_idx_{};  // points to the constant summand, if any; used
                                 // to sum up constants in append/prepend
-
-  cursor begin_cursor() override {
-    return summands_.empty() ? Expr::begin_cursor() : cursor{&summands_[0]};
-  };
-  cursor end_cursor() override {
-    return summands_.empty() ? Expr::end_cursor()
-                             : cursor{&summands_[0] + summands_.size()};
-  };
-  cursor begin_cursor() const override {
-    return summands_.empty() ? Expr::begin_cursor() : cursor{&summands_[0]};
-  };
-  cursor end_cursor() const override {
-    return summands_.empty() ? Expr::end_cursor()
-                             : cursor{&summands_[0] + summands_.size()};
-  };
 
   /// @return the hash of this object
   /// @note this ensures that hash of a Sum of a single summand is

--- a/SeQuant/core/expressions/sum.hpp
+++ b/SeQuant/core/expressions/sum.hpp
@@ -275,7 +275,7 @@ class Sum : public Expr {
     return *this;
   }
 
-  ExprIterator begin() override {
+  ExprIterator begin_subexpr() override {
     if (!summands_.empty()) {
       reset_hash_value();
     }
@@ -283,15 +283,15 @@ class Sum : public Expr {
     return ExprIterator{summands_.data()};
   }
 
-  ExprIterator end() override {
+  ExprIterator end_subexpr() override {
     return ExprIterator{summands_.data() + summands_.size()};
   }
 
-  ConstExprIterator begin() const override {
+  ConstExprIterator begin_subexpr() const override {
     return ConstExprIterator{summands_.data()};
   }
 
-  ConstExprIterator end() const override {
+  ConstExprIterator end_subexpr() const override {
     return ConstExprIterator{summands_.data() + summands_.size()};
   }
 

--- a/SeQuant/core/io/serialization/v1/serialize.cpp
+++ b/SeQuant/core/io/serialization/v1/serialize.cpp
@@ -196,7 +196,7 @@ std::wstring to_string(Sum const& sum, const SerializationOptions& options) {
   std::wstring serialized;
 
   for (std::size_t i = 0; i < sum.size(); ++i) {
-    ExprPtr& current = sum[i];
+    const ExprPtr& current = sum[i];
 
     const bool parenthesize = current->is<Sum>();
 

--- a/tests/unit/test_expr.cpp
+++ b/tests/unit/test_expr.cpp
@@ -41,22 +41,19 @@ struct Dummy : public sequant::Expr {
   bool static_equal(const sequant::Expr &) const override { return true; }
 };
 
-// Note: we have to use template specialization in order to conditionally
-// provide custom begin/end implementations as virtual functions aren't allowed
-// to be shadowed in the child class via explicit implementations.
-template <typename T, bool = false>
-struct VecExprImpl : public std::vector<T>, public sequant::Expr {
+template <typename T>
+struct VecExpr : public std::vector<T>, public sequant::Expr {
   using base_type = std::vector<T>;
   using base_type::begin;
   using base_type::end;
   using base_type::size;
 
-  VecExprImpl() = default;
+  VecExpr() = default;
   template <typename U>
-  VecExprImpl(std::initializer_list<U> elements) : std::vector<T>(elements) {}
+  VecExpr(std::initializer_list<U> elements) : std::vector<T>(elements) {}
   template <typename Iter>
-  VecExprImpl(Iter begin, Iter end) : std::vector<T>(begin, end) {}
-  virtual ~VecExprImpl() = default;
+  VecExpr(Iter begin, Iter end) : std::vector<T>(begin, end) {}
+  virtual ~VecExpr() = default;
   std::wstring to_latex() const override {
     std::wstring result = L"{\\text{VecExpr}\\{";
     for (const auto &e : *this) {
@@ -70,80 +67,50 @@ struct VecExprImpl : public std::vector<T>, public sequant::Expr {
     return result;
   }
 
-  type_id_type type_id() const override {
-    return get_type_id<VecExprImpl<T>>();
-  };
+  type_id_type type_id() const override { return get_type_id<VecExpr<T>>(); };
 
- private:
-  bool static_equal(const sequant::Expr &that) const override {
-    return static_cast<const base_type &>(*this) ==
-           static_cast<const base_type &>(
-               static_cast<const VecExprImpl &>(that));
-  }
-
-  sequant::ExprPtr clone() const override {
-    return sequant::ex<VecExprImpl>(this->begin(), this->end());
-  }
-};
-
-template <typename T>
-struct VecExprImpl<T, true> : public std::vector<T>, public sequant::Expr {
-  using base_type = std::vector<T>;
-  using sequant::Expr::size;
-
-  VecExprImpl() = default;
-  template <typename U>
-  VecExprImpl(std::initializer_list<U> elements) : std::vector<T>(elements) {}
-  template <typename Iter>
-  VecExprImpl(Iter begin, Iter end) : std::vector<T>(begin, end) {}
-  virtual ~VecExprImpl() = default;
-  std::wstring to_latex() const override {
-    std::wstring result = L"{\\text{VecExpr}\\{";
-    for (const auto &e : *this) {
-      if constexpr (sequant::Expr::is_shared_ptr_of_expr_or_derived<T>::value) {
-        result += e->to_latex() + L" ";
-      } else {
-        result += std::to_wstring(e) + L" ";
-      }
+  sequant::ConstExprIterator begin_subexpr() const override {
+    if constexpr (sequant::Expr::is_shared_ptr_of_expr<T>::value) {
+      return sequant::ConstExprIterator{base_type::data()};
+    } else {
+      return Expr::begin_subexpr();
     }
-    result += L"\\}}";
-    return result;
   }
 
-  type_id_type type_id() const override {
-    return get_type_id<VecExprImpl<T>>();
+  sequant::ConstExprIterator end_subexpr() const override {
+    if constexpr (sequant::Expr::is_shared_ptr_of_expr<T>::value) {
+      return sequant::ConstExprIterator{base_type::data() + base_type::size()};
+    } else {
+      return Expr::end_subexpr();
+    }
+  }
+
+  sequant::ExprIterator begin_subexpr() override {
+    if constexpr (sequant::Expr::is_shared_ptr_of_expr<T>::value) {
+      return sequant::ExprIterator{base_type::data()};
+    } else {
+      return Expr::begin_subexpr();
+    }
+  }
+
+  sequant::ExprIterator end_subexpr() override {
+    if constexpr (sequant::Expr::is_shared_ptr_of_expr<T>::value) {
+      return sequant::ExprIterator{base_type::data() + base_type::size()};
+    } else {
+      return Expr::end_subexpr();
+    }
   };
-
-  sequant::ExprIterator begin() override {
-    return sequant::ExprIterator{base_type::data()};
-  }
-
-  sequant::ExprIterator end() override {
-    return sequant::ExprIterator{base_type::data() + base_type::size()};
-  }
-
-  sequant::ConstExprIterator begin() const override {
-    return sequant::ConstExprIterator{base_type::data()};
-  }
-
-  sequant::ConstExprIterator end() const override {
-    return sequant::ConstExprIterator{base_type::data() + base_type::size()};
-  }
 
  private:
   bool static_equal(const sequant::Expr &that) const override {
     return static_cast<const base_type &>(*this) ==
-           static_cast<const base_type &>(
-               static_cast<const VecExprImpl &>(that));
+           static_cast<const base_type &>(static_cast<const VecExpr &>(that));
   }
 
   sequant::ExprPtr clone() const override {
-    return sequant::ex<VecExprImpl>(this->begin(), this->end());
+    return sequant::ex<VecExpr>(this->begin(), this->end());
   }
 };
-
-template <typename T>
-using VecExpr = VecExprImpl<T, sequant::Expr::is_shared_ptr_of_expr<T>::value>;
 
 struct Adjointable : public sequant::Expr {
   Adjointable() = default;

--- a/tests/unit/test_expr.cpp
+++ b/tests/unit/test_expr.cpp
@@ -41,19 +41,22 @@ struct Dummy : public sequant::Expr {
   bool static_equal(const sequant::Expr &) const override { return true; }
 };
 
-template <typename T>
-struct VecExpr : public std::vector<T>, public sequant::Expr {
+// Note: we have to use template specialization in order to conditionally
+// provide custom begin/end implementations as virtual functions aren't allowed
+// to be shadowed in the child class via explicit implementations.
+template <typename T, bool = false>
+struct VecExprImpl : public std::vector<T>, public sequant::Expr {
   using base_type = std::vector<T>;
   using base_type::begin;
   using base_type::end;
   using base_type::size;
 
-  VecExpr() = default;
+  VecExprImpl() = default;
   template <typename U>
-  VecExpr(std::initializer_list<U> elements) : std::vector<T>(elements) {}
+  VecExprImpl(std::initializer_list<U> elements) : std::vector<T>(elements) {}
   template <typename Iter>
-  VecExpr(Iter begin, Iter end) : std::vector<T>(begin, end) {}
-  virtual ~VecExpr() = default;
+  VecExprImpl(Iter begin, Iter end) : std::vector<T>(begin, end) {}
+  virtual ~VecExprImpl() = default;
   std::wstring to_latex() const override {
     std::wstring result = L"{\\text{VecExpr}\\{";
     for (const auto &e : *this) {
@@ -67,41 +70,80 @@ struct VecExpr : public std::vector<T>, public sequant::Expr {
     return result;
   }
 
-  type_id_type type_id() const override { return get_type_id<VecExpr<T>>(); };
+  type_id_type type_id() const override {
+    return get_type_id<VecExprImpl<T>>();
+  };
 
  private:
-  cursor begin_cursor() const override {
-    if constexpr (sequant::Expr::is_shared_ptr_of_expr<T>::value) {
-      return base_type::empty() ? Expr::begin_cursor()
-                                : cursor{&base_type::at(0)};
-    } else {
-      return Expr::begin_cursor();
-    }
-  };
-  cursor end_cursor() const override {
-    if constexpr (sequant::Expr::is_shared_ptr_of_expr<T>::value) {
-      return base_type::empty() ? Expr::end_cursor()
-                                : cursor{&base_type::at(0) + base_type::size()};
-    } else {
-      return Expr::end_cursor();
-    }
-  };
-  cursor begin_cursor() override {
-    return const_cast<const VecExpr &>(*this).begin_cursor();
-  };
-  cursor end_cursor() override {
-    return const_cast<const VecExpr &>(*this).end_cursor();
-  };
-
   bool static_equal(const sequant::Expr &that) const override {
     return static_cast<const base_type &>(*this) ==
-           static_cast<const base_type &>(static_cast<const VecExpr &>(that));
+           static_cast<const base_type &>(
+               static_cast<const VecExprImpl &>(that));
   }
 
   sequant::ExprPtr clone() const override {
-    return sequant::ex<VecExpr>(this->begin(), this->end());
+    return sequant::ex<VecExprImpl>(this->begin(), this->end());
   }
 };
+
+template <typename T>
+struct VecExprImpl<T, true> : public std::vector<T>, public sequant::Expr {
+  using base_type = std::vector<T>;
+  using sequant::Expr::size;
+
+  VecExprImpl() = default;
+  template <typename U>
+  VecExprImpl(std::initializer_list<U> elements) : std::vector<T>(elements) {}
+  template <typename Iter>
+  VecExprImpl(Iter begin, Iter end) : std::vector<T>(begin, end) {}
+  virtual ~VecExprImpl() = default;
+  std::wstring to_latex() const override {
+    std::wstring result = L"{\\text{VecExpr}\\{";
+    for (const auto &e : *this) {
+      if constexpr (sequant::Expr::is_shared_ptr_of_expr_or_derived<T>::value) {
+        result += e->to_latex() + L" ";
+      } else {
+        result += std::to_wstring(e) + L" ";
+      }
+    }
+    result += L"\\}}";
+    return result;
+  }
+
+  type_id_type type_id() const override {
+    return get_type_id<VecExprImpl<T>>();
+  };
+
+  sequant::ExprIterator begin() override {
+    return sequant::ExprIterator{base_type::data()};
+  }
+
+  sequant::ExprIterator end() override {
+    return sequant::ExprIterator{base_type::data() + base_type::size()};
+  }
+
+  sequant::ConstExprIterator begin() const override {
+    return sequant::ConstExprIterator{base_type::data()};
+  }
+
+  sequant::ConstExprIterator end() const override {
+    return sequant::ConstExprIterator{base_type::data() + base_type::size()};
+  }
+
+ private:
+  bool static_equal(const sequant::Expr &that) const override {
+    return static_cast<const base_type &>(*this) ==
+           static_cast<const base_type &>(
+               static_cast<const VecExprImpl &>(that));
+  }
+
+  sequant::ExprPtr clone() const override {
+    return sequant::ex<VecExprImpl>(this->begin(), this->end());
+  }
+};
+
+template <typename T>
+using VecExpr = VecExprImpl<T, sequant::Expr::is_shared_ptr_of_expr<T>::value>;
 
 struct Adjointable : public sequant::Expr {
   Adjointable() = default;


### PR DESCRIPTION
Previously, the Expr implementation used range-v3's view facade to
implement range semantics on Expr objects. However, views are different
things from containers which had some more or less subtle consequences.
See also https://stackoverflow.com/a/31462435

This PR replaces the view facade with virtual begin/end
implementations returning ExprIterator objects. Hence, Expr is now a
fully fledged container that is usable as a random-access range.