### PR TITLE
Product: reset the memoized hash in the non-const factors()

### DIFF
--- a/SeQuant/core/expressions/product.cpp
+++ b/SeQuant/core/expressions/product.cpp
@@ -46,7 +46,15 @@ const Product::scalar_type &Product::scalar() const { return scalar_; }
 bool Product::is_zero() const { return Constant::is_zero(this->scalar()); }
 
 const Product::factors_type &Product::factors() const { return factors_; }
-Product::factors_type &Product::factors() { return factors_; }
+Product::factors_type &Product::factors() {
+  // N.B. handing out a mutable reference to factors_ invalidates the memoized
+  // hash.  Unlike begin_subexpr()/end_subexpr(), this must not be guarded by
+  // `!factors_.empty()`: those hand out iterators, and an empty range yields
+  // nothing to dereference, whereas the caller can grow an empty factors_
+  // through this reference (e.g. push_back()).
+  reset_hash_value();
+  return factors_;
+}
 
 const ExprPtr &Product::factor(size_t i) const { return factors_.at(i); }
 

--- a/tests/unit/test_expr.cpp
+++ b/tests/unit/test_expr.cpp
@@ -1035,6 +1035,31 @@ TEST_CASE("expr", "[elements]") {
     }
   }
 
+  SECTION("hash invalidation on mutable factors() access") {
+    // Product::factors() non-const hands out a mutable reference into
+    // factors_, so it must invalidate the memoized hash, exactly as the
+    // non-const begin_subexpr()/end_subexpr() do
+    auto prod =
+        ex<Product>(ExprPtrList{ex<Variable>(L"x"), ex<Variable>(L"y")});
+    const auto hash_before = prod->hash_value();
+
+    prod->as<Product>().factors()[0] = ex<Variable>(L"mutated");
+
+    REQUIRE(prod->hash_value() != hash_before);
+  }
+
+  SECTION("hash invalidation on growing an empty Product via factors()") {
+    // an empty Product can still be *grown* through the mutable factors()
+    // reference, so the invalidation must not be guarded by
+    // `!factors_.empty()` the way begin_subexpr()/end_subexpr() are
+    auto prod = ex<Product>(ExprPtrList{});
+    const auto hash_before = prod->hash_value();
+
+    prod->as<Product>().factors().push_back(ex<Variable>(L"x"));
+
+    REQUIRE(prod->hash_value() != hash_before);
+  }
+
   SECTION("commutativity") {
     const auto ex1 = std::make_shared<VecExpr<std::shared_ptr<Constant>>>(
         std::initializer_list<std::shared_ptr<Constant>>{


### PR DESCRIPTION
`Product::factors()` non-const hands out a mutable reference to `factors_` without invalidating the memoized hash:

```cpp
Product::factors_type &Product::factors() { return factors_; }
```

Mutating a factor through it leaves the stale hash in place. With asserts enabled that trips

```cpp
SEQUANT_ASSERT(*hash_value_ == compute_hash());
```

in `Product::memoizing_hash()`; with `SEQUANT_ASSERT_BEHAVIOR=IGNORE` it silently returns the stale value, which makes `static_equal()` short-circuit to `false` for `Product`s that are in fact equal.

This is the same defect #594 fixes for `begin_subexpr()`/`end_subexpr()`. `factors()` is the remaining hole, and it is the wider one — the other two hand out iterators, this hands out the whole container.

No caller in tree mutates through the reference today, so the bug is latent rather than live. Split out of the #594 review rather than folded into it, since it is independent of that PR's three fixes.

`Sum` needs no equivalent change: it exposes `summands()` as const only.

### The `!empty()` guard is deliberately absent

`begin_subexpr()`/`end_subexpr()` guard their reset with `!factors_.empty()`, which is safe there — an empty range yields nothing to dereference. It is **not** safe here, because a caller can grow an empty `factors_` through this reference:

```cpp
prod->as<Product>().factors().push_back(ex<Variable>(L"x"));  // no factor to
                                                              // dereference,
                                                              // hash still stale
```

so the reset is unconditional. The second test below pins this down and fails if the guard is added.

### Verification

Written test-first; both tests were watched failing before the fix went in:

| test | without the fix |
|---|---|
| `hash invalidation on mutable factors() access` | `8269482685011228508 != 8269482685011228508` — stale hash returned verbatim |
| `hash invalidation on growing an empty Product via factors()` | `0 != 0` — with the `!empty()` guard added, the empty `Product`'s hash survives a `push_back` |

Full unit suite, both assertion configurations:

- Debug, `SEQUANT_ASSERT_BEHAVIOR=THROW`: 6795 assertions in 62 test cases, all passed
- Release, `SEQUANT_ASSERT_BEHAVIOR=IGNORE`: 310956 assertions in 63 test cases, all passed

### Note on internal callers

`Product::adjoint()` (and the `CProduct`/`NCProduct` overrides) read through the non-const `factors()`, as does the `SEQUANT_ASSERT` in `add_identical()`, so those now take a spurious reset. Both are harmless — `adjoint()` assigns a freshly built `Product` over `*this` anyway, and `add_identical()` only touches `scalar_`, which `Product`'s hash deliberately excludes. Routing those reads through the const overload would avoid the resets; left out of this PR as a separate cleanup.
