### PR TITLE
Use standard license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,3 @@
-SeQuant: Symbolic Tensor Algebra in C++
-Copyright (C) 2018 the SeQuant contributors (see CITATION.cff for details)
-
-SeQuant is licensed under the GNU Lesser General Public License version 3.
-The full text of the license follows.
-
                   GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 


### PR DESCRIPTION
Due to the addition of custom text in the license, GitHub doesn't recognize the license and doesn't display the SPDX identifier in the repository's sidebar. This makes it more cumbersome for people to figure out what license SeQuant is using.

This commit removes the customization again in order to restore said sidebar information.

----

Current sidebar


<img width="307" height="213" alt="image" src="https://github.com/user-attachments/assets/70604962-7a0d-48f4-a7c2-c9657f942fe8" />

Sidebar after this commit

<img width="307" height="213" alt="image" src="https://github.com/user-attachments/assets/37a5743a-5ceb-4189-8027-1167f6b07967" />
